### PR TITLE
Augment diploids to allow spatial simulation

### DIFF
--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -21,6 +21,7 @@
 
 #include <pybind11/stl.h>
 #include <cstdint>
+#include <tuple>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
 #include <fwdpp/sugar/generalmut.hpp>
@@ -58,22 +59,23 @@ namespace fwdpy11
         double e;
         //! Fitness.  This is not necessarily written to by a simulation.
         double w;
+        //! Indexes of parents
+        std::tuple<std::uint32_t, std::uint32_t> parents;
+        //! Geography
+        std::tuple<double, double, double> xyz;
+        //! "Sex"
+        std::int8_t sex;
         //! Constructor
-        diploid_t() noexcept : first(first_type()),
-                               second(second_type()),
-                               label(0),
-                               g(0.),
-                               e(0.),
-                               w(1.)
+        diploid_t() noexcept
+            : first(first_type()), second(second_type()), label(0), g(0.),
+              e(0.), w(1.), parents{ 0, 0 }, xyz{ 0., 0., 0. }, sex(0)
         {
         }
         //! Construct from two indexes to gametes
-        diploid_t(first_type g1, first_type g2) noexcept : first(g1),
-                                                           second(g2),
-                                                           label(0),
-                                                           g(0.),
-                                                           e(0.),
-                                                           w(1.)
+        diploid_t(first_type g1, first_type g2) noexcept
+            : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
+
+              parents{ 0, 0 }, xyz{ 0., 0., 0. }, sex(0)
         {
         }
 
@@ -83,7 +85,10 @@ namespace fwdpy11
         {
             return this->first == dip.first && this->second == dip.second
                    && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                   && this->label == dip.label;
+                   && this->label == dip.label &&
+                   this->parents == dip.parents &&
+                   this->xyz == dip.xyz &&
+                   this->sex == dip.sex;
         }
     };
 

--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -42,11 +42,11 @@ namespace fwdpy11
     {
         using first_type = std::size_t;
         using second_type = std::size_t;
-        //! First gamete.  A gamete is vector<size_t> where the elements are
-        //! indexes to a population's gamete container
+        //! First gamete.  A gamete contains vector<uint32_t> where the elements are
+        //! indexes to a population's mutation container
         first_type first;
-        //! Second gamete. A gamete is vector<size_t> where the elements are
-        //! indexes to a population's gamete container
+        //! Second gamete. A gamete contains vector<uint32_t> where the elements are
+        //! indexes to a population's mutation container
         second_type second;
         //! 64 bits of data to do stuff with.  Initialized to zero upon
         //! construction

--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -78,7 +78,6 @@ namespace fwdpy11
         //! Construct from two indexes to gametes
         diploid_t(first_type g1, first_type g2) noexcept
             : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
-
               parents{ 0, 0 }, xyz{ 0., 0., 0. }, deme(0), sex(0)
         {
         }

--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -42,10 +42,12 @@ namespace fwdpy11
     {
         using first_type = std::size_t;
         using second_type = std::size_t;
-        //! First gamete.  A gamete contains vector<uint32_t> where the elements are
+        //! First gamete.  A gamete contains vector<uint32_t> where the
+        //! elements are
         //! indexes to a population's mutation container
         first_type first;
-        //! Second gamete. A gamete contains vector<uint32_t> where the elements are
+        //! Second gamete. A gamete contains vector<uint32_t> where the
+        //! elements are
         //! indexes to a population's mutation container
         second_type second;
         //! 64 bits of data to do stuff with.  Initialized to zero upon
@@ -63,19 +65,21 @@ namespace fwdpy11
         std::tuple<std::uint32_t, std::uint32_t> parents;
         //! Geography
         std::tuple<double, double, double> xyz;
+        //! Current deme
+        std::uint32_t deme;
         //! "Sex"
         std::int8_t sex;
         //! Constructor
         diploid_t() noexcept
             : first(first_type()), second(second_type()), label(0), g(0.),
-              e(0.), w(1.), parents{ 0, 0 }, xyz{ 0., 0., 0. }, sex(0)
+              e(0.), w(1.), parents{ 0, 0 }, xyz{ 0., 0., 0. }, deme(0), sex(0)
         {
         }
         //! Construct from two indexes to gametes
         diploid_t(first_type g1, first_type g2) noexcept
             : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
 
-              parents{ 0, 0 }, xyz{ 0., 0., 0. }, sex(0)
+              parents{ 0, 0 }, xyz{ 0., 0., 0. }, deme(0), sex(0)
         {
         }
 
@@ -85,10 +89,9 @@ namespace fwdpy11
         {
             return this->first == dip.first && this->second == dip.second
                    && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                   && this->label == dip.label &&
-                   this->parents == dip.parents &&
-                   this->xyz == dip.xyz &&
-                   this->sex == dip.sex;
+                   && this->label == dip.label && this->parents == dip.parents
+                   && this->xyz == dip.xyz && this->sex == dip.sex
+                   && this->deme == dip.deme;
         }
     };
 

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -21,6 +21,7 @@
  */
 #ifndef FWDPY11_SERIALIZATION_HPP
 #define FWDPY11_SERIALIZATION_HPP
+
 #include <fwdpp/sugar/serialization.hpp>
 
 namespace fwdpy11
@@ -30,7 +31,7 @@ namespace fwdpy11
         inline constexpr int
         magic()
         {
-            return 1;
+            return 2; //changed to 2 in 0.1.3
         }
 
         template <typename poptype, typename mwriter_t, typename dipwriter_t>

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -31,7 +31,7 @@ namespace fwdpy11
         inline constexpr int
         magic()
         {
-            return 2; //changed to 2 in 0.1.3
+            return 2; // changed to 2 in 0.1.3
         }
 
         template <typename poptype, typename mwriter_t, typename dipwriter_t>
@@ -42,7 +42,8 @@ namespace fwdpy11
             KTfwd::serialize rv;
             std::ostringstream buffer;
             buffer << "fp11";
-            buffer.write(reinterpret_cast<const char *>(&dipwriter.v), sizeof(int));
+            buffer.write(reinterpret_cast<const char *>(&dipwriter.v),
+                         sizeof(int));
             buffer.write(reinterpret_cast<const char *>((&pop->generation)),
                          sizeof(unsigned));
             rv(buffer, *pop, mwriter, dipwriter);
@@ -64,14 +65,14 @@ namespace fwdpy11
                 // We need to test for existance of serialization
                 // version numbers, introduced in 0.1.3.  Prior to that,
                 // it was wild west :).
-                bool have_magic = (s.substr(0,4)=="fp11") ? true : false;
-                //We default to version 1, which includes all
-                //previous releases that had no version numbers
+                bool have_magic = (s.substr(0, 4) == "fp11") ? true : false;
+                // We default to version 1, which includes all
+                // previous releases that had no version numbers
                 int version = 1;
                 if (have_magic)
                     {
                         char c[4];
-                        buffer.read(&c[0],4*sizeof(char));
+                        buffer.read(&c[0], 4 * sizeof(char));
                         buffer.read(reinterpret_cast<char *>(&version),
                                     sizeof(int));
                     }

--- a/fwdpy11/headers/fwdpy11/types.hpp
+++ b/fwdpy11/headers/fwdpy11/types.hpp
@@ -41,10 +41,10 @@ namespace fwdpy11
     template <int VERSION> struct diploid_writer
     {
         using result_type = void;
-        //This should really be constexpr. 
-        //Figure it out later:
+        // This should really be constexpr.
+        // Figure it out later:
         const int v;
-        diploid_writer() : v(VERSION){}
+        diploid_writer() : v(VERSION) {}
         template <typename diploid_t, typename streamtype>
         inline result_type
         operator()(const diploid_t &dip, streamtype &o) const
@@ -53,6 +53,20 @@ namespace fwdpy11
             KTfwd::fwdpp_internal::scalar_writer()(o, &dip.e);
             KTfwd::fwdpp_internal::scalar_writer()(o, &dip.w);
             KTfwd::fwdpp_internal::scalar_writer()(o, &dip.label);
+            if (v == 2)
+                {
+                    KTfwd::fwdpp_internal::scalar_writer()(
+                        o, &std::get<0>(dip.parents));
+                    KTfwd::fwdpp_internal::scalar_writer()(
+                        o, &std::get<1>(dip.parents));
+                    KTfwd::fwdpp_internal::scalar_writer()(
+                        o, &std::get<0>(dip.xyz));
+                    KTfwd::fwdpp_internal::scalar_writer()(
+                        o, &std::get<1>(dip.xyz));
+                    KTfwd::fwdpp_internal::scalar_writer()(
+                        o, &std::get<2>(dip.xyz));
+                    KTfwd::fwdpp_internal::scalar_writer()(o, &dip.sex);
+                }
         }
     };
 
@@ -68,6 +82,22 @@ namespace fwdpy11
             KTfwd::fwdpp_internal::scalar_reader()(i, &dip.e);
             KTfwd::fwdpp_internal::scalar_reader()(i, &dip.w);
             KTfwd::fwdpp_internal::scalar_reader()(i, &dip.label);
+            if (version == 2)
+                {
+                    std::uint32_t p;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &p);
+                    std::get<0>(dip.parents) = p;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &p);
+                    std::get<1>(dip.parents) = p;
+                    double space;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &space);
+                    std::get<0>(dip.xyz) = space;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &space);
+                    std::get<1>(dip.xyz) = space;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &space);
+                    std::get<2>(dip.xyz) = space;
+                    KTfwd::fwdpp_internal::scalar_reader()(i, &dip.sex);
+                }
         }
     };
 

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -262,9 +262,13 @@ PYBIND11_PLUGIN(fwdpy11_types)
                       "Random/environmental effects (read-only).")
         .def_readonly("label", &fwdpy11::diploid_t::label,
                       "Index of the diploid in its deme")
-        .def_readonly("parents", &fwdpy11::diploid_t::parents)
-        .def_readonly("space", &fwdpy11::diploid_t::xyz)
-        .def_readonly("sex", &fwdpy11::diploid_t::sex)
+        .def_readonly("parents", &fwdpy11::diploid_t::parents,
+                      "Indexes of parents (read-only).")
+        .def_readonly("space", &fwdpy11::diploid_t::xyz,
+                      "x,y,z coordinates (read-only).")
+        .def_readonly("deme", &fwdpy11::diploid_t::deme,
+                      "Current deme (read-only).")
+        .def_readonly("sex", &fwdpy11::diploid_t::sex, "Sex (read-only).")
         .def("__getstate__",
              [](const fwdpy11::diploid_t& d) {
                  return py::make_tuple(d.first, d.second, d.w, d.g, d.e);
@@ -514,8 +518,8 @@ PYBIND11_PLUGIN(fwdpy11_types)
         )delim");
 
     py::bind_vector<std::vector<diploid_space>>(m, "VecDipSpace",
-                                                  py::buffer_protocol(),
-                                                  R"delim(
+                                                py::buffer_protocol(),
+                                                R"delim(
         Vector of the space field in a " 
         ":class:`fwdpy11.fwdpp_types.SingleLocusDiploid`.
 

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -125,6 +125,82 @@ PYBIND11_MAKE_OPAQUE(std::vector<diploid_gametes>);
 PYBIND11_MAKE_OPAQUE(std::vector<diploid_space>);
 PYBIND11_MAKE_OPAQUE(std::vector<diploid_parents>);
 
+constexpr auto TRAIT_ARRAY_DOCSTRING =
+    R"delim(
+         :rtype: :class:`fwdpy11.fwdpy11_types.VecDipTraits` 
+			 
+         .. versionadded:: 0.1.2 
+         )delim";
+
+constexpr auto KEY_ARRAY_DOCSTRING =
+    R"delim(
+             :rtype: :class:`fwdpy11.fwdpy11_types.VecDipGametes`
+			 
+			 .. versionadded:: 0.1.2
+			 )delim";
+
+constexpr auto PARENTS_ARRAY_DOCSTRING =
+    R"delim(
+             :rtype: :class:`fwdpy11.fwdpy11_types.VecDipParents`
+			 
+			 .. versionadded:: 0.1.3
+			 )delim";
+
+constexpr auto SPACE_ARRAY_DOCSTRING =
+    R"delim(
+             :rtype: :class:`fwdpy11.fwdpy11_types.VecDipSpace`
+			 
+			 .. versionadded:: 0.1.3
+			 )delim";
+
+#define MAKE_DIPLOID_ARRAY(NAME, TYPE, FN, DSTRING)                           \
+    .def(NAME,                                                                \
+         [](const fwdpy11::dipvector_t& diploids) {                           \
+             std::vector<TYPE> rv;                                            \
+             rv.reserve(diploids.size());                                     \
+             for (auto&& dip : diploids)                                      \
+                 {                                                            \
+                     rv.push_back(FN(dip));                                   \
+                 }                                                            \
+             return rv;                                                       \
+         },                                                                   \
+         DSTRING)
+
+#define MAKE_DIPLOID_ARRAY_IND(NAME, TYPE, FN, DSTRING)                       \
+    .def(NAME,                                                                \
+         [](const fwdpy11::dipvector_t& diploids,                             \
+            py::array_t<std::size_t> individuals) {                           \
+             auto r = individuals.unchecked<1>();                             \
+             std::vector<TYPE> rv;                                            \
+             rv.reserve(r.shape(0));                                          \
+             for (std::size_t i = 0; i < r.shape(0); ++i)                     \
+                 {                                                            \
+                     auto&& dip = diploids.at(r(i));                          \
+                     rv.push_back(FN(dip));                                   \
+                 }                                                            \
+             return rv;                                                       \
+         },                                                                   \
+         DSTRING)
+
+#define MAKE_DIPLOID_ARRAY_SLICE(NAME, TYPE, FN, DSTRING)                     \
+    .def(NAME,                                                                \
+         [](const fwdpy11::dipvector_t& diploids, py::slice slice) {          \
+             size_t start, stop, step, slicelength;                           \
+             if (!slice.compute(diploids.size(), &start, &stop, &step,        \
+                                &slicelength))                                \
+                 throw py::error_already_set();                               \
+             std::vector<TYPE> rv;                                            \
+             rv.reserve(slicelength);                                         \
+             for (size_t i = 0; i < slicelength; ++i)                         \
+                 {                                                            \
+                     auto&& dip = diploids.at(start);                         \
+                     rv.push_back(FN(dip));                                   \
+                     start += step;                                           \
+                 }                                                            \
+             return rv;                                                       \
+         },                                                                   \
+         DSTRING)
+
 namespace
 {
     static const auto MCOUNTS_DOCSTRING = R"delim(
@@ -169,9 +245,10 @@ PYBIND11_PLUGIN(fwdpy11_types)
         .def(py::init<unsigned>(),
              "Constructor takes unsigned integer as a seed");
 
-    py::class_<fwdpy11::diploid_t>(
-        m, "SingleLocusDiploid",
-        "Diploid data type for a single (usually contiguous) genomic region")
+    py::class_<fwdpy11::diploid_t>(m, "SingleLocusDiploid",
+                                   "Diploid data type for a single "
+                                   "(usually contiguous) genomic "
+                                   "region")
         .def(py::init<>())
         .def(py::init<std::size_t, std::size_t>())
         .def_readonly("first", &fwdpy11::diploid_t::first,
@@ -205,118 +282,53 @@ PYBIND11_PLUGIN(fwdpy11_types)
         "C++ representation of a list of "
         ":class:`fwdpy11.fwdpy11_types."
         "SingleLocusDiploid`.  Typically, access will be read-only.")
-        .def("trait_array",
-             [](const fwdpy11::dipvector_t& diploids) {
-                 std::vector<diploid_traits> rv;
-                 rv.reserve(diploids.size());
-                 for (auto&& dip : diploids)
-                     {
-                         rv.push_back(make_diploid_traits(dip));
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipTraits`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim")
-        .def("trait_array",
-             [](const fwdpy11::dipvector_t& diploids,
-                py::array_t<std::size_t> individuals) {
-                 auto r = individuals.unchecked<1>();
-                 std::vector<diploid_traits> rv;
-                 rv.reserve(r.shape(0));
-                 for (std::size_t i = 0; i < r.shape(0); ++i)
-                     {
-                         // range-check here
-                         auto&& dip = diploids.at(r(i));
-                         rv.push_back(make_diploid_traits(dip));
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipTraits`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim")
-        .def("trait_array",
-             [](const fwdpy11::dipvector_t& diploids, py::slice slice) {
-                 size_t start, stop, step, slicelength;
-
-                 if (!slice.compute(diploids.size(), &start, &stop, &step,
-                                    &slicelength))
-                     throw py::error_already_set();
-
-                 std::vector<diploid_traits> rv;
-                 rv.reserve(slicelength);
-                 for (size_t i = 0; i < slicelength; ++i)
-                     {
-                         auto&& dip = diploids.at(start);
-                         rv.push_back(make_diploid_traits(dip));
-                         start += step;
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipTraits`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim")
-        .def("key_array",
-             [](const fwdpy11::dipvector_t& diploids) {
-                 std::vector<diploid_gametes> rv;
-                 rv.reserve(diploids.size());
-                 for (auto&& dip : diploids)
-                     {
-                         rv.push_back(make_diploid_gametes(dip, 0));
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipGametes`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim")
-        .def("key_array",
-             [](const fwdpy11::dipvector_t& diploids,
-                py::array_t<std::size_t> individuals) {
-                 auto r = individuals.unchecked<1>();
-                 std::vector<diploid_gametes> rv;
-                 rv.reserve(r.shape(0));
-                 for (std::size_t i = 0; i < r.shape(0); ++i)
-                     {
-                         rv.push_back(make_diploid_gametes(diploids.at(i), 0));
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipGametes`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim")
-        .def("key_array",
-             [](const fwdpy11::dipvector_t& diploids, py::slice slice) {
-                 size_t start, stop, step, slicelength;
-
-                 if (!slice.compute(diploids.size(), &start, &stop, &step,
-                                    &slicelength))
-                     throw py::error_already_set();
-
-                 std::vector<diploid_gametes> rv;
-                 rv.reserve(slicelength);
-                 for (size_t i = 0; i < slicelength; ++i)
-                     {
-                         rv.push_back(
-                             make_diploid_gametes(diploids.at(start), 0));
-                         start += step;
-                     }
-                 return rv;
-             },
-             R"delim(
-			 :rtype: :class:`fwdpy11.fwdpy11_types.VecDipGametes`
-			 
-			 .. versionadded:: 0.1.2
-			 )delim");
+        MAKE_DIPLOID_ARRAY("trait_array", diploid_traits, make_diploid_traits,
+                           TRAIT_ARRAY_DOCSTRING)
+            MAKE_DIPLOID_ARRAY_IND("trait_array", diploid_traits,
+                                   make_diploid_traits, TRAIT_ARRAY_DOCSTRING)
+                MAKE_DIPLOID_ARRAY_SLICE("trait_array", diploid_traits,
+                                         make_diploid_traits,
+                                         TRAIT_ARRAY_DOCSTRING)
+                    MAKE_DIPLOID_ARRAY("key_array", diploid_gametes,
+                                       std::bind(make_diploid_gametes,
+                                                 std::placeholders::_1, 0),
+                                       KEY_ARRAY_DOCSTRING)
+                        MAKE_DIPLOID_ARRAY_IND("key_array", diploid_gametes,
+                                               std::bind(make_diploid_gametes,
+                                                         std::placeholders::_1,
+                                                         0),
+                                               KEY_ARRAY_DOCSTRING)
+                            MAKE_DIPLOID_ARRAY_SLICE(
+                                "key_array", diploid_gametes,
+                                std::bind(make_diploid_gametes,
+                                          std::placeholders::_1, 0),
+                                KEY_ARRAY_DOCSTRING)
+                                MAKE_DIPLOID_ARRAY("parents_array",
+                                                   diploid_parents,
+                                                   make_diploid_parents,
+                                                   PARENTS_ARRAY_DOCSTRING)
+                                    MAKE_DIPLOID_ARRAY_IND(
+                                        "parents_array", diploid_parents,
+                                        make_diploid_parents,
+                                        PARENTS_ARRAY_DOCSTRING)
+                                        MAKE_DIPLOID_ARRAY_SLICE(
+                                            "parents_array", diploid_parents,
+                                            make_diploid_parents,
+                                            PARENTS_ARRAY_DOCSTRING)
+                                            MAKE_DIPLOID_ARRAY(
+                                                "space_array", diploid_space,
+                                                make_diploid_space,
+                                                SPACE_ARRAY_DOCSTRING)
+                                                MAKE_DIPLOID_ARRAY_IND(
+                                                    "space_array",
+                                                    diploid_space,
+                                                    make_diploid_space,
+                                                    SPACE_ARRAY_DOCSTRING)
+                                                    MAKE_DIPLOID_ARRAY_SLICE(
+                                                        "space_array",
+                                                        diploid_space,
+                                                        make_diploid_space,
+                                                        SPACE_ARRAY_DOCSTRING);
 
     py::bind_vector<std::vector<fwdpy11::dipvector_t>>(
         m, "VecDiploidContainer", "Vector of "
@@ -462,6 +474,9 @@ PYBIND11_PLUGIN(fwdpy11_types)
     PYBIND11_NUMPY_DTYPE(flattened_popgenmut, pos, s, h, g, label, neutral);
     PYBIND11_NUMPY_DTYPE(diploid_traits, g, e, w);
     PYBIND11_NUMPY_DTYPE(diploid_gametes, locus, first, second);
+    PYBIND11_NUMPY_DTYPE(diploid_parents, p1, p2);
+    PYBIND11_NUMPY_DTYPE(diploid_space, x, y, z);
+
     py::bind_vector<std::vector<flattened_popgenmut>>(m, "VecMutStruct",
                                                       py::buffer_protocol(),
                                                       R"delim(
@@ -487,6 +502,24 @@ PYBIND11_PLUGIN(fwdpy11_types)
         ":class:`fwdpy11.fwdpp_types.SingleLocusDiploid`.
 
         .. versionadded: 0.1.2
+        )delim");
+
+    py::bind_vector<std::vector<diploid_parents>>(m, "VecDipParents",
+                                                  py::buffer_protocol(),
+                                                  R"delim(
+        Vector of the parents in a " 
+        ":class:`fwdpy11.fwdpp_types.SingleLocusDiploid`.
+
+        .. versionadded: 0.1.3
+        )delim");
+
+    py::bind_vector<std::vector<diploid_parents>>(m, "VecDipSpace",
+                                                  py::buffer_protocol(),
+                                                  R"delim(
+        Vector of the space field in a " 
+        ":class:`fwdpy11.fwdpp_types.SingleLocusDiploid`.
+
+        .. versionadded: 0.1.3
         )delim");
 
     py::bind_vector<fwdpy11::mcont_t>(

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -513,7 +513,7 @@ PYBIND11_PLUGIN(fwdpy11_types)
         .. versionadded: 0.1.3
         )delim");
 
-    py::bind_vector<std::vector<diploid_parents>>(m, "VecDipSpace",
+    py::bind_vector<std::vector<diploid_space>>(m, "VecDipSpace",
                                                   py::buffer_protocol(),
                                                   R"delim(
         Vector of the space field in a " 

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -90,9 +90,40 @@ make_diploid_gametes(const fwdpy11::diploid_t& dip, const std::size_t locus)
     return d;
 }
 
+struct diploid_parents
+{
+    std::uint32_t p1, p2;
+};
+
+inline diploid_parents
+make_diploid_parents(const fwdpy11::diploid_t& dip)
+{
+    diploid_parents rv;
+    rv.p1 = std::get<0>(dip.parents);
+    rv.p2 = std::get<1>(dip.parents);
+    return rv;
+}
+
+struct diploid_space
+{
+    double x, y, z;
+};
+
+inline diploid_space
+make_diploid_space(const fwdpy11::diploid_t& dip)
+{
+    diploid_space rv;
+    rv.x = std::get<0>(dip.xyz);
+    rv.y = std::get<1>(dip.xyz);
+    rv.z = std::get<2>(dip.xyz);
+    return rv;
+}
+
 PYBIND11_MAKE_OPAQUE(std::vector<flattened_popgenmut>);
 PYBIND11_MAKE_OPAQUE(std::vector<diploid_traits>);
 PYBIND11_MAKE_OPAQUE(std::vector<diploid_gametes>);
+PYBIND11_MAKE_OPAQUE(std::vector<diploid_space>);
+PYBIND11_MAKE_OPAQUE(std::vector<diploid_parents>);
 
 namespace
 {
@@ -154,6 +185,9 @@ PYBIND11_PLUGIN(fwdpy11_types)
                       "Random/environmental effects (read-only).")
         .def_readonly("label", &fwdpy11::diploid_t::label,
                       "Index of the diploid in its deme")
+        .def_readonly("parents", &fwdpy11::diploid_t::parents)
+        .def_readonly("space", &fwdpy11::diploid_t::xyz)
+        .def_readonly("sex", &fwdpy11::diploid_t::sex)
         .def("__getstate__",
              [](const fwdpy11::diploid_t& d) {
                  return py::make_tuple(d.first, d.second, d.w, d.g, d.e);
@@ -285,10 +319,9 @@ PYBIND11_PLUGIN(fwdpy11_types)
 			 )delim");
 
     py::bind_vector<std::vector<fwdpy11::dipvector_t>>(
-        m, "VecDiploidContainer",
-        "Vector of "
-        ":class:`fwdpy11.fwdpy11_types."
-        "SingleLocusDiploid`.")
+        m, "VecDiploidContainer", "Vector of "
+                                  ":class:`fwdpy11.fwdpy11_types."
+                                  "SingleLocusDiploid`.")
         .def("trait_array",
              [](const std::vector<fwdpy11::dipvector_t>& diploids) {
                  std::vector<diploid_traits> rv;
@@ -457,10 +490,9 @@ PYBIND11_PLUGIN(fwdpy11_types)
         )delim");
 
     py::bind_vector<fwdpy11::mcont_t>(
-        m, "MutationContainer",
-        "C++ representation of a list of "
-        ":class:`fwdpy11.fwdpp_types.Mutation`.  "
-        "Typically, access will be read-only.")
+        m, "MutationContainer", "C++ representation of a list of "
+                                ":class:`fwdpy11.fwdpp_types.Mutation`.  "
+                                "Typically, access will be read-only.")
         .def("array",
              [](const fwdpy11::mcont_t& mc) {
                  std::vector<flattened_popgenmut> rv;
@@ -502,10 +534,9 @@ PYBIND11_PLUGIN(fwdpy11_types)
     // Expose the type based on fwdpp's "sugar"
     // layer
     py::class_<fwdpy11::singlepop_t, singlepop_sugar_base>(
-        m, "SlocusPop",
-        "Population object representing a single "
-        "deme and a "
-        "single genomic region.")
+        m, "SlocusPop", "Population object representing a single "
+                        "deme and a "
+                        "single genomic region.")
         .def(py::init<unsigned>(), "Construct with an unsigned integer "
                                    "representing the initial "
                                    "population size.")
@@ -545,9 +576,8 @@ PYBIND11_PLUGIN(fwdpy11_types)
                 const fwdpy11::singlepop_t& rhs) { return lhs == rhs; });
 
     py::class_<fwdpy11::multilocus_t, multilocus_sugar_base>(
-        m, "MlocusPop",
-        "Representation of a multi-locus, single "
-        "deme system.")
+        m, "MlocusPop", "Representation of a multi-locus, single "
+                        "deme system.")
         .def(py::init<unsigned, unsigned>(), py::arg("N"), py::arg("nloci"),
              "Construct with population size and "
              "number of loci.")
@@ -632,5 +662,7 @@ PYBIND11_PLUGIN(fwdpy11_types)
                           const fwdpy11::singlepop_gm_vec_t& rhs) {
             return lhs == rhs;
         });
+
+    m.def("sizeof", []() { return sizeof(fwdpy11::diploid_t); });
     return m.ptr();
 }

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
-                ext.extra_link_args = ['-stdlib=stdlibc++',
+                ext.extra_link_args = ['-stdlib=libc++',
                                        '-mmacosx-version-min=10.7']
         build_ext.build_extensions(self)
 

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ class BuildExt(build_ext):
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
                 ext.extra_link_args = ['-stdlib=stdlibc++',
-                                       '-mmacosx-version-min = 10.7']
+                                       '-mmacosx-version-min=10.7']
         build_ext.build_extensions(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
-                ext.extra_link_args = ['-stdlib = libc++',
+                ext.extra_link_args = ['-stdlib=stdlibc++',
                                        '-mmacosx-version-min = 10.7']
         build_ext.build_extensions(self)
 

--- a/setup.py.in
+++ b/setup.py.in
@@ -222,7 +222,7 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
-                ext.extra_link_args = ['-stdlib=stdlibc++',
+                ext.extra_link_args = ['-stdlib=libc++',
                                        '-mmacosx-version-min=10.7']
         build_ext.build_extensions(self)
 

--- a/setup.py.in
+++ b/setup.py.in
@@ -223,7 +223,7 @@ class BuildExt(build_ext):
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
                 ext.extra_link_args = ['-stdlib=stdlibc++',
-                                       '-mmacosx-version-min = 10.7']
+                                       '-mmacosx-version-min=10.7']
         build_ext.build_extensions(self)
 
 

--- a/setup.py.in
+++ b/setup.py.in
@@ -222,7 +222,7 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args = opts
             if sys.platform == 'darwin' and USE_GCC is False:
-                ext.extra_link_args = ['-stdlib = libc++',
+                ext.extra_link_args = ['-stdlib=stdlibc++',
                                        '-mmacosx-version-min = 10.7']
         build_ext.build_extensions(self)
 


### PR DESCRIPTION
This PR adds fields to the diploid type to enable simulations in both continuous and discrete space.

TODO:

- [ ] Performance testing to make sure that the extra meta-data don't cause a huge slowdown