### PR TITLE
Give read/write access to the neutral and selected fields of a DataMatrix

### DIFF
--- a/doc/examples/DataMatrix.rst
+++ b/doc/examples/DataMatrix.rst
@@ -21,7 +21,7 @@ The API is extremely flexible, allowing for the inclusion or exclustion of selec
    position, effect size, etc.  You may also apply a frequency filter.  The data returned from :func:`fwdpy11.sampling.mutation_keys` records the sample frequency and the `mcounts` objects present in populations can be used to filter on population frequencies.
 4. Generate the fwdpy11.sampling.DataMatrix object by calling either :func:`fwdpy11.sampling.genotype_matrix` or
    `fwdpy11.sampling.haplotype_matrix`.
-5. Get the matrices as numpy arrays via a call to :meth:`fwdpy11.sampling.DataMatrix.neutral` or :meth:`fwdpy11.sampling.DataMatrix.selected`.  These functions return 1d numpy arrays, which should be reshaped with the help of :attr:`fwdpy11.sampling.DataMatrix.ndim_neutral`, :meth:`fwdpy11.sampling.DataMatrix.ndim_selected`.
+5. Get the matrices as numpy arrays via a call to :meth:`fwdpy11.sampling.DataMatrix.neutral` or :meth:`fwdpy11.sampling.DataMatrix.selected`.  These functions return 1d numpy arrays, which should be reshaped with the help of :attr:`fwdpy11.sampling.DataMatrix.ndim_neutral`, :attr:`fwdpy11.sampling.DataMatrix.ndim_selected`.
 
 The positions and population frequencies are also stored in the :class:`fwdpy11.sampling.DataMatrix` instance.  The
 order of these mutations is the same order as the mutation keys used to generated the object.
@@ -93,7 +93,7 @@ The following example is a tour of the API:
     print(type(dm))
 
     #Get the neutral genotypes out as a 2d 2d numpy array
-    n = np.ndarray(dm.ndim_neutral(),buffer=dm.neutral,dtype=np.int8) 
+    n = np.ndarray(dm.ndim_neutral,buffer=dm.neutral,dtype=np.int8) 
     print(type(n))
     print(n.dtype)
     print(n.ndim)

--- a/doc/examples/DataMatrix.rst
+++ b/doc/examples/DataMatrix.rst
@@ -21,7 +21,7 @@ The API is extremely flexible, allowing for the inclusion or exclustion of selec
    position, effect size, etc.  You may also apply a frequency filter.  The data returned from :func:`fwdpy11.sampling.mutation_keys` records the sample frequency and the `mcounts` objects present in populations can be used to filter on population frequencies.
 4. Generate the fwdpy11.sampling.DataMatrix object by calling either :func:`fwdpy11.sampling.genotype_matrix` or
    `fwdpy11.sampling.haplotype_matrix`.
-5. Get the matrices as numpy arrays via a call to :meth:`fwdpy11.sampling.DataMatrix.neutral` or :meth:`fwdpy11.sampling.DataMatrix.selected`.  These functions return 1d numpy arrays, which should be reshaped with the help of :attr:`fwdpy11.sampling.DataMatrix.nrow`, :meth:`fwdpy11.sampling.DataMatrix.ncol_neutral`, and :meth:`fwdpy11.sampling.DataMatrix.ncol_selected`.
+5. Get the matrices as numpy arrays via a call to :meth:`fwdpy11.sampling.DataMatrix.neutral` or :meth:`fwdpy11.sampling.DataMatrix.selected`.  These functions return 1d numpy arrays, which should be reshaped with the help of :attr:`fwdpy11.sampling.DataMatrix.ndim_neutral`, :meth:`fwdpy11.sampling.DataMatrix.ndim_selected`.
 
 The positions and population frequencies are also stored in the :class:`fwdpy11.sampling.DataMatrix` instance.  The
 order of these mutations is the same order as the mutation keys used to generated the object.

--- a/fwdpy11/src/fwdpy11_sampling.cc
+++ b/fwdpy11/src/fwdpy11_sampling.cc
@@ -195,23 +195,37 @@ PYBIND11_MODULE(sampling, m)
 		)delim")
         .def(py::init<>())
         .def(py::init<std::size_t>())
-        .def_readonly("neutral", &KTfwd::data_matrix::neutral,
+        .def_readwrite("neutral", &KTfwd::data_matrix::neutral,
                       R"delim(
                 Return a buffer representing neutral variants.
                 This buffer may be used to create a NumPy
                 ndarray object.
 
+                .. warning::
+                    Changing the size of this property is
+                    undefined behavior.
+
                 .. versionchanged:: 0.1.2
                     Return a buffer instead of 1d numpy.array
+
+                .. versionchanged: 0.1.4
+                    Allow read/write access instead of readonly
                 )delim")
-        .def_readonly("selected", &KTfwd::data_matrix::selected,
+        .def_readwrite("selected", &KTfwd::data_matrix::selected,
                       R"delim(
                 Return a buffer representing neutral variants.
                 This buffer may be used to create a NumPy
                 ndarray object.
 
+                .. warning::
+                    Changing the size of this property is
+                    undefined behavior.
+
                 .. versionchanged:: 0.1.2
                     Return a buffer instead of 1d numpy.array
+
+                .. versionchanged: 0.1.4
+                    Allow read/write access instead of readonly
                 )delim")
         .def_readonly("neutral_positions",
                       &KTfwd::data_matrix::neutral_positions,

--- a/fwdpy11/src/fwdpy11_sampling.cc
+++ b/fwdpy11/src/fwdpy11_sampling.cc
@@ -242,7 +242,7 @@ PYBIND11_MODULE(sampling, m)
                       &KTfwd::data_matrix::selected_popfreq,
                       "The list of population frequencies of "
                       "selected mutations.")
-        .def("ndim_neutral",
+        .def_property_readonly("ndim_neutral",
              [](const KTfwd::data_matrix &dm) {
                  return py::make_tuple(dm.nrow, dm.neutral.size() / dm.nrow);
              },

--- a/fwdpy11/src/fwdpy11_sampling.cc
+++ b/fwdpy11/src/fwdpy11_sampling.cc
@@ -196,7 +196,7 @@ PYBIND11_MODULE(sampling, m)
         .def(py::init<>())
         .def(py::init<std::size_t>())
         .def_readwrite("neutral", &KTfwd::data_matrix::neutral,
-                      R"delim(
+                       R"delim(
                 Return a buffer representing neutral variants.
                 This buffer may be used to create a NumPy
                 ndarray object.
@@ -212,7 +212,7 @@ PYBIND11_MODULE(sampling, m)
                     Allow read/write access instead of readonly
                 )delim")
         .def_readwrite("selected", &KTfwd::data_matrix::selected,
-                      R"delim(
+                       R"delim(
                 Return a buffer representing neutral variants.
                 This buffer may be used to create a NumPy
                 ndarray object.
@@ -239,29 +239,37 @@ PYBIND11_MODULE(sampling, m)
         .def_readonly(
             "selected_popfreq", &KTfwd::data_matrix::selected_popfreq,
             "The list of population frequencies of selected mutations.")
-        .def("ndim_neutral",
-             [](const KTfwd::data_matrix &dm) {
-                 return py::make_tuple(dm.nrow, dm.neutral.size() / dm.nrow);
-             },
-             R"delim(
+        .def_property_readonly("ndim_neutral",
+                               [](const KTfwd::data_matrix &dm) {
+                                   return py::make_tuple(
+                                       dm.nrow, dm.neutral.size() / dm.nrow);
+                               },
+                               R"delim(
              Return the dimensions of the neutral matrix
              
              :rtype: tuple
 
              .. versionadded:: 0.1.2
                 Replaces ncol and nrow_neutral functions
+
+             .. versionchanged:: 0.1.4
+                Changed from a function to a readonly property
              )delim")
-        .def("ndim_selected",
-             [](const KTfwd::data_matrix &dm) {
-                 return py::make_tuple(dm.nrow, dm.selected.size() / dm.nrow);
-             },
-             R"delim(
+        .def_property_readonly("ndim_selected",
+                               [](const KTfwd::data_matrix &dm) {
+                                   return py::make_tuple(
+                                       dm.nrow, dm.selected.size() / dm.nrow);
+                               },
+                               R"delim(
              Return the dimensions of the selected matrix
 
              :rtype: tuple
              
              .. versionadded:: 0.1.2
                 Replaces ncol and nrow_selected functions
+
+             .. versionchanged:: 0.1.4
+                Changed from a function to a readonly property
              )delim")
         .def(py::pickle(
             [](const KTfwd::data_matrix &d) {

--- a/tests/test_DataMatrix.py
+++ b/tests/test_DataMatrix.py
@@ -21,16 +21,16 @@ class test_DataMatrixFromSlocusPop(unittest.TestCase):
         self.gm = fwdpy11.sampling.genotype_matrix(
             self.pop, self.indlist, self.keys[0], self.keys[1])
         self.hm_neutral = np.ndarray(
-            self.hm.ndim_neutral(),
+            self.hm.ndim_neutral,
             buffer=self.hm.neutral, dtype=np.int8)
         self.hm_selected = np.ndarray(
-            self.hm.ndim_selected(),
+            self.hm.ndim_selected,
             buffer=self.hm.selected, dtype=np.int8)
         self.gm_neutral = np.ndarray(
-            self.gm.ndim_neutral(),
+            self.gm.ndim_neutral,
             buffer=self.gm.neutral, dtype=np.int8)
         self.gm_selected = np.ndarray(
-            self.gm.ndim_selected(),
+            self.gm.ndim_selected,
             buffer=self.gm.selected, dtype=np.int8)
 
     def testKeyNeutralityAndCount(self):
@@ -120,16 +120,16 @@ class test_DataMatrixFromMlocusPop(unittest.TestCase):
         self.gm = fwdpy11.sampling.genotype_matrix(
             self.pop, self.indlist, self.keys[0], self.keys[1])
         self.hm_neutral = np.ndarray(
-            self.hm.ndim_neutral(),
+            self.hm.ndim_neutral,
             buffer=self.hm.neutral, dtype=np.int8)
         self.hm_selected = np.ndarray(
-            self.hm.ndim_selected(),
+            self.hm.ndim_selected,
             buffer=self.hm.selected, dtype=np.int8)
         self.gm_neutral = np.ndarray(
-            self.gm.ndim_neutral(),
+            self.gm.ndim_neutral,
             buffer=self.gm.neutral, dtype=np.int8)
         self.gm_selected = np.ndarray(
-            self.gm.ndim_selected(),
+            self.gm.ndim_selected,
             buffer=self.gm.selected, dtype=np.int8)
 
     def testConvertHapMatrixToSample(self):


### PR DESCRIPTION
This PR changes 2 properties from def_readonly to def_readwrite, allowing write-access to the C++ back end.