### PR TITLE
Get RTD working again

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - gsl
     - nbsphinx
     - msprime
+    - gcc
     - pip:
         - numpy
         - matplotlib


### PR DESCRIPTION
This branch gets manual builds working on RTD by using the conda GCC.