### PR TITLE
add parental_data field to diploid. It records the parental labels.

### DIFF
--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -21,6 +21,7 @@
 
 #include <pybind11/stl.h>
 #include <cstdint>
+#include <tuple>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
 #include <fwdpp/sugar/generalmut.hpp>
@@ -58,21 +59,31 @@ namespace fwdpy11
         double e;
         //! Fitness.  This is not necessarily written to by a simulation.
         double w;
+        //! IDs of parents.  NB: this will be changed in future releases
+        std::tuple<std::size_t, std::size_t> parental_data;
         //! Constructor
         diploid_t() noexcept
             : first(first_type()), second(second_type()), label(0), g(0.),
-              e(0.), w(1.)
+              e(0.), w(1.), parental_data(std::make_tuple(
+                                std::numeric_limits<std::size_t>::max(),
+                                std::numeric_limits<std::size_t>::max()))
         {
         }
         //! Construct from two indexes to gametes
         diploid_t(first_type g1, first_type g2) noexcept
-            : first(g1), second(g2), label(0), g(0.), e(0.), w(1.)
+            : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
+              parental_data(
+                  std::make_tuple(std::numeric_limits<std::size_t>::max(),
+                                  std::numeric_limits<std::size_t>::max()))
         {
         }
 
         diploid_t(first_type g1, first_type g2, std::size_t label_, double g_,
                   double e_, double w_)
-            : first(g1), second(g2), label(label_), g(g_), e(e_), w(w_)
+            : first(g1), second(g2), label(label_), g(g_), e(e_), w(w_),
+              parental_data(
+                  std::make_tuple(std::numeric_limits<std::size_t>::max(),
+                                  std::numeric_limits<std::size_t>::max()))
         {
         }
 
@@ -89,7 +100,8 @@ namespace fwdpy11
         {
             return this->first == dip.first && this->second == dip.second
                    && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                   && this->label == dip.label;
+                   && this->label == dip.label &&
+                   this->parental_data == dip.parental_data;
         }
     };
 

--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -100,8 +100,7 @@ namespace fwdpy11
         {
             return this->first == dip.first && this->second == dip.second
                    && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                   && this->label == dip.label &&
-                   this->parental_data == dip.parental_data;
+                   && this->label == dip.label;
         }
     };
 

--- a/fwdpy11/headers/fwdpy11/rules/qtrait.hpp
+++ b/fwdpy11/headers/fwdpy11/rules/qtrait.hpp
@@ -60,6 +60,7 @@ namespace fwdpy11
             {
                 offspring.e
                     = noise_function(pop.diploids[p1], pop.diploids[p2]);
+                offspring.parental_data = std::make_tuple(p1,p2);
                 return;
             }
         };
@@ -161,6 +162,7 @@ namespace fwdpy11
             {
                 offspring[0].e
                     = noise_function(pop.diploids[p1], pop.diploids[p2]);
+                offspring[0].parental_data = std::make_tuple(p1,p2);
             }
         };
     } // namespace qtrait

--- a/fwdpy11/headers/fwdpy11/rules/wf_rules.hpp
+++ b/fwdpy11/headers/fwdpy11/rules/wf_rules.hpp
@@ -62,6 +62,7 @@ namespace fwdpy11
         {
             offspring.e = 0.0;
             offspring.g = 0.0;
+            offspring.parental_data = std::make_tuple(p1, p2);
             return;
         }
     };

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -156,6 +156,8 @@ PYBIND11_MODULE(fwdpy11_types, m)
                       "Random/environmental effects (read-only).")
         .def_readonly("label", &fwdpy11::diploid_t::label,
                       "Index of the diploid in its deme")
+        .def_readonly("parental_data", &fwdpy11::diploid_t::parental_data,
+                      "label values of this diploid's parents")
         .def(py::pickle(
             [](const fwdpy11::diploid_t& d) {
                 return py::make_tuple(d.first, d.second, d.w, d.g, d.e,


### PR DESCRIPTION
This commit adds `parental_data` as a filed in the diploid object.  Simulations populate it with the label values of each parent.

NB: this data field is not pickled.  Rather, it is a placeholder for more general recording of parental information.