### PR TITLE
Parental data as object

### DIFF
--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -61,7 +61,7 @@ namespace fwdpy11
         //! Fitness.  This is not necessarily written to by a simulation.
         double w;
         //! IDs of parents.  NB: this will be changed in future releases
-		pybind11::object parental_data;
+        pybind11::object parental_data;
         //! Constructor
         diploid_t() noexcept
             : first(first_type()), second(second_type()), label(0), g(0.),
@@ -93,9 +93,27 @@ namespace fwdpy11
         operator==(const diploid_t& dip) const noexcept
         //! Required for py::bind_vector
         {
-            return this->first == dip.first && this->second == dip.second
-                   && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                   && this->label == dip.label;
+            auto cpp_data_comparison
+                = this->first == dip.first && this->second == dip.second
+                  && this->w == dip.w && this->g == dip.g && this->e == dip.e
+                  && this->label == dip.label;
+            //We now attempt to compare the parental data.
+            //pybind11 doesn't have a rich comparison support,
+            //so we rely on the __eq__ attribute.  If no 
+            //such attribute exists, we simply clear the
+            //error and move on.
+            try
+                {
+                    bool parental_data_comp
+                        = this->parental_data.attr("__eq__")(dip.parental_data)
+                              .cast<bool>();
+                    return cpp_data_comparison && parental_data_comp;
+                }
+            catch (...)
+                {
+                    PyErr_Clear();
+                }
+            return cpp_data_comparison;
         }
     };
 

--- a/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
+++ b/fwdpy11/headers/fwdpy11/opaque/opaque_types.hpp
@@ -19,6 +19,7 @@
 #ifndef FWDPY11_OPAQUE_TYPES_HPP__
 #define FWDPY11_OPAQUE_TYPES_HPP__
 
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <cstdint>
 #include <tuple>
@@ -60,30 +61,24 @@ namespace fwdpy11
         //! Fitness.  This is not necessarily written to by a simulation.
         double w;
         //! IDs of parents.  NB: this will be changed in future releases
-        std::tuple<std::size_t, std::size_t> parental_data;
+		pybind11::object parental_data;
         //! Constructor
         diploid_t() noexcept
             : first(first_type()), second(second_type()), label(0), g(0.),
-              e(0.), w(1.), parental_data(std::make_tuple(
-                                std::numeric_limits<std::size_t>::max(),
-                                std::numeric_limits<std::size_t>::max()))
+              e(0.), w(1.), parental_data(pybind11::none())
         {
         }
         //! Construct from two indexes to gametes
         diploid_t(first_type g1, first_type g2) noexcept
             : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
-              parental_data(
-                  std::make_tuple(std::numeric_limits<std::size_t>::max(),
-                                  std::numeric_limits<std::size_t>::max()))
+              parental_data(pybind11::none())
         {
         }
 
         diploid_t(first_type g1, first_type g2, std::size_t label_, double g_,
                   double e_, double w_)
             : first(g1), second(g2), label(label_), g(g_), e(e_), w(w_),
-              parental_data(
-                  std::make_tuple(std::numeric_limits<std::size_t>::max(),
-                                  std::numeric_limits<std::size_t>::max()))
+              parental_data(pybind11::none())
         {
         }
 

--- a/fwdpy11/headers/fwdpy11/rules/qtrait.hpp
+++ b/fwdpy11/headers/fwdpy11/rules/qtrait.hpp
@@ -60,7 +60,7 @@ namespace fwdpy11
             {
                 offspring.e
                     = noise_function(pop.diploids[p1], pop.diploids[p2]);
-                offspring.parental_data = std::make_tuple(p1,p2);
+                offspring.parental_data = pybind11::make_tuple(p1,p2);
                 return;
             }
         };
@@ -162,7 +162,7 @@ namespace fwdpy11
             {
                 offspring[0].e
                     = noise_function(pop.diploids[p1], pop.diploids[p2]);
-                offspring[0].parental_data = std::make_tuple(p1,p2);
+                offspring[0].parental_data = pybind11::make_tuple(p1,p2);
             }
         };
     } // namespace qtrait

--- a/fwdpy11/headers/fwdpy11/rules/wf_rules.hpp
+++ b/fwdpy11/headers/fwdpy11/rules/wf_rules.hpp
@@ -62,7 +62,7 @@ namespace fwdpy11
         {
             offspring.e = 0.0;
             offspring.g = 0.0;
-            offspring.parental_data = std::make_tuple(p1, p2);
+            offspring.parental_data = pybind11::make_tuple(p1, p2);
             return;
         }
     };

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -166,7 +166,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def(py::pickle(
             [](const fwdpy11::diploid_t& d) {
                 return py::make_tuple(d.first, d.second, d.w, d.g, d.e,
-                                      d.label);
+                                      d.label, d.parental_data);
             },
             [](py::tuple t) {
                 std::unique_ptr<fwdpy11::diploid_t> d(new fwdpy11::diploid_t(
@@ -175,6 +175,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
                 d->g = t[3].cast<double>();
                 d->e = t[4].cast<double>();
                 d->label = t[5].cast<decltype(fwdpy11::diploid_t::label)>();
+                //Unpickle the Python object.
+                //The if statement is for backwards compatibility.
+                if (t.size() == 7)
+                    {
+                        d->parental_data = t[6];
+                    }
                 return d;
             }));
 

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -162,10 +162,6 @@ PYBIND11_MODULE(fwdpy11_types, m)
 				The details are simulation-dependent.
 
 				.. versionadded:: 0.1.4
-
-				.. note::
-					This field is not used in equality comparison
-					between diploids.
 				)delim")
         .def(py::pickle(
             [](const fwdpy11::diploid_t& d) {

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -179,7 +179,6 @@ PYBIND11_MODULE(fwdpy11_types, m)
                 d->e = t[4].cast<double>();
                 d->label = t[5].cast<decltype(fwdpy11::diploid_t::label)>();
                 return d;
-                return d;
             }));
 
     py::bind_vector<fwdpy11::dipvector_t>(


### PR DESCRIPTION
This PR builds on #47, refactoring `parental_data` as a Python object.