### PR TITLE
Add python fields to pops

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -15,6 +15,7 @@ dependencies:
     - gcc
     - pip:
         - numpy
+        - pandas
         - matplotlib
         - ipython
         - cppimport

--- a/doc/examples/parentage.rst
+++ b/doc/examples/parentage.rst
@@ -36,6 +36,7 @@ offspring, etc.
 
     PedigreeData = namedtuple('PedigreeData',['gen','id','p1','p2'])
 
+    # Our recorder is very simple:
     class RecordParents(object):
         def __call__(self,pop):
             parents = [PedigreeData(pop.generation,i.label,*i.parental_data) for i in pop.diploids]
@@ -43,8 +44,11 @@ offspring, etc.
 
     rng = fwdpy11.GSLrng(42)
 
-    theta,rho = 100.0,100.0
     pop = fwdpy11.SlocusPop(10)
+
+    # It is important to initialize
+    # popdata_user, whose default
+    # value is None:
     pop.popdata_user = []
     pdict = fwdpy11.ezparams.mslike(pop,simlen=pop.N)
     params = fwdpy11.model_params.SlocusParams(**pdict)
@@ -52,5 +56,6 @@ offspring, etc.
     r = RecordParents()
     fwdpy11.wright_fisher.evolve(rng,pop,params,r)
 
+    # Store the data as a DataFrame
     df = pd.DataFrame.from_records(pop.popdata_user,columns=PedigreeData._fields)
     print(df.head())

--- a/doc/examples/parentage.rst
+++ b/doc/examples/parentage.rst
@@ -5,6 +5,10 @@ Tracking parentage
 
 .. versionadded:: 0.1.4
 
+Background reading:
+
+* :ref:`recorders`
+
 This example shows one way to track parentage during a simulation.  We'll run a single-deme simulation and use
 :attr:`fwdpy11.fwdpy11_types.SlocusPop.popdata_user` to record the complete pedigree for the population over time.
 

--- a/doc/examples/parentage.rst
+++ b/doc/examples/parentage.rst
@@ -1,0 +1,43 @@
+.. _parentage:
+
+Tracking parentage
+======================================================================
+
+.. versionadded:: 0.1.4
+
+This example shows one way to track parentage during a simulation.  We'll run a single-deme simulation and use
+:attr:`fwdpy11.fwdpy11_types.SlocusPop.popdata_user` to record the complete pedigree for the population over time.
+
+The mechanics are quite simple.  We define a custom recorder that gathers the parent data
+(:attr:`fwdpy11.fwdpp_types.SingleLocusDiploid.parental_data`) into a list each generation.  
+
+A real-world example would have to do more work than this.  You would probably need to assign unique individual IDs each
+generation, etc., and get the data into some standard format (PLINK's ped/fam, for example), in order to do interesting
+work with the pedigree.
+
+.. ipython:: python
+
+    import fwdpy11
+    import fwdpy11.fitness
+    import fwdpy11.model_params
+    import fwdpy11.ezparams
+    import fwdpy11.wright_fisher
+    import numpy as np
+
+    class RecordParents(object):
+        def __call__(self,pop):
+            parents = [i.parental_data for i in pop.diploids]
+            pop.popdata_user.append(parents)
+
+    rng = fwdpy11.GSLrng(42)
+
+    theta,rho = 100.0,100.0
+    pop = fwdpy11.SlocusPop(10)
+    pop.popdata_user = []
+    pdict = fwdpy11.ezparams.mslike(pop,simlen=pop.N)
+    params = fwdpy11.model_params.SlocusParams(**pdict)
+
+    r = RecordParents()
+    fwdpy11.wright_fisher.evolve(rng,pop,params,r)
+    for i in pop.popdata_user:
+        print(i)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,7 @@ Welcome to fwdpy11's documentation!
     examples/DataMatrix
     examples/qtrait
     examples/processingpops
+    examples/parentage
 
 .. toctree::
     :caption: Maximizing performance

--- a/doc/pages/types.rst
+++ b/doc/pages/types.rst
@@ -113,6 +113,10 @@ contains the following read-only properties:
     "g", "Genetic value."
     "e", "Random component of trait value."
     "label", "The index of this diploid in the population."
+    "parental_data", "A Python object with information about parents."
+
+The information stored in `parental_data` is simulation-dependent.  For models with no population structure, it will
+typically be a Python tuple containing the `label` value for each parent.  See :ref:`parentage` for an example.
 
 For a multi-locus simulation, the diploid genotype at each locus is stored in a :class:`fwdpy11.fwdpy11_types.DiploidContainer`, which is an opaque list of :class:`fwdpy11.fwdpy11_types.SingleLocusDiploid` objects.  **The w/g/e/label fields are only populated for the first locus.**
 
@@ -180,3 +184,12 @@ The need for `locus_boundaries` will be discussed elsewhere.
 .. todo::
 
     Discuss locus boundaries somewhere.
+
+Python data types stored in population objects
+---------------------------------------------------------------------------------
+
+.. versionadded:: 0.1.4
+
+All population objects contain two generic Python objects.  These are called `popdata` and `popdata_user`.  The former
+is read-only and exists to provide flexibility to the internal details of simulation functions.  The latter is a
+read-write property that the user can modify.

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -623,7 +623,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
             }))
         .def("__eq__",
              [](const fwdpy11::singlepop_t& lhs,
-                const fwdpy11::singlepop_t& rhs) { return lhs == rhs })
+                const fwdpy11::singlepop_t& rhs) { return lhs == rhs; })
         .def("sample",
              [](const fwdpy11::singlepop_t& pop, const fwdpy11::GSLrng_t& rng,
                 const std::int64_t nsam, const bool separate,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -579,8 +579,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
                       FIXATION_TIMES_DOCSTRING)
         .def_readonly("gametes", &fwdpp_popgenmut_base::gametes,
                       GAMETES_DOCSTRING)
-        .def_readonly("popdata", &fwdpy11::singlepop_t::popdata)
-        .def_readwrite("popdata_user", &fwdpy11::singlepop_t::popdata_user)
+        .def_readonly("popdata", &fwdpy11::singlepop_t::popdata,
+                      "A Python object that may be written to by a "
+                      "simulation. Any data written should be documented by "
+                      "the simulation function.")
+        .def_readwrite("popdata_user", &fwdpy11::singlepop_t::popdata_user,
+                       "A Python object with read-write access.")
         .def(py::pickle(
             [](const fwdpy11::singlepop_t& pop) -> py::object {
                 auto pb = py::bytes(pop.serialize());
@@ -772,6 +776,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def_readwrite("locus_boundaries",
                        &fwdpy11::multilocus_t::locus_boundaries,
                        "[beg,end) positions for each locus")
+        .def_readonly("popdata", &fwdpy11::multilocus_t::popdata,
+                      "A Python object that may be written to by a "
+                      "simulation. Any data written should be documented by "
+                      "the simulation function.")
+        .def_readwrite("popdata_user", &fwdpy11::multilocus_t::popdata_user,
+                       "A Python object with read-write access.")
         .def(py::pickle(
             [](const fwdpy11::multilocus_t& pop) -> py::object {
                 auto pb = py::bytes(pop.serialize());
@@ -794,6 +804,11 @@ PYBIND11_MODULE(fwdpy11_types, m)
                         PyErr_Clear();
                     }
                 auto t = pickled.cast<py::tuple>();
+                if (t.size() != 4)
+                    {
+                        throw std::runtime_error(
+                            "expected tuple with 4 elements");
+                    }
                 auto s = t[0].cast<py::bytes>();
                 auto l = t[1].cast<py::list>();
                 auto rv = std::unique_ptr<fwdpy11::multilocus_t>(
@@ -802,6 +817,8 @@ PYBIND11_MODULE(fwdpy11_types, m)
                     {
                         rv->diploids[i][0].parental_data = l[i];
                     }
+                rv->popdata = t[2];
+                rv->popdata_user = t[3];
                 return rv;
             }))
         .def("__eq__",
@@ -964,6 +981,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def_readonly("fixation_times",
                       &fwdpy11::singlepop_gm_vec_t::fixation_times,
                       FIXATION_TIMES_DOCSTRING)
+        .def_readonly("popdata", &fwdpy11::singlepop_gm_vec_t::popdata,
+                      "A Python object that may be written to by a "
+                      "simulation. Any data written should be documented by "
+                      "the simulation function.")
+        .def_readwrite("popdata_user", &fwdpy11::singlepop_gm_vec_t::popdata_user,
+                       "A Python object with read-write access.")
         .def(py::pickle(
             [](const fwdpy11::singlepop_gm_vec_t& pop) {
                 return py::bytes(pop.serialize());

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -128,6 +128,14 @@ namespace
         To distinguish them, use the locations of nonzero values in "mcounts" 
         for an instance of this type."
     )delim";
+
+    static const auto POPDATA_DOCSTRING
+        = "Python object that may be written to by a simulation. Any data "
+          "written should be documented by the simulation function.\n\n.. "
+          "versionadded:: 0.1.4";
+
+    static const auto POPDATA_USER_DOCSTRING
+        = "A Python object with read-write access.\n\n.. versionadded:: 0.1.4";
 }
 
 PYBIND11_MODULE(fwdpy11_types, m)
@@ -580,11 +588,9 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def_readonly("gametes", &fwdpp_popgenmut_base::gametes,
                       GAMETES_DOCSTRING)
         .def_readonly("popdata", &fwdpy11::singlepop_t::popdata,
-                      "A Python object that may be written to by a "
-                      "simulation. Any data written should be documented by "
-                      "the simulation function.")
+                      POPDATA_DOCSTRING)
         .def_readwrite("popdata_user", &fwdpy11::singlepop_t::popdata_user,
-                       "A Python object with read-write access.")
+                       POPDATA_USER_DOCSTRING)
         .def(py::pickle(
             [](const fwdpy11::singlepop_t& pop) -> py::object {
                 auto pb = py::bytes(pop.serialize());
@@ -777,11 +783,9 @@ PYBIND11_MODULE(fwdpy11_types, m)
                        &fwdpy11::multilocus_t::locus_boundaries,
                        "[beg,end) positions for each locus")
         .def_readonly("popdata", &fwdpy11::multilocus_t::popdata,
-                      "A Python object that may be written to by a "
-                      "simulation. Any data written should be documented by "
-                      "the simulation function.")
+                      POPDATA_DOCSTRING)
         .def_readwrite("popdata_user", &fwdpy11::multilocus_t::popdata_user,
-                       "A Python object with read-write access.")
+                       POPDATA_USER_DOCSTRING)
         .def(py::pickle(
             [](const fwdpy11::multilocus_t& pop) -> py::object {
                 auto pb = py::bytes(pop.serialize());
@@ -982,13 +986,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                       &fwdpy11::singlepop_gm_vec_t::fixation_times,
                       FIXATION_TIMES_DOCSTRING)
         .def_readonly("popdata", &fwdpy11::singlepop_gm_vec_t::popdata,
-                      "A Python object that may be written to by a "
-                      "simulation. Any data written should be documented by "
-                      "the simulation function.")
+                      POPDATA_DOCSTRING)
         .def_readwrite("popdata_user",
                        &fwdpy11::singlepop_gm_vec_t::popdata_user,
-                       "A Python object with read-write access.")
-
+                       POPDATA_USER_DOCSTRING)
         .def(py::pickle(
 
             [](const fwdpy11::singlepop_gm_vec_t& pop) -> py::object {

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -1011,16 +1011,6 @@ PYBIND11_MODULE(fwdpy11_types, m)
                                       pop.popdata, pop.popdata_user);
             },
             [](py::object pickled) {
-                try
-                    {
-                        auto s = pickled.cast<py::bytes>();
-                        return std::unique_ptr<fwdpy11::singlepop_gm_vec_t>(
-                            new fwdpy11::singlepop_gm_vec_t(s));
-                    }
-                catch (std::runtime_error& eas)
-                    {
-                        PyErr_Clear();
-                    }
                 auto t = pickled.cast<py::tuple>();
                 if (t.size() != 4)
                     {


### PR DESCRIPTION
This PR adds Python types to the population objects.  One is read-only, and reserved for modification on the C++ side.  The other is read-write.