### PR TITLE
Fix multilocus sampling

### DIFF
--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -291,12 +291,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                          remove_fixed);
-                         auto t = py::make_tuple(s.first, s.second);
-                         return t;
+                         return py::make_tuple(s.first, s.second);
                      }
-                 py::list rv;
-                 auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                 rv = py::cast(s);
+                 py::list rv = py::cast(
+                     KTfwd::sample(rng.get(), pop, nsam, remove_fixed));
                  return rv;
              },
              py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -331,12 +329,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(pop, individuals,
                                                          remove_fixed);
-                         auto t = py::make_tuple(s.first, s.second);
-                         return t;
+                         return py::make_tuple(s.first, s.second);
                      }
-                 py::list rv;
-                 auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 rv = py::cast(s);
+                 py::list rv
+                     = py::cast(KTfwd::sample(pop, individuals, remove_fixed));
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,
@@ -481,13 +477,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
                  py::list rv;
                  if (separate)
                      {
-                         auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
-                                                         remove_fixed);
-                         rv = py::cast(s);
+                         rv = py::cast(KTfwd::sample_separate(
+                             rng.get(), pop, nsam, remove_fixed));
                          return rv;
                      }
-                 auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                 rv = py::cast(s);
+                 rv = py::cast(
+                     KTfwd::sample(rng.get(), pop, nsam, remove_fixed));
                  return rv;
              },
              py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -521,13 +516,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                  py::list rv;
                  if (separate)
                      {
-                         auto s = KTfwd::sample_separate(pop, individuals,
-                                                         remove_fixed);
-                         rv = py::cast(s);
-                         return rv;
+                         rv = py::cast(KTfwd::sample_separate(pop, individuals,
+                                                              remove_fixed));
                      }
-                 auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 rv = py::cast(s);
+                 rv = py::cast(KTfwd::sample(pop, individuals, remove_fixed));
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,
@@ -669,12 +661,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                          remove_fixed);
-                         auto t = py::make_tuple(s.first, s.second);
-                         return t;
+                         return py::make_tuple(s.first, s.second);
                      }
-                 py::list rv;
-                 auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                 rv = py::cast(s);
+                 py::list rv = py::cast(
+                     KTfwd::sample(rng.get(), pop, nsam, remove_fixed));
                  return rv;
              },
              py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -709,13 +699,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(pop, individuals,
                                                          remove_fixed);
-                         auto t = py::make_tuple(s.first, s.second);
-                         return t;
+                         return py::make_tuple(s.first, s.second);
                      }
-                 py::list rv;
-                 auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 rv = py::cast(s);
-                 return rv;
+                 py::list rv
+                     = py::cast(KTfwd::sample(pop, individuals, remove_fixed));
              },
              py::arg("individuals"), py::arg("separate") = true,
              py::arg("remove_fixed") = true,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -297,10 +297,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      }
                  py::list rv;
                  auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                 for (auto& i : s)
-                     {
-                         rv.append(i);
-                     }
+                 rv = py::cast(s);
                  return rv;
              },
              py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -481,29 +478,21 @@ PYBIND11_MODULE(fwdpy11_types, m)
             "sample",
             [](const fwdpy11::multilocus_t& pop, const fwdpy11::GSLrng_t& rng,
                const std::int64_t nsam, const bool separate,
-               const bool remove_fixed) -> py::object {
+               const bool remove_fixed) -> py::list {
                 if (nsam <= 0)
                     {
                         throw std::invalid_argument("sample size must be > 0");
                     }
+                py::list rv;
                 if (separate)
                     {
                         auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                         remove_fixed);
-                        py::list rv;
-                        for (auto& i : s)
-                            {
-                                rv.append(py::make_tuple(std::move(i.first),
-                                                         std::move(i.second)));
-                            }
+                        rv = py::cast(s);
                         return rv;
                     }
-                py::list rv;
                 auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                for (auto& i : s)
-                    {
-                        rv.append(i);
-                    }
+                rv = py::cast(s);
                 return rv;
             },
             py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -533,25 +522,17 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def("sample_ind",
              [](const fwdpy11::multilocus_t& pop,
                 const std::vector<std::size_t>& individuals,
-                const bool separate, const bool remove_fixed) -> py::object {
+                const bool separate, const bool remove_fixed) -> py::list {
+                 py::list rv;
                  if (separate)
                      {
                          auto s = KTfwd::sample_separate(pop, individuals,
                                                          remove_fixed);
-                         py::list rv;
-                         for (auto& i : s)
-                             {
-                                 rv.append(py::make_tuple(
-                                     std::move(i.first), std::move(i.second)));
-                                 return rv;
-                             }
+                         rv = py::cast(s);
+                         return rv;
                      }
-                 py::list rv;
                  auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 for (auto& i : s)
-                     {
-                         rv.append(i);
-                     }
+                 rv = py::cast(s);
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -291,8 +291,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                          remove_fixed);
-                         auto t = py::make_tuple(s.first,
-                                                 s.second);
+                         auto t = py::make_tuple(s.first, s.second);
                          return t;
                      }
                  py::list rv;
@@ -332,16 +331,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(pop, individuals,
                                                          remove_fixed);
-                         auto t = py::make_tuple(std::move(s.first),
-                                                 std::move(s.second));
+                         auto t = py::make_tuple(s.first, s.second);
                          return t;
                      }
                  py::list rv;
                  auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 for (auto& i : s)
-                     {
-                         rv.append(i);
-                     }
+                 s = py::cast(s);
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,
@@ -474,30 +469,30 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def("__eq__",
              [](const fwdpy11::multilocus_t& lhs,
                 const fwdpy11::multilocus_t& rhs) { return lhs == rhs; })
-        .def(
-            "sample",
-            [](const fwdpy11::multilocus_t& pop, const fwdpy11::GSLrng_t& rng,
-               const std::int64_t nsam, const bool separate,
-               const bool remove_fixed) -> py::list {
-                if (nsam <= 0)
-                    {
-                        throw std::invalid_argument("sample size must be > 0");
-                    }
-                py::list rv;
-                if (separate)
-                    {
-                        auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
-                                                        remove_fixed);
-                        rv = py::cast(s);
-                        return rv;
-                    }
-                auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                rv = py::cast(s);
-                return rv;
-            },
-            py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
-            py::arg("remove_fixed") = true,
-            R"delim(
+        .def("sample",
+             [](const fwdpy11::multilocus_t& pop, const fwdpy11::GSLrng_t& rng,
+                const std::int64_t nsam, const bool separate,
+                const bool remove_fixed) -> py::list {
+                 if (nsam <= 0)
+                     {
+                         throw std::invalid_argument(
+                             "sample size must be > 0");
+                     }
+                 py::list rv;
+                 if (separate)
+                     {
+                         auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
+                                                         remove_fixed);
+                         rv = py::cast(s);
+                         return rv;
+                     }
+                 auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
+                 rv = py::cast(s);
+                 return rv;
+             },
+             py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
+             py::arg("remove_fixed") = true,
+             R"delim(
              Sample random diploids *with replacement*.
              
              :param rng: A :class:`fwdpy11.fwdpy11_types.GSLrng`
@@ -674,8 +669,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                          remove_fixed);
-                         auto t = py::make_tuple(std::move(s.first),
-                                                 std::move(s.second));
+                         auto t = py::make_tuple(s.first, s.second);
                          return t;
                      }
                  py::list rv;
@@ -718,8 +712,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(pop, individuals,
                                                          remove_fixed);
-                         auto t = py::make_tuple(std::move(s.first),
-                                                 std::move(s.second));
+                         auto t = py::make_tuple(s.first, s.second);
                          return t;
                      }
                  py::list rv;

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -336,7 +336,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      }
                  py::list rv;
                  auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 s = py::cast(s);
+                 rv = py::cast(s);
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,
@@ -674,10 +674,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      }
                  py::list rv;
                  auto s = KTfwd::sample(rng.get(), pop, nsam, remove_fixed);
-                 for (auto& i : s)
-                     {
-                         rv.append(i);
-                     }
+                 rv = py::cast(s);
                  return rv;
              },
              py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
@@ -717,10 +714,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      }
                  py::list rv;
                  auto s = KTfwd::sample(pop, individuals, remove_fixed);
-                 for (auto& i : s)
-                     {
-                         rv.append(i);
-                     }
+                 rv = py::cast(s);
                  return rv;
              },
              py::arg("individuals"), py::arg("separate") = true,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -291,8 +291,8 @@ PYBIND11_MODULE(fwdpy11_types, m)
                      {
                          auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
                                                          remove_fixed);
-                         auto t = py::make_tuple(std::move(s.first),
-                                                 std::move(s.second));
+                         auto t = py::make_tuple(s.first,
+                                                 s.second);
                          return t;
                      }
                  py::list rv;
@@ -547,13 +547,16 @@ PYBIND11_MODULE(fwdpy11_types, m)
 
              The final sample size is ``2*len(individuals)``.
 
-             The output is a list of tuples.  Each tuple is (pair, state), where state is 
+             The output is a list of tuples.  When separate is False,
+             Each tuple is (pair, state), where state is 
              a string encoded as 0 = ancestral and 1 = derived.   Adjacent characters
              in each string are diploid genotypes.  The order of diploids is constant
              across variable sites.
 
-             When ``separate`` is ``True``, the function returns a tuple of two lists.
-             The first list is for neutral variants, and the second for non-neutral.
+             When ``separate`` is ``True``, the function returns a list of tuples.
+             Each tuple is of length two, with the first element being a list of tuples
+             for neutral variants following the layout described above.  The second
+             element is for selected variants.
 
 			 .. versionadded:: 0.1.4
              )delim");

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -62,18 +62,24 @@ class testMlocusPopExceptions(unittest.TestCase):
 
 class testSampling(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
         from quick_pops import quick_mlocus_qtrait
         self.pop = quick_mlocus_qtrait()
         self.rng = fp11.GSLrng(42)
 
     def testRandomSample(self):
-        self.pop.sample(self.rng, 10)
-        self.pop.sample(self.rng, 10, separate=False)
-        self.pop.sample(self.rng, 10, remove_fixed=False)
-        self.pop.sample(self.rng, 10, separate=True, remove_fixed=False)
-        self.pop.sample(self.rng, 10, separate=False, remove_fixed=False)
-        self.pop.sample(self.rng, 10, separate=True, remove_fixed=True)
+        x = self.pop.sample(self.rng, 10)
+        self.assertEqual(len(x), self.pop.nloci)
+        x = self.pop.sample(self.rng, 10, separate=False)
+        self.assertEqual(len(x), self.pop.nloci)
+        x = self.pop.sample(self.rng, 10, remove_fixed=False)
+        self.assertEqual(len(x), self.pop.nloci)
+        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=False)
+        self.assertEqual(len(x), self.pop.nloci)
+        x = self.pop.sample(self.rng, 10, separate=False, remove_fixed=False)
+        self.assertEqual(len(x), self.pop.nloci)
+        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=True)
+        self.assertEqual(len(x), self.pop.nloci)
 
         self.pop.locus_boundaries = []
 
@@ -81,8 +87,8 @@ class testSampling(unittest.TestCase):
             self.pop.sample(self.rng, 10, remove_fixed=False)
 
     def testDefinedSample(self):
-        self.pop.sample_ind(range(10))
-
+        x = self.pop.sample_ind(range(10))
+        self.assertEqual(len(x), self.pop.nloci)
         with self.assertRaises(IndexError):
             """
             fwdpp catches case where i >= N

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -76,6 +76,9 @@ class testSampling(unittest.TestCase):
         self.assertEqual(len(x), self.pop.nloci)
         x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=False)
         self.assertEqual(len(x), self.pop.nloci)
+        for i in x:
+            self.assertTrue(isinstance(i, tuple))
+            self.assertEqual(len(i), 2)
         x = self.pop.sample(self.rng, 10, separate=False, remove_fixed=False)
         self.assertEqual(len(x), self.pop.nloci)
         x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=True)


### PR DESCRIPTION
This PR fixes a bug introduced in #43.  The bug resulted in incorrect samples for multi-locus populations.

Additional changes involve code and documentation cleanups.