### PR TITLE
Refine sampling

### DIFF
--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -315,9 +315,12 @@ PYBIND11_MODULE(fwdpy11_types, m)
                              = KTfwd::sample_separate(pop, ind, remove_fixed);
                          rv = py::make_tuple(temp.first, temp.second);
                      }
-                 auto temp = KTfwd::sample(pop, ind, remove_fixed);
-                 py::list tlist = py::cast(temp);
-                 rv = tlist;
+                 else
+                     {
+                         auto temp = KTfwd::sample(pop, ind, remove_fixed);
+                         py::list tlist = py::cast(temp);
+                         rv = tlist;
+                     }
                  return rv;
              },
              py::arg("separate") = true, py::arg("remove_fixed") = true,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -464,86 +464,59 @@ PYBIND11_MODULE(fwdpy11_types, m)
              [](const fwdpy11::multilocus_t& lhs,
                 const fwdpy11::multilocus_t& rhs) { return lhs == rhs; })
         .def("sample",
-             [](const fwdpy11::multilocus_t& pop, const fwdpy11::GSLrng_t& rng,
-                const std::int64_t nsam, const bool separate,
-                const bool remove_fixed) -> py::list {
-                 if (nsam <= 0)
-                     {
-                         throw std::invalid_argument(
-                             "sample size must be > 0");
-                     }
+             [](const fwdpy11::multilocus_t& pop, const bool separate,
+                const bool remove_fixed, py::kwargs kwargs) -> py::list {
                  py::list rv;
+
+                 std::vector<std::size_t> ind = get_individuals(pop.N, kwargs);
+
                  if (separate)
                      {
-                         rv = py::cast(KTfwd::sample_separate(
-                             rng.get(), pop, nsam, remove_fixed));
-                         return rv;
+                         auto temp
+                             = KTfwd::sample_separate(pop, ind, remove_fixed);
+                         rv = py::cast(temp);
                      }
-                 rv = py::cast(
-                     KTfwd::sample(rng.get(), pop, nsam, remove_fixed));
-                 return rv;
-             },
-             py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
-             py::arg("remove_fixed") = true,
-             R"delim(
-             Sample random diploids *with replacement*.
-             
-             :param rng: A :class:`fwdpy11.GSLrng`
-             :param nsam: An integer representing the sample size in chromosomes (2 times number of diploids).
-             :param separate: (True) Separate neutral from non-neutral variants in output.
-             :param remove_fixed: (True) Remove sites fixed in the sample from the return value.
-
-             The output is a list of tuples.  Each tuple is (pair, state), where state is 
-             a string encoded as 0 = ancestral and 1 = derived.   Adjacent characters
-             in each string are diploid genotypes.  The order of diploids is constant
-             across variable sites.
-
-             When ``separate`` is ``True``, the function returns a tuple of two lists.
-             The first list is for neutral variants, and the second for non-neutral.
-
-             .. note::
-                If you want sampling *without* replacement, see
-                :func:`~fwdpy11.MlocusPop.sample_ind`.
-
-			 .. versionadded:: 0.1.4
-             )delim")
-        .def("sample_ind",
-             [](const fwdpy11::multilocus_t& pop,
-                const std::vector<std::size_t>& individuals,
-                const bool separate, const bool remove_fixed) -> py::list {
-                 py::list rv;
-                 if (separate)
+                 else
                      {
-                         rv = py::cast(KTfwd::sample_separate(pop, individuals,
-                                                              remove_fixed));
+                         auto temp = KTfwd::sample(pop, ind, remove_fixed);
+                         rv = py::cast(temp);
                      }
-                 rv = py::cast(KTfwd::sample(pop, individuals, remove_fixed));
                  return rv;
              },
-             py::arg("individuals"), py::arg("separate") = true,
-             py::arg("remove_fixed") = true,
              R"delim(
-             Sample specific diploids.
+            Sample diploids from the population.
+
+             :param separate: (True) Return neutral and selected variants separately.
+             :param remove_fixed: (True) Remove variants fixed in the sample.
+             :param kwargs: See below.
+
+             :rtype: list
+
+             :returns: Haplotype information for a sample.
+
+             The valid kwargs are:
+
+             * individuals, which should be a list of non-negative integers
+             * rng, which should be a :class:`fwdpy11.GSLrng`
+             * nsam, which should be a positive integer
              
-             :param individuals: The individuals to sample.
-             :param separate: (True) Separate neutral from non-neutral variants in output.
-             :param remove_fixed: (True) Remove sites fixed in the sample from the return value.
+             The latter two kwargs must be used together, and will generate a sample of
+             ``nsam`` individuals taken *with replacement* from the population. 
 
-             The final sample size is ``2*len(individuals)``.
+             The return value is structured around a list of tuples.  Each tuple
+             is (position, genotype), where genotype are encoded as 0/1 = ancestral/derived.
+             From index 0 to 2*nsam - 1 (or 2*len(individuals) -1), adjacent pairs of 
+             values represent diploid genotype data.  Across sites, the data represent
+             individual haplotypes.
 
-             The output is a list of tuples.  When separate is False,
-             Each tuple is (pair, state), where state is 
-             a string encoded as 0 = ancestral and 1 = derived.   Adjacent characters
-             in each string are diploid genotypes.  The order of diploids is constant
-             across variable sites.
-
-             When ``separate`` is ``True``, the function returns a list of tuples.
-             Each tuple is of length two, with the first element being a list of tuples
-             for neutral variants following the layout described above.  The second
-             element is for selected variants.
+             When `separate` is `True`, a list of tuples is returned.  The length of this
+             list equals the number of loci, and each tuple has two elements. The first
+             element is a list genotypes at neutral variants, following the format described
+             above.   The second element is for non-neutral variants.
 
 			 .. versionadded:: 0.1.4
-             )delim");
+             )delim",
+        py::arg("separate")=true,py::arg("remove_fixed")=true);
 
     py::class_<fwdpy11::singlepop_gm_vec_t,
                singlepop_generalmut_vec_sugar_base>(m,

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -615,80 +615,56 @@ PYBIND11_MODULE(fwdpy11_types, m)
              [](const fwdpy11::singlepop_gm_vec_t& lhs,
                 const fwdpy11::singlepop_gm_vec_t& rhs) { return lhs == rhs; })
         .def("sample",
-             [](const fwdpy11::singlepop_gm_vec_t& pop,
-                const fwdpy11::GSLrng_t& rng, const std::int64_t nsam,
-                const bool separate, const bool remove_fixed) -> py::object {
-                 if (nsam <= 0)
-                     {
-                         throw std::invalid_argument(
-                             "sample size must be > 0");
-                     }
+             [](const fwdpy11::singlepop_gm_vec_t& pop, const bool separate,
+                const bool remove_fixed, py::kwargs kwargs) -> py::object {
+                 py::object rv;
+
+                 std::vector<std::size_t> ind = get_individuals(pop.N, kwargs);
+
                  if (separate)
                      {
-                         auto s = KTfwd::sample_separate(rng.get(), pop, nsam,
-                                                         remove_fixed);
-                         return py::make_tuple(s.first, s.second);
+                         auto temp
+                             = KTfwd::sample_separate(pop, ind, remove_fixed);
+                         rv = py::make_tuple(temp.first, temp.second);
                      }
-                 py::list rv = py::cast(
-                     KTfwd::sample(rng.get(), pop, nsam, remove_fixed));
-                 return rv;
-             },
-             py::arg("rng"), py::arg("nsam"), py::arg("separate") = true,
-             py::arg("remove_fixed") = true,
-             R"delim(
-             Sample random diploids *with replacement*.
-             
-             :param rng: A :class:`fwdpy11.GSLrng`
-             :param nsam: An integer representing the sample size in chromosomes (2 times number of diploids).
-             :param separate: (True) Separate neutral from non-neutral variants in output.
-             :param remove_fixed: (True) Remove sites fixed in the sample from the return value.
-
-             The output is a list of tuples.  Each tuple is (pair, state), where state is 
-             a string encoded as 0 = ancestral and 1 = derived.   Adjacent characters
-             in each string are diploid genotypes.  The order of diploids is constant
-             across variable sites.
-
-             When ``separate`` is ``True``, the function returns a tuple of two lists.
-             The first list is for neutral variants, and the second for non-neutral.
-
-             .. note::
-                If you want sampling *without* replacement, see
-                :func:`~fwdpy11.SlocusPopGeneralMutVec.sample_ind`.
-
-			 .. versionadded:: 0.1.4
-             )delim")
-        .def("sample_ind",
-             [](const fwdpy11::singlepop_gm_vec_t& pop,
-                const std::vector<std::size_t>& individuals,
-                const bool separate, const bool remove_fixed) -> py::object {
-                 if (separate)
+                 else
                      {
-                         auto s = KTfwd::sample_separate(pop, individuals,
-                                                         remove_fixed);
-                         return py::make_tuple(s.first, s.second);
+                         auto temp = KTfwd::sample(pop, ind, remove_fixed);
+                         py::list tlist = py::cast(temp);
+                         rv = tlist;
                      }
-                 py::list rv
-                     = py::cast(KTfwd::sample(pop, individuals, remove_fixed));
                  return rv;
              },
-             py::arg("individuals"), py::arg("separate") = true,
-             py::arg("remove_fixed") = true,
+             py::arg("separate") = true, py::arg("remove_fixed") = true,
              R"delim(
-             Sample specific diploids.
+             Sample diploids from the population.
+
+             :param separate: (True) Return neutral and selected variants separately.
+             :param remove_fixed: (True) Remove variants fixed in the sample.
+             :param kwargs: See below.
+
+             :rtype: object
+
+             :returns: Haplotype information for a sample.
+
+             The valid kwargs are:
+
+             * individuals, which should be a list of non-negative integers
+             * rng, which should be a :class:`fwdpy11.GSLrng`
+             * nsam, which should be a positive integer
              
-             :param individuals: The individuals to sample.
-             :param separate: (True) Separate neutral from non-neutral variants in output.
-             :param remove_fixed: (True) Remove sites fixed in the sample from the return value.
+             The latter two kwargs must be used together, and will generate a sample of
+             ``nsam`` individuals taken *with replacement* from the population. 
 
-             The final sample size is ``2*len(individuals)``.
+             The return value is structured around a list of tuples.  Each tuple
+             is (position, genotype), where genotype are encoded as 0/1 = ancestral/derived.
+             From index 0 to 2*nsam - 1 (or 2*len(individuals) -1), adjacent pairs of 
+             values represent diploid genotype data.  Across sites, the data represent
+             individual haplotypes.
 
-             The output is a list of tuples.  Each tuple is (pair, state), where state is 
-             a string encoded as 0 = ancestral and 1 = derived.   Adjacent characters
-             in each string are diploid genotypes.  The order of diploids is constant
-             across variable sites.
-
-             When ``separate`` is ``True``, the function returns a tuple of two lists.
-             The first list is for neutral variants, and the second for non-neutral.
+             When `separate` is `True`, a tuple of two such lists is returned.  The first
+             list is for genotypes at neutral variants.  The second list is for non-neutral
+             variants.
 
 			 .. versionadded:: 0.1.4
              )delim");

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -68,42 +68,45 @@ class testSampling(unittest.TestCase):
         self.rng = fp11.GSLrng(42)
 
     def testRandomSample(self):
-        x = self.pop.sample(self.rng, 10)
+        x = self.pop.sample(rng=self.rng, nsam=10)
         self.assertEqual(len(x), self.pop.nloci)
-        x = self.pop.sample(self.rng, 10, separate=False)
+        x = self.pop.sample(rng=self.rng, nsam=10, separate=False)
         self.assertEqual(len(x), self.pop.nloci)
-        x = self.pop.sample(self.rng, 10, remove_fixed=False)
+        x = self.pop.sample(rng=self.rng, nsam=10, remove_fixed=False)
         self.assertEqual(len(x), self.pop.nloci)
-        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=False)
+        x = self.pop.sample(rng=self.rng, nsam=10,
+                            separate=True, remove_fixed=False)
         self.assertEqual(len(x), self.pop.nloci)
         for i in x:
             self.assertTrue(isinstance(i, tuple))
             self.assertEqual(len(i), 2)
-        x = self.pop.sample(self.rng, 10, separate=False, remove_fixed=False)
+        x = self.pop.sample(rng=self.rng, nsam=10,
+                            separate=False, remove_fixed=False)
         self.assertEqual(len(x), self.pop.nloci)
-        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=True)
+        x = self.pop.sample(rng=self.rng, nsam=10,
+                            separate=True, remove_fixed=True)
         self.assertEqual(len(x), self.pop.nloci)
 
         self.pop.locus_boundaries = []
 
         with self.assertRaises(RuntimeError):
-            self.pop.sample(self.rng, 10, remove_fixed=False)
+            self.pop.sample(rng=self.rng, nsam=10, remove_fixed=False)
 
     def testDefinedSample(self):
-        x = self.pop.sample_ind(range(10))
+        x = self.pop.sample(individuals = range(10))
         self.assertEqual(len(x), self.pop.nloci)
         with self.assertRaises(IndexError):
             """
             fwdpp catches case where i >= N
             """
-            self.pop.sample_ind(range(self.pop.N, self.pop.N + 10))
+            self.pop.sample(individuals = range(self.pop.N, self.pop.N + 10))
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(Exception):
             """
             pybind11 disallows conversion of negative
             numbers to a list of unsigned types.
             """
-            self.pop.sample_ind(range(-10, 10))
+            self.pop.sample(individuals = range(-10, 10))
 
 
 if __name__ == "__main__":

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -64,34 +64,31 @@ class testSampling(unittest.TestCase):
         self.rng = fp11.GSLrng(42)
 
     def testRandomSample(self):
-        x = self.pop.sample(self.rng, 10)
+        x = self.pop.sample(rng=self.rng, nsam=10)
         self.assertTrue(type(x) is tuple)
-        x = self.pop.sample(self.rng, 10, separate=False)
+        x = self.pop.sample(rng=self.rng, nsam=10, separate=False)
         self.assertTrue(type(x) is list)
-        x = self.pop.sample(self.rng, 10, remove_fixed=False)
+        x = self.pop.sample(rng=self.rng, nsam=10, remove_fixed=False)
         self.assertTrue(type(x) is tuple)
-        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=False)
-        self.assertTrue(type(x) is tuple)
-        x = self.pop.sample(self.rng, 10, separate=False, remove_fixed=False)
-        self.assertTrue(type(x) is list)
-        x = self.pop.sample(self.rng, 10, separate=True, remove_fixed=True)
+        x = self.pop.sample(rng=self.rng, nsam=10,
+                            separate=True, remove_fixed=False)
         self.assertTrue(type(x) is tuple)
 
     def testDefinedSample(self):
-        self.pop.sample_ind(range(10))
+        self.pop.sample(individuals=range(10))
 
         with self.assertRaises(IndexError):
             """
             fwdpp catches case where i >= N
             """
-            self.pop.sample_ind(range(self.pop.N, self.pop.N + 10))
+            self.pop.sample(individuals=range(self.pop.N, self.pop.N + 10))
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(Exception):
             """
             pybind11 disallows conversion of negative
             numbers to a list of unsigned types.
             """
-            self.pop.sample_ind(range(-10, 10))
+            self.pop.sample(individuals=range(-10, 10))
 
 
 class testPythonObjects(unittest.TestCase):


### PR DESCRIPTION
This PR refines #43 to use *kwargs and merge `sample` and `sample_ind` into a single function.