### PR TITLE
Improve docs for 0.1.4 release.

### DIFF
--- a/doc/examples/qtrait.rst
+++ b/doc/examples/qtrait.rst
@@ -1,6 +1,6 @@
 .. _qtraits1:
 
-Simulating quantitative traits, I.
+Simulating quantitative traits, I
 ==========================================
 
 Background reading:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,8 @@ Welcome to fwdpy11's documentation!
     pages/types
     pages/rng
     pages/regions
+    pages/geneticvalues
+    pages/fixations
     pages/model_params
     pages/recorders
 

--- a/doc/pages/changelog.rst
+++ b/doc/pages/changelog.rst
@@ -30,7 +30,7 @@ API changes/new features:
   been changed from functions to read-only properties. `PR #45 <https://github.com/molpopgen/fwdpy11/pull/45>`_
 * The 'label' field of :class:`fwdpy11.Region` (and :class:`fwdpy11.Sregion`) now populate the label
   field of a mutation. `PR #32 <https://github.com/molpopgen/fwdpy11/pull/32>`_ See tests/test_mutation_labels.py for an example.
-* Population objects may now be constructed programatically.   `PR #36 <https://github.com/molpopgen/fwdpy11/pull/36>`_
+* Population objects may now be constructed programatically. See :ref:`popobjects`.   `PR #36 <https://github.com/molpopgen/fwdpy11/pull/36>`_ 
 
 Back-end changes
 ------------------------

--- a/doc/pages/definitions.rst
+++ b/doc/pages/definitions.rst
@@ -42,6 +42,8 @@ Evolving a multi-locus system in a single deme means evolving a :class:`fwdpy11.
 :ref:`mlocuspop` for details.
 
 
+.. _simtypes:
+
 Simulation types
 -----------------------------------------------------------
 

--- a/doc/pages/definitions.rst
+++ b/doc/pages/definitions.rst
@@ -43,6 +43,36 @@ Evolving a multi-locus system in a single deme means evolving a :class:`fwdpy11.
 
 .. _genetic_values:
 
+Simulation types
+-----------------------------------------------------------
+
+When it comes to the effect of mutations on fitness, we have two types:
+
+.. glossary::
+
+    direct
+
+        The mutation's effect size(s) affects fitness directly.  This is the :math:`s` of standard population
+        genetic models.
+
+    indirect
+
+        The mutation's effect size(s) affect one or more traits.  The trait vector/matrix of a diploid then
+        determines fitness.
+
+Thus, we have two types of simulation:
+
+.. glossary::
+
+    "Standard population genetic simulation"
+
+        A simulation where mutations directly affect fitness
+
+    "Quantitative genetic simulation"
+
+        A simulation where mutations affect trait (phenotype) values first, which in turn affects fitness.
+
+
 Genetic values, fitness, etc.
 -----------------------------------------------------------
 

--- a/doc/pages/definitions.rst
+++ b/doc/pages/definitions.rst
@@ -97,7 +97,7 @@ We apply the following definitions here:
 
 Consider the following two cases:
 
-First,  standard population genetic model of the sort that sfs_code_ or SLiM2_  are typically used for.  Mutations
+First,  standard population genetic models of the sort that sfs_code_ or SLiM2_  are typically used for.  Mutations
 affecting fitness interact multiplicatively.  Here, mutations directly affect fitness.  In our terms, :math:`G = w`.
 
 Next, we thing about a quantitative trait under Gaussian stabilizing selection with respect to an optimum.  Mutations

--- a/doc/pages/definitions.rst
+++ b/doc/pages/definitions.rst
@@ -41,7 +41,6 @@ details on this type.
 Evolving a multi-locus system in a single deme means evolving a :class:`fwdpy11.MlocusPop` object.  See
 :ref:`mlocuspop` for details.
 
-.. _genetic_values:
 
 Simulation types
 -----------------------------------------------------------
@@ -72,6 +71,8 @@ Thus, we have two types of simulation:
 
         A simulation where mutations affect trait (phenotype) values first, which in turn affects fitness.
 
+
+.. _genetic_values:
 
 Genetic values, fitness, etc.
 -----------------------------------------------------------

--- a/doc/pages/fixations.rst
+++ b/doc/pages/fixations.rst
@@ -3,3 +3,82 @@
 Handling fixations during a simulation
 ===========================================================================================
 
+Background reading:
+
+* :ref:`data_types`
+* :ref:`simtypes`
+* :ref:`genetic_values`
+* :ref:`genetic_values_types`
+
+This section discusses how fixations (mutations at a relative frequency of 1) are treated during simulations.  This
+section is simple, and it also matters quite a bit!  The gist of this section is that we currently have a tradeoff between modeling the biology
+and the efficiency of a simulation.
+
+The biology is as follows:
+
+* For standard population genetic simulations, relative fitness matters, and relative fitness is constant *up to a
+  multiplicative constant*
+* For simulations of traits, the absolute distance of a trait value from the optimum determines fitness.
+
+The software engineering issue is:
+
+* The model parameters objects have a *prune_selected* field, which is a boolean.  When `True`, mutations affecting
+  fitness are recorded in a populations `fixations` field, along with their fixation time.  Further, "keys" to these
+  mutations are removed from every gamete in the population.  This removal means that *selected mutations are no longer
+  involved in genetic value calculations*. See :ref:`model_params` to point you to the docs on parameterizing
+  simulations.
+
+The "pruning" of fixations always results in faster simulations (assuming that you are simulating selected mutations).
+Whether or not it is the right thing to do depends on the modeling scenario.  
+
+Here ar examples of doing the wrong thing:
+
+1. You are simulating additive effects on fitness, using :class:`fwdpy11.fitness.SlocusAdditive`.  If you prune
+   fixations, you will be removing an *additive constant* from every diploid, meaning that relative fitnesses are
+   affected.  We can illustrate this as follows, using a simple numerical example:
+
+.. ipython:: python
+
+    import numpy as np
+
+    np.random.seed(42)
+    # Pretend that these are the genetic values of 
+    # ten diploids, only considering segregating variation:
+    genetic_values = np.random.random_sample(10)
+    # Pretend that this is the sum of effect sizes of fixations:
+    fixed_effects = 0.1
+
+    # Relative fitness, ignoring fixations:
+    rw = genetic_values/np.sum(genetic_values)
+
+    # Relative fitness, with fixations included
+    rwf = (genetic_values+fixed_effects)/(np.sum(genetic_values+fixed_effects))
+    
+    # The values are different
+    print(any(rw == rwf) is True)
+
+    # But the rank orders are the same:
+    rw_rank = np.argsort(rw)
+    rwf_rank = np.argsort(rw)
+    print(all(rw_rank == rwf_rank) is True)
+
+2. You are simulating a trait under Gaussian stabilizing selection with respect to an optimum.  As mutations with effect
+   sizes in the direction of the optimum increase in frequency, genotypes with those mutations increase in fitness.  If
+   you prune selected fixations, each time a fixation occurs, the distance of every individual to the optimum is
+   affected, and thus relative fitnesses may be affected.
+
+General advice:
+
+1. Prefer multiplicative fitness for regular pop-gen simulations.  Prune selected fixations in this case.
+2. Do not prune selected fixations when simulating quantitative traits.
+
+.. note::
+
+    Neutral fixations are always recorded and removed from gametes.  This removal is for efficiency, so
+    that we don't have to recombine fixed variants between gametes which, by definition, both have the fixed variants.
+
+The future
+-----------------------------------------------------
+
+In the future, we hope to unify how fixations are handled.  Doing so will probably depend upon upstream changes in
+fwdpp.

--- a/doc/pages/fixations.rst
+++ b/doc/pages/fixations.rst
@@ -1,0 +1,5 @@
+.. _handling_fixations:
+
+Handling fixations during a simulation
+===========================================================================================
+

--- a/doc/pages/geneticvalues.rst
+++ b/doc/pages/geneticvalues.rst
@@ -1,0 +1,97 @@
+.. _genetic_values_types:
+
+Objects for calculation of genetic values
+====================================================================================
+
+Background reading:
+
+* :ref:`genetic_values`
+
+For the calculation of *fitness* in a single-region simulation, the following objects are available:
+
+* :class:`fwdpy11.fitness.SlocusAdditive`
+* :class:`fwdpy11.fitness.SlocusMult`
+
+These two classes take a **scaling** parameter as a constructor argument:
+
+.. ipython:: python
+
+    import fwdpy11.fitness
+
+    # For a single mutation, fitness is
+    # 1, 1+sh, 1+s
+    a1 = fwdpy11.fitness.SlocusAdditive(1.0)
+
+    # For a single mutation, fitness is
+    # 1, 1+sh, 1+2*s
+    a2 = fwdpy11.fitness.SlocusAdditive(2.0)
+
+For the calculation of *genetic values* in a single-region simulation, the following objects are available:
+
+* :class:`fwdpy11.trait_values.SlocusAdditiveTrait`
+* :class:`fwdpy11.trait_values.SlocusMultTrait`
+* :class:`fwdpy11.trait_values.SlocusGBRTrait`
+
+The first two objects also take **scaling** parameters as constructor arguments.  The third class is only valid for
+distributions of effects sizes returning non-negative values.
+
+For multi-region simulations, calculations are run through instances of
+:class:`fwdpy11.multilocus.MultiLocusGeneticValue`.  Instances of this object hold lists of single-region objects:
+
+.. ipython:: python
+
+    import fwdpy11.trait_values
+    import fwdpy11.multilocus
+
+    # Genetic value calculator for a quantitative trait simulation
+    # of ten regions under a "Turelli-like" additive model of 
+    # genotype -> phenotype:
+    am = fwdpy11.multilocus.MultiLocusGeneticValue([fwdpy11.trait_values.SlocusAdditiveTrait(2.0)]*10)
+
+During a simulation, each function stored is applied to each region.  The result is a list of floating-point values,
+which are the genetic values due to each locus.  These have to be *aggregated* into a final genetic value for an
+individual.  An aggregator is any callable accepting a NumPy array and returning a single float.  We provide the
+following built-in aggregator types:
+
+* :class:`fwdpy11.multilocus.AggAddFitness`
+* :class:`fwdpy11.multilocus.AggMultFitness`
+* :class:`fwdpy11.multilocus.AggAddTrait`
+* :class:`fwdpy11.multilocus.AggMultTrait`
+
+The first two are for *fitness* calculations and the latter two for *genetic value* calculations (for quantitative trait
+simulations).
+
+You may provide your own aggregators, written either in C++ or in Python.
+
+.. note::
+
+    It is really important to match your aggregator types to your single-locus types.  Mixing a list of
+    :class:`fwdpy11.trait_values.SlocusAdditiveTrait` with :class:`fwdpy11.multilocus.AggAddFitness` for
+    an aggregator will give strange results, as you are mixing a zero-centered calculator with an aggregator centered on
+    one.
+
+The relationship to fixations
+--------------------------------------------------------------------
+
+For standard population-genetic simulations, relative fitness is what matters.  Relative fitnesses are unaffected by
+fixations under multiplicative models, but the same is not true under additive models.  Please note that multiplicative
+models are typically assumed, and thus you should use :class:`fwdpy11.fitness.SlocusMult` most of the time.  Doing so
+will simply make your life easier (and your simulations more efficient--keep reading...).
+
+For simulations of phenotypes where fitness is determined by comparing phenotype to some optimum value, fixations always
+affect the distance of an individual from this optimum.
+
+The reason to bring all this up is because fixations may be removed from gametes during simulation, depending on
+parameters that you input.  Pruning fixations results in faster simulations, because those sites are not considered in
+fitness calculations.  However, you should *not* prune them when simulating additive models of fitness or when
+simulating phenotypes.  See :ref:`handling_fixations` for more details.
+
+The future
+-----------------------------------------------------------
+
+We hope to:
+
+* Reduce the number of single locus types so that the trait-vs-fitness decision is a constructor argument.
+* Add a GBR type for fitness.
+* Reduce the complexity of the code underyling all this, which will hopefully enable the above.
+* Make all this stuff about fixations something that the user (you) doesn't have to worry about.

--- a/doc/pages/model_params.rst
+++ b/doc/pages/model_params.rst
@@ -1,6 +1,6 @@
 .. _model_params:
 
-Parameterizing a simulation.
+Parameterizing a simulation
 ======================================================================
 
 .. versionadded:: 0.1.1

--- a/doc/pages/popobjects.rst
+++ b/doc/pages/popobjects.rst
@@ -1,6 +1,6 @@
 .. _popobjects:
 
-Construction of population objects from a predetermined state.
+Construction of population objects from a predetermined state
 ============================================================================================================================================
 
 Background reading:

--- a/doc/performance/processingpops_np.rst
+++ b/doc/performance/processingpops_np.rst
@@ -142,6 +142,7 @@ You may get the mutations from the population into an array via:
 .. note::
     You may create a numpy array of the fixations list similarly.
 
+
 The mutation keys in gametes
 -------------------------------------------
 
@@ -248,6 +249,22 @@ Check that both routines give the same answer:
 
     check = esize_sum_py(pop)==esize_sum_np(pop)
     np.where(check == False)
+
+As of fwdpy11 0.1.4, you can use elements from a numpy array based on mutations to create new :class:`fwdpy11.Mutation`
+instances:
+
+.. ipython:: python
+
+    ma = np.array(pop.mutations.array())
+    # Conversion to tuple and exclusion of last field
+    # gives us a valid tuple for construction:
+    m = fwdpy11.Mutation(tuple(ma[0])[:-1])
+    print(m,pop.mutations[0])
+    print(m is pop.mutations[0])
+
+One possible use case for the above is to create a new population using data from an existing population. For more
+details on that topic, see :ref:`popobjects`
+
 
 The site-frequency spectrum
 -------------------------------------------


### PR DESCRIPTION
PR to clean up the documentation in anticipation of 0.1.4:

- [x] Document how a Mutation's numpy dtype can be used to build a new object instance
- [x] For changelog entries for this release, refer to doc pages wherever possible.
- [x] Add page on how genetic value scaling is modeled.
- [x] Add page on pruning of fixations in "pop-gen" vs "q-trait" scenarios.