### PR TITLE
deprecate all types based on fwdpp's generalmut_vec

### DIFF
--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -28,7 +28,7 @@ from .fwdpp_types import *
 from ._opaque_gametes import *
 from ._opaque_mutations import *
 from ._opaque_diploids import *
-from ._opaque_generalmutvecs import *
+# from ._opaque_generalmutvecs import *
 from .fwdpy11_types import SingleLocusDiploid
 from .fwdpy11_types import VecUint32
 from ._regions import *
@@ -36,5 +36,5 @@ from ._dev import *
 from ._gslrng import GSLrng
 from .SlocusPop import SlocusPop
 from .MlocusPop import MlocusPop
-from .SlocusPopGeneralMutVec import SlocusPopGeneralMutVec
+# from .SlocusPopGeneralMutVec import SlocusPopGeneralMutVec
 

--- a/fwdpy11/headers/fwdpy11/types.hpp
+++ b/fwdpy11/headers/fwdpy11/types.hpp
@@ -31,7 +31,7 @@
 #include "types/diploid.hpp"
 #include <fwdpy11/rng.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
-#include <fwdpp/sugar/generalmut.hpp>
+//#include <fwdpp/sugar/generalmut.hpp>
 #include <fwdpp/sugar/singlepop.hpp>
 #include <fwdpp/sugar/multiloc.hpp>
 #include <fwdpp/sugar/metapop.hpp>
@@ -388,109 +388,109 @@ namespace fwdpy11
     // Types based on KTfwd::generalmut_vec  //! Typedef for gamete type
 
     //! Typedef for gamete container
-    using gcont_gm_vec_t = std::vector<gamete_t>;
+    // using gcont_gm_vec_t = std::vector<gamete_t>;
 
-    struct singlepop_gm_vec_t
-        : public KTfwd::singlepop<KTfwd::generalmut_vec, diploid_t>
-    /*!
-      \brief Single-deme object where mutations contain vector<double> for
-    internal data.
-    ,
-      See fwdpy11::singlepop_t documentation for details, which are the
-    same as
-    for this type.
-    */
-    {
-        using base = KTfwd::singlepop<KTfwd::generalmut_vec, diploid_t>;
-        unsigned generation;
-        pybind11::object popdata;
-        //! A Python objeft that users may access during a simulation
-        pybind11::object popdata_user;
-        //! Constructor takes number of diploids as argument
-        explicit singlepop_gm_vec_t(const unsigned &N)
-            : base(N), generation(0), popdata{ pybind11::none() },
-              popdata_user{ pybind11::none() }
-        {
-            if (!N)
-                {
-                    throw std::invalid_argument("population size must be > 0");
-                }
-        }
+    // struct singlepop_gm_vec_t
+    //     : public KTfwd::singlepop<KTfwd::generalmut_vec, diploid_t>
+    // /*!
+    //   \brief Single-deme object where mutations contain vector<double> for
+    // internal data.
+    // ,
+    //   See fwdpy11::singlepop_t documentation for details, which are the
+    // same as
+    // for this type.
+    // */
+    // {
+    //     using base = KTfwd::singlepop<KTfwd::generalmut_vec, diploid_t>;
+    //     unsigned generation;
+    //     pybind11::object popdata;
+    //     //! A Python objeft that users may access during a simulation
+    //     pybind11::object popdata_user;
+    //     //! Constructor takes number of diploids as argument
+    //     explicit singlepop_gm_vec_t(const unsigned &N)
+    //         : base(N), generation(0), popdata{ pybind11::none() },
+    //           popdata_user{ pybind11::none() }
+    //     {
+    //         if (!N)
+    //             {
+    //                 throw std::invalid_argument("population size must be > 0");
+    //             }
+    //     }
 
-        // Perfect-forwarding constructor:
-        template <typename diploids_input, typename gametes_input,
-                  typename mutations_input>
-        explicit singlepop_gm_vec_t(diploids_input &&diploids,
-                                    gametes_input &&gametes,
-                                    mutations_input &&mutations)
-            : base(std::forward<diploids_input>(diploids),
-                   std::forward<gametes_input>(gametes),
-                   std::forward<mutations_input>(mutations)),
-              generation{ 0 }, popdata{ pybind11::none() },
-              popdata_user{ pybind11::none() }
-        {
-        }
+    //     // Perfect-forwarding constructor:
+    //     template <typename diploids_input, typename gametes_input,
+    //               typename mutations_input>
+    //     explicit singlepop_gm_vec_t(diploids_input &&diploids,
+    //                                 gametes_input &&gametes,
+    //                                 mutations_input &&mutations)
+    //         : base(std::forward<diploids_input>(diploids),
+    //                std::forward<gametes_input>(gametes),
+    //                std::forward<mutations_input>(mutations)),
+    //           generation{ 0 }, popdata{ pybind11::none() },
+    //           popdata_user{ pybind11::none() }
+    //     {
+    //     }
 
-        explicit singlepop_gm_vec_t(const std::string &s)
-            : base(0), popdata{ pybind11::none() },
-              popdata_user{ pybind11::none() }
-        {
-            this->deserialize(s);
-        }
+    //     explicit singlepop_gm_vec_t(const std::string &s)
+    //         : base(0), popdata{ pybind11::none() },
+    //           popdata_user{ pybind11::none() }
+    //     {
+    //         this->deserialize(s);
+    //     }
 
-        static singlepop_gm_vec_t
-        create(base::dipvector_t &diploids, base::gcont_t &gametes,
-               base::mcont_t &mutations)
-        {
-            return create_wrapper<singlepop_gm_vec_t>(
-                std::move(diploids), std::move(gametes), std::move(mutations));
-        }
+    //     static singlepop_gm_vec_t
+    //     create(base::dipvector_t &diploids, base::gcont_t &gametes,
+    //            base::mcont_t &mutations)
+    //     {
+    //         return create_wrapper<singlepop_gm_vec_t>(
+    //             std::move(diploids), std::move(gametes), std::move(mutations));
+    //     }
 
-        static singlepop_gm_vec_t
-        create_with_fixations(base::dipvector_t &diploids,
-                              base::gcont_t &gametes, base::mcont_t &mutations,
-                              base::mcont_t &fixations,
-                              std::vector<KTfwd::uint_t> &fixation_times,
-                              const KTfwd::uint_t generation)
-        {
-            return create_wrapper<singlepop_gm_vec_t>(
-                std::move(diploids), std::move(gametes), std::move(mutations),
-                fixations, fixation_times, generation);
-        }
-        std::string
-        serialize() const
-        {
-            return serialization::serialize_details(
-                this, KTfwd::mutation_writer(),
-                fwdpy11::diploid_writer<fwdpy11::serialization::magic()>());
-        }
+    //     static singlepop_gm_vec_t
+    //     create_with_fixations(base::dipvector_t &diploids,
+    //                           base::gcont_t &gametes, base::mcont_t &mutations,
+    //                           base::mcont_t &fixations,
+    //                           std::vector<KTfwd::uint_t> &fixation_times,
+    //                           const KTfwd::uint_t generation)
+    //     {
+    //         return create_wrapper<singlepop_gm_vec_t>(
+    //             std::move(diploids), std::move(gametes), std::move(mutations),
+    //             fixations, fixation_times, generation);
+    //     }
+    //     std::string
+    //     serialize() const
+    //     {
+    //         return serialization::serialize_details(
+    //             this, KTfwd::mutation_writer(),
+    //             fwdpy11::diploid_writer<fwdpy11::serialization::magic()>());
+    //     }
 
-        void
-        deserialize(const std::string &s)
-        {
-            *this = serialization::deserialize_details<singlepop_gm_vec_t>()(
-                s, KTfwd::mutation_reader<singlepop_gm_vec_t::mutation_t>(),
-                fwdpy11::diploid_reader(), 1u);
-        }
+    //     void
+    //     deserialize(const std::string &s)
+    //     {
+    //         *this = serialization::deserialize_details<singlepop_gm_vec_t>()(
+    //             s, KTfwd::mutation_reader<singlepop_gm_vec_t::mutation_t>(),
+    //             fwdpy11::diploid_reader(), 1u);
+    //     }
 
-        // int
-        // tofile(const char *filename, bool append = false) const
-        //{
-        //    return fwdpy11::serialization::gzserialize_details(
-        //        *this, KTfwd::mutation_writer(),
-        //        fwdpy11::diploid_writer(),
-        //        filename, append);
-        //}
+    //     // int
+    //     // tofile(const char *filename, bool append = false) const
+    //     //{
+    //     //    return fwdpy11::serialization::gzserialize_details(
+    //     //        *this, KTfwd::mutation_writer(),
+    //     //        fwdpy11::diploid_writer(),
+    //     //        filename, append);
+    //     //}
 
-        // void
-        // fromfile(const char *filename, std::size_t offset)
-        //{
-        //    *this = serialization::
-        //        gzdeserialize_details<singlepop_gm_vec_t>()(
-        //            KTfwd::mutation_reader<singlepop_gm_vec_t::mutation_t>(),
-        //            fwdpy11::diploid_reader(), filename, offset, 0u);
-        //}
-    };
+    //     // void
+    //     // fromfile(const char *filename, std::size_t offset)
+    //     //{
+    //     //    *this = serialization::
+    //     //        gzdeserialize_details<singlepop_gm_vec_t>()(
+    //     //            KTfwd::mutation_reader<singlepop_gm_vec_t::mutation_t>(),
+    //     //            fwdpy11::diploid_reader(), filename, offset, 0u);
+    //     //}
+    // };
 
     // Types for multi-"locus" (multi-region) simulations
     using multilocus_diploid_t = std::vector<diploid_t>;

--- a/fwdpy11/src/fwdpp_types.cc
+++ b/fwdpy11/src/fwdpp_types.cc
@@ -22,13 +22,13 @@
 #include <pybind11/stl_bind.h>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
-#include <fwdpp/sugar/generalmut.hpp>
+//#include <fwdpp/sugar/generalmut.hpp>
 
 namespace py = pybind11;
 
 PYBIND11_MAKE_OPAQUE(std::vector<KTfwd::uint_t>);
-PYBIND11_MAKE_OPAQUE(
-    std::vector<double>); // for generalmut_vec::s and generalmut_vec::h
+//PYBIND11_MAKE_OPAQUE(
+//    std::vector<double>); // for generalmut_vec::s and generalmut_vec::h
 
 PYBIND11_MODULE(fwdpp_types, m)
 {
@@ -230,73 +230,73 @@ PYBIND11_MODULE(fwdpp_types, m)
         .def("__eq__", [](const KTfwd::popgenmut &a,
                           const KTfwd::popgenmut &b) { return a == b; });
 
-    py::bind_vector<std::vector<double>>(
-        m, "VecDouble", "Vector of 64-bit floats.", py::buffer_protocol());
+    //py::bind_vector<std::vector<double>>(
+    //    m, "VecDouble", "Vector of 64-bit floats.", py::buffer_protocol());
 
-    py::class_<KTfwd::generalmut_vec, KTfwd::mutation_base>(
-        m, "GeneralMutVec",
-        "Mutation type with vector of effect size and dominance terms.")
-        .def(py::init<KTfwd::generalmut_vec::constructor_tuple>(),
-             R"delim(
-                Construct from a tuple.
-                
-                .. testcode::
-                    
-                    import fwdpy11
-                    s = fwdpy11.VecDouble([-0.1, 0.1])
-                    h = fwdpy11.VecDouble([0.0, 1.0])
-                    m = fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))
-                    print(m.pos)
-                    print(m.g)
-                    print(m.label)
-                    print(list(m.s))
-                    print(list(m.h))
+    //py::class_<KTfwd::generalmut_vec, KTfwd::mutation_base>(
+    //    m, "GeneralMutVec",
+    //    "Mutation type with vector of effect size and dominance terms.")
+    //    .def(py::init<KTfwd::generalmut_vec::constructor_tuple>(),
+    //         R"delim(
+    //            Construct from a tuple.
+    //            
+    //            .. testcode::
+    //                
+    //                import fwdpy11
+    //                s = fwdpy11.VecDouble([-0.1, 0.1])
+    //                h = fwdpy11.VecDouble([0.0, 1.0])
+    //                m = fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))
+    //                print(m.pos)
+    //                print(m.g)
+    //                print(m.label)
+    //                print(list(m.s))
+    //                print(list(m.h))
 
-                .. testoutput::
+    //            .. testoutput::
 
-                    0.1
-                    3
-                    0
-                    [-0.1, 0.1]
-                    [0.0, 1.0]
-                )delim")
-        .def_readonly("s", &KTfwd::generalmut_vec::s,
-                      "List of selection coefficients/effect sizes.")
-        .def_readonly("h", &KTfwd::generalmut_vec::h,
-                      "List of dominance terms.")
-        .def_readonly("g", &KTfwd::generalmut_vec::g,
-                      "Generation when mutation arose.")
-        .def(py::pickle(
-            [](const KTfwd::generalmut_vec &m) {
-                py::list h, s;
-                for (auto &&i : m.h)
-                    {
-                        h.append(i);
-                    }
-                for (auto &&i : m.s)
-                    {
-                        s.append(i);
-                    }
-                return py::make_tuple(m.pos, s, h, m.g, m.xtra);
-            },
-            [](py::tuple t) {
-                py::list s = t[1].cast<py::list>();
-                py::list h = t[2].cast<py::list>();
-                std::vector<double> vs, vh;
-                for (auto &&i : s)
-                    {
-                        vs.push_back(i.cast<double>());
-                    }
-                for (auto &&i : h)
-                    {
-                        vh.push_back(i.cast<double>());
-                    }
-                double pos = t[0].cast<double>();
-                KTfwd::uint_t g = t[3].cast<KTfwd::uint_t>();
-                auto xtra = t[4].cast<decltype(KTfwd::generalmut_vec::xtra)>();
-                return KTfwd::generalmut_vec(std::make_tuple(
-                    std::move(vs), std::move(vh), pos, g, xtra));
-            }))
-        .def("__eq__", [](const KTfwd::generalmut_vec &a,
-                          const KTfwd::generalmut_vec &b) { return a == b; });
+    //                0.1
+    //                3
+    //                0
+    //                [-0.1, 0.1]
+    //                [0.0, 1.0]
+    //            )delim")
+    //    .def_readonly("s", &KTfwd::generalmut_vec::s,
+    //                  "List of selection coefficients/effect sizes.")
+    //    .def_readonly("h", &KTfwd::generalmut_vec::h,
+    //                  "List of dominance terms.")
+    //    .def_readonly("g", &KTfwd::generalmut_vec::g,
+    //                  "Generation when mutation arose.")
+    //    .def(py::pickle(
+    //        [](const KTfwd::generalmut_vec &m) {
+    //            py::list h, s;
+    //            for (auto &&i : m.h)
+    //                {
+    //                    h.append(i);
+    //                }
+    //            for (auto &&i : m.s)
+    //                {
+    //                    s.append(i);
+    //                }
+    //            return py::make_tuple(m.pos, s, h, m.g, m.xtra);
+    //        },
+    //        [](py::tuple t) {
+    //            py::list s = t[1].cast<py::list>();
+    //            py::list h = t[2].cast<py::list>();
+    //            std::vector<double> vs, vh;
+    //            for (auto &&i : s)
+    //                {
+    //                    vs.push_back(i.cast<double>());
+    //                }
+    //            for (auto &&i : h)
+    //                {
+    //                    vh.push_back(i.cast<double>());
+    //                }
+    //            double pos = t[0].cast<double>();
+    //            KTfwd::uint_t g = t[3].cast<KTfwd::uint_t>();
+    //            auto xtra = t[4].cast<decltype(KTfwd::generalmut_vec::xtra)>();
+    //            return KTfwd::generalmut_vec(std::make_tuple(
+    //                std::move(vs), std::move(vh), pos, g, xtra));
+    //        }))
+    //    .def("__eq__", [](const KTfwd::generalmut_vec &a,
+    //                      const KTfwd::generalmut_vec &b) { return a == b; });
 }

--- a/fwdpy11/src/fwdpy11_sampling.cc
+++ b/fwdpy11/src/fwdpy11_sampling.cc
@@ -161,14 +161,14 @@ PYBIND11_MODULE(sampling, m)
                            "fwdpy11.SlocusPop")
     SAMPLE_SEPARATE_RANDOM(fwdpy11::multilocus_t,
                            "fwdpy11.MlocusPop")
-    SAMPLE_SEPARATE_RANDOM(fwdpy11::singlepop_gm_vec_t,
-                           "fwdpy11.SlocusPopGeneralMutVec")
+    // SAMPLE_SEPARATE_RANDOM(fwdpy11::singlepop_gm_vec_t,
+    //                        "fwdpy11.SlocusPopGeneralMutVec")
     SAMPLE_SEPARATE_IND(fwdpy11::singlepop_t,
                         "fwdpy11.SlocusPop")
     SAMPLE_SEPARATE_IND(fwdpy11::multilocus_t,
                         "fwdpy11.MlocusPop")
-    SAMPLE_SEPARATE_IND(fwdpy11::singlepop_gm_vec_t,
-                        "fwdpy11.SlocusPopGeneralMutVec")
+    // SAMPLE_SEPARATE_IND(fwdpy11::singlepop_gm_vec_t,
+    //                     "fwdpy11.SlocusPopGeneralMutVec")
 
     py::bind_vector<std::vector<std::int8_t>>(
         m, "VecInt8", py::buffer_protocol(),
@@ -387,18 +387,18 @@ PYBIND11_MODULE(sampling, m)
 
     MUTATION_KEYS(fwdpy11::singlepop_t, "fwdpy11.SlocusPop");
     MUTATION_KEYS(fwdpy11::multilocus_t, "fwdpy11.MlocusPop");
-    MUTATION_KEYS(fwdpy11::singlepop_gm_vec_t,
-                  "fwdpy11.SlocusPopGeneralMutVec");
+    // MUTATION_KEYS(fwdpy11::singlepop_gm_vec_t,
+    //               "fwdpy11.SlocusPopGeneralMutVec");
 
     GENOTYPE_MATRIX(fwdpy11::singlepop_t, "fwdpy11.SlocusPop");
     GENOTYPE_MATRIX(fwdpy11::multilocus_t, "fwdpy11.MlocusPop");
-    GENOTYPE_MATRIX(fwdpy11::singlepop_gm_vec_t,
-                    "fwdpy11.SlocusPopGeneralMutVec");
+    // GENOTYPE_MATRIX(fwdpy11::singlepop_gm_vec_t,
+    //                 "fwdpy11.SlocusPopGeneralMutVec");
 
     HAPLOTYPE_MATRIX(fwdpy11::singlepop_t, "fwdpy11.SlocusPop");
     HAPLOTYPE_MATRIX(fwdpy11::multilocus_t, "fwdpy11.MlocusPop");
-    HAPLOTYPE_MATRIX(fwdpy11::singlepop_gm_vec_t,
-                     "fwdpy11.SlocusPopGeneralMutVec");
+    // HAPLOTYPE_MATRIX(fwdpy11::singlepop_gm_vec_t,
+    //                  "fwdpy11.SlocusPopGeneralMutVec");
 
     m.def("matrix_to_sample",
           [](const KTfwd::data_matrix &m, const bool neutral)

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -28,13 +28,13 @@ using fwdpp_popgenmut_base = fwdpy11::singlepop_t::popbase_t;
 using singlepop_sugar_base = fwdpy11::singlepop_t::base;
 using multilocus_sugar_base = fwdpy11::multilocus_t::base;
 using multilocus_popgenmut_base = multilocus_sugar_base::popbase_t;
-using singlepop_generalmut_vec_sugar_base = fwdpy11::singlepop_gm_vec_t::base;
-using singlepop_generalmut_vec_base
-    = singlepop_generalmut_vec_sugar_base::popbase_t;
+//using singlepop_generalmut_vec_sugar_base = fwdpy11::singlepop_gm_vec_t::base;
+//using singlepop_generalmut_vec_base
+//    = singlepop_generalmut_vec_sugar_base::popbase_t;
 
 PYBIND11_MAKE_OPAQUE(fwdpy11::gcont_t);
 PYBIND11_MAKE_OPAQUE(fwdpy11::mcont_t);
-PYBIND11_MAKE_OPAQUE(std::vector<KTfwd::generalmut_vec>);
+//PYBIND11_MAKE_OPAQUE(std::vector<KTfwd::generalmut_vec>);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::diploid_t>);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::dipvector_t>);
 PYBIND11_MAKE_OPAQUE(std::vector<KTfwd::uint_t>);
@@ -191,10 +191,10 @@ PYBIND11_MODULE(fwdpy11_types, m)
     py::class_<multilocus_sugar_base, multilocus_popgenmut_base>(m,
                                                                  "MlocusBase");
 
-    py::class_<singlepop_generalmut_vec_base>(m, "SlocusPopGeneralMutVecBase");
-    py::class_<singlepop_generalmut_vec_sugar_base,
-               singlepop_generalmut_vec_base>(
-        m, "SlocusPopGeneralMutVecSugarBase");
+    //py::class_<singlepop_generalmut_vec_base>(m, "SlocusPopGeneralMutVecBase");
+    //py::class_<singlepop_generalmut_vec_sugar_base,
+    //           singlepop_generalmut_vec_base>(
+    //    m, "SlocusPopGeneralMutVecSugarBase");
 
     // Expose the type based on fwdpp's "sugar"
     // layer
@@ -518,154 +518,154 @@ PYBIND11_MODULE(fwdpy11_types, m)
              )delim",
         py::arg("separate")=true,py::arg("remove_fixed")=true);
 
-    py::class_<fwdpy11::singlepop_gm_vec_t,
-               singlepop_generalmut_vec_sugar_base>(m,
-                                                    "SlocusPopGeneralMutVec")
-        .def(py::init<unsigned>(), py::arg("N"),
-             "Construct object with N diploids.")
-        .def(py::init<const fwdpy11::singlepop_gm_vec_t::dipvector_t&,
-                      const fwdpy11::singlepop_gm_vec_t::gcont_t&,
-                      const fwdpy11::singlepop_gm_vec_t::mcont_t&>(),
-             R"delim(
-             Construct with tuple of (diploids, gametes, mutations).
-             
-             .. versionadded:: 0.1.4
-             )delim")
-        .def(py::init<const fwdpy11::singlepop_gm_vec_t&>(),
-             R"delim(
-                Copy constructor.
+    //py::class_<fwdpy11::singlepop_gm_vec_t,
+    //           singlepop_generalmut_vec_sugar_base>(m,
+    //                                                "SlocusPopGeneralMutVec")
+    //    .def(py::init<unsigned>(), py::arg("N"),
+    //         "Construct object with N diploids.")
+    //    .def(py::init<const fwdpy11::singlepop_gm_vec_t::dipvector_t&,
+    //                  const fwdpy11::singlepop_gm_vec_t::gcont_t&,
+    //                  const fwdpy11::singlepop_gm_vec_t::mcont_t&>(),
+    //         R"delim(
+    //         Construct with tuple of (diploids, gametes, mutations).
+    //         
+    //         .. versionadded:: 0.1.4
+    //         )delim")
+    //    .def(py::init<const fwdpy11::singlepop_gm_vec_t&>(),
+    //         R"delim(
+    //            Copy constructor.
 
-                .. versionadded:: 0.1.4
-                )delim")
-        .def_static(
-            "create",
-            [](fwdpy11::dipvector_t& diploids, fwdpy11::gcont_t& gametes,
-               std::vector<KTfwd::generalmut_vec>& mutations, py::tuple args) {
-                if (args.size() == 0)
-                    {
-                        return fwdpy11::singlepop_gm_vec_t::create(
-                            diploids, gametes, mutations);
-                    }
-                auto& fixations
-                    = args[0].cast<std::vector<KTfwd::generalmut_vec>&>();
-                auto& fixation_times
-                    = args[1].cast<std::vector<KTfwd::uint_t>&>();
-                auto g = args[2].cast<KTfwd::uint_t>();
-                return fwdpy11::singlepop_gm_vec_t::create_with_fixations(
-                    diploids, gametes, mutations, fixations, fixation_times,
-                    g);
-            })
-        .def("clear", &fwdpy11::singlepop_gm_vec_t::clear,
-             "Clears all population data.")
-        .def_readonly("generation", &fwdpy11::singlepop_gm_vec_t::generation,
-                      "The current generation.")
-        .def_readonly("N", &fwdpy11::singlepop_gm_vec_t::N,
-                      "Curent population size.")
-        .def_readonly("diploids", &fwdpy11::singlepop_gm_vec_t::diploids,
-                      DIPLOIDS_DOCSTRING)
-        .def_readonly("mutations", &fwdpy11::singlepop_gm_vec_t::mutations,
-                      "A list of "
-                      ":class:`fwdpy11.VecGeneralMutVec`.")
-        .def_readonly("gametes", &fwdpy11::singlepop_gm_vec_t::gametes,
-                      GAMETES_DOCSTRING)
-        .def_readonly("mcounts", &fwdpy11::singlepop_gm_vec_t::mcounts,
-                      MCOUNTS_DOCSTRING)
-        .def_readonly("fixations", &fwdpy11::singlepop_gm_vec_t::fixations,
-                      "A list of :class:`fwdpy11.VecGeneralMutVec`.")
-        .def_readonly("fixation_times",
-                      &fwdpy11::singlepop_gm_vec_t::fixation_times,
-                      FIXATION_TIMES_DOCSTRING)
-        .def_readonly("popdata", &fwdpy11::singlepop_gm_vec_t::popdata,
-                      POPDATA_DOCSTRING)
-        .def_readwrite("popdata_user",
-                       &fwdpy11::singlepop_gm_vec_t::popdata_user,
-                       POPDATA_USER_DOCSTRING)
-        .def(py::pickle(
+    //            .. versionadded:: 0.1.4
+    //            )delim")
+    //    .def_static(
+    //        "create",
+    //        [](fwdpy11::dipvector_t& diploids, fwdpy11::gcont_t& gametes,
+    //           std::vector<KTfwd::generalmut_vec>& mutations, py::tuple args) {
+    //            if (args.size() == 0)
+    //                {
+    //                    return fwdpy11::singlepop_gm_vec_t::create(
+    //                        diploids, gametes, mutations);
+    //                }
+    //            auto& fixations
+    //                = args[0].cast<std::vector<KTfwd::generalmut_vec>&>();
+    //            auto& fixation_times
+    //                = args[1].cast<std::vector<KTfwd::uint_t>&>();
+    //            auto g = args[2].cast<KTfwd::uint_t>();
+    //            return fwdpy11::singlepop_gm_vec_t::create_with_fixations(
+    //                diploids, gametes, mutations, fixations, fixation_times,
+    //                g);
+    //        })
+    //    .def("clear", &fwdpy11::singlepop_gm_vec_t::clear,
+    //         "Clears all population data.")
+    //    .def_readonly("generation", &fwdpy11::singlepop_gm_vec_t::generation,
+    //                  "The current generation.")
+    //    .def_readonly("N", &fwdpy11::singlepop_gm_vec_t::N,
+    //                  "Curent population size.")
+    //    .def_readonly("diploids", &fwdpy11::singlepop_gm_vec_t::diploids,
+    //                  DIPLOIDS_DOCSTRING)
+    //    .def_readonly("mutations", &fwdpy11::singlepop_gm_vec_t::mutations,
+    //                  "A list of "
+    //                  ":class:`fwdpy11.VecGeneralMutVec`.")
+    //    .def_readonly("gametes", &fwdpy11::singlepop_gm_vec_t::gametes,
+    //                  GAMETES_DOCSTRING)
+    //    .def_readonly("mcounts", &fwdpy11::singlepop_gm_vec_t::mcounts,
+    //                  MCOUNTS_DOCSTRING)
+    //    .def_readonly("fixations", &fwdpy11::singlepop_gm_vec_t::fixations,
+    //                  "A list of :class:`fwdpy11.VecGeneralMutVec`.")
+    //    .def_readonly("fixation_times",
+    //                  &fwdpy11::singlepop_gm_vec_t::fixation_times,
+    //                  FIXATION_TIMES_DOCSTRING)
+    //    .def_readonly("popdata", &fwdpy11::singlepop_gm_vec_t::popdata,
+    //                  POPDATA_DOCSTRING)
+    //    .def_readwrite("popdata_user",
+    //                   &fwdpy11::singlepop_gm_vec_t::popdata_user,
+    //                   POPDATA_USER_DOCSTRING)
+    //    .def(py::pickle(
 
-            [](const fwdpy11::singlepop_gm_vec_t& pop) -> py::object {
-                auto pb = py::bytes(pop.serialize());
-                py::list pdata;
-                for (auto& d : pop.diploids)
-                    {
-                        pdata.append(d.parental_data);
-                    }
-                return py::make_tuple(std::move(pb), std::move(pdata),
-                                      pop.popdata, pop.popdata_user);
-            },
-            [](py::object pickled) {
-                auto t = pickled.cast<py::tuple>();
-                if (t.size() != 4)
-                    {
-                        throw std::runtime_error(
-                            "expected tuple with 4 elements");
-                    }
-                auto s = t[0].cast<py::bytes>();
-                auto l = t[1].cast<py::list>();
-                auto rv = std::unique_ptr<fwdpy11::singlepop_gm_vec_t>(
-                    new fwdpy11::singlepop_gm_vec_t(s));
-                for (std::size_t i = 0; i < rv->diploids.size(); ++i)
-                    {
-                        rv->diploids[i].parental_data = l[i];
-                    }
-                rv->popdata = t[2];
-                rv->popdata_user = t[3];
-                return rv;
-            }))
-        .def("__eq__",
-             [](const fwdpy11::singlepop_gm_vec_t& lhs,
-                const fwdpy11::singlepop_gm_vec_t& rhs) { return lhs == rhs; })
-        .def("sample",
-             [](const fwdpy11::singlepop_gm_vec_t& pop, const bool separate,
-                const bool remove_fixed, py::kwargs kwargs) -> py::object {
-                 py::object rv;
+    //        [](const fwdpy11::singlepop_gm_vec_t& pop) -> py::object {
+    //            auto pb = py::bytes(pop.serialize());
+    //            py::list pdata;
+    //            for (auto& d : pop.diploids)
+    //                {
+    //                    pdata.append(d.parental_data);
+    //                }
+    //            return py::make_tuple(std::move(pb), std::move(pdata),
+    //                                  pop.popdata, pop.popdata_user);
+    //        },
+    //        [](py::object pickled) {
+    //            auto t = pickled.cast<py::tuple>();
+    //            if (t.size() != 4)
+    //                {
+    //                    throw std::runtime_error(
+    //                        "expected tuple with 4 elements");
+    //                }
+    //            auto s = t[0].cast<py::bytes>();
+    //            auto l = t[1].cast<py::list>();
+    //            auto rv = std::unique_ptr<fwdpy11::singlepop_gm_vec_t>(
+    //                new fwdpy11::singlepop_gm_vec_t(s));
+    //            for (std::size_t i = 0; i < rv->diploids.size(); ++i)
+    //                {
+    //                    rv->diploids[i].parental_data = l[i];
+    //                }
+    //            rv->popdata = t[2];
+    //            rv->popdata_user = t[3];
+    //            return rv;
+    //        }))
+    //    .def("__eq__",
+    //         [](const fwdpy11::singlepop_gm_vec_t& lhs,
+    //            const fwdpy11::singlepop_gm_vec_t& rhs) { return lhs == rhs; })
+    //    .def("sample",
+    //         [](const fwdpy11::singlepop_gm_vec_t& pop, const bool separate,
+    //            const bool remove_fixed, py::kwargs kwargs) -> py::object {
+    //             py::object rv;
 
-                 std::vector<std::size_t> ind = get_individuals(pop.N, kwargs);
+    //             std::vector<std::size_t> ind = get_individuals(pop.N, kwargs);
 
-                 if (separate)
-                     {
-                         auto temp
-                             = KTfwd::sample_separate(pop, ind, remove_fixed);
-                         rv = py::make_tuple(temp.first, temp.second);
-                     }
-                 else
-                     {
-                         auto temp = KTfwd::sample(pop, ind, remove_fixed);
-                         py::list tlist = py::cast(temp);
-                         rv = tlist;
-                     }
-                 return rv;
-             },
-             py::arg("separate") = true, py::arg("remove_fixed") = true,
-             R"delim(
-             Sample diploids from the population.
+    //             if (separate)
+    //                 {
+    //                     auto temp
+    //                         = KTfwd::sample_separate(pop, ind, remove_fixed);
+    //                     rv = py::make_tuple(temp.first, temp.second);
+    //                 }
+    //             else
+    //                 {
+    //                     auto temp = KTfwd::sample(pop, ind, remove_fixed);
+    //                     py::list tlist = py::cast(temp);
+    //                     rv = tlist;
+    //                 }
+    //             return rv;
+    //         },
+    //         py::arg("separate") = true, py::arg("remove_fixed") = true,
+    //         R"delim(
+    //         Sample diploids from the population.
 
-             :param separate: (True) Return neutral and selected variants separately.
-             :param remove_fixed: (True) Remove variants fixed in the sample.
-             :param kwargs: See below.
+    //         :param separate: (True) Return neutral and selected variants separately.
+    //         :param remove_fixed: (True) Remove variants fixed in the sample.
+    //         :param kwargs: See below.
 
-             :rtype: object
+    //         :rtype: object
 
-             :returns: Haplotype information for a sample.
+    //         :returns: Haplotype information for a sample.
 
-             The valid kwargs are:
+    //         The valid kwargs are:
 
-             * individuals, which should be a list of non-negative integers
-             * rng, which should be a :class:`fwdpy11.GSLrng`
-             * nsam, which should be a positive integer
-             
-             The latter two kwargs must be used together, and will generate a sample of
-             ``nsam`` individuals taken *with replacement* from the population. 
+    //         * individuals, which should be a list of non-negative integers
+    //         * rng, which should be a :class:`fwdpy11.GSLrng`
+    //         * nsam, which should be a positive integer
+    //         
+    //         The latter two kwargs must be used together, and will generate a sample of
+    //         ``nsam`` individuals taken *with replacement* from the population. 
 
-             The return value is structured around a list of tuples.  Each tuple
-             is (position, genotype), where genotype are encoded as 0/1 = ancestral/derived.
-             From index 0 to 2*nsam - 1 (or 2*len(individuals) -1), adjacent pairs of 
-             values represent diploid genotype data.  Across sites, the data represent
-             individual haplotypes.
+    //         The return value is structured around a list of tuples.  Each tuple
+    //         is (position, genotype), where genotype are encoded as 0/1 = ancestral/derived.
+    //         From index 0 to 2*nsam - 1 (or 2*len(individuals) -1), adjacent pairs of 
+    //         values represent diploid genotype data.  Across sites, the data represent
+    //         individual haplotypes.
 
-             When `separate` is `True`, a tuple of two such lists is returned.  The first
-             list is for genotypes at neutral variants.  The second list is for non-neutral
-             variants.
+    //         When `separate` is `True`, a tuple of two such lists is returned.  The first
+    //         list is for genotypes at neutral variants.  The second list is for non-neutral
+    //         variants.
 
-			 .. versionadded:: 0.1.4
-             )delim");
+	//		 .. versionadded:: 0.1.4
+    //         )delim");
 }

--- a/setup.py
+++ b/setup.py
@@ -95,14 +95,14 @@ ext_modules = [
         libraries=['gsl', 'gslcblas'],
         language='c++'
     ),
-    Extension(
-        'fwdpy11._opaque_generalmutvecs',
-        ['fwdpy11/src/_opaque_generalmutvecs.cc'],
-        library_dirs=LIBRARY_DIRS,
-        include_dirs=INCLUDES,
-        libraries=['gsl', 'gslcblas'],
-        language='c++'
-    ),
+    # Extension(
+    #     'fwdpy11._opaque_generalmutvecs',
+    #     ['fwdpy11/src/_opaque_generalmutvecs.cc'],
+    #     library_dirs=LIBRARY_DIRS,
+    #     include_dirs=INCLUDES,
+    #     libraries=['gsl', 'gslcblas'],
+    #     language='c++'
+    # ),
     Extension(
         'fwdpy11._opaque_diploids',
         ['fwdpy11/src/_opaque_diploids.cc'],

--- a/setup.py.in
+++ b/setup.py.in
@@ -95,14 +95,14 @@ ext_modules = [
         libraries=['gsl', 'gslcblas'],
         language='c++'
     ),
-    Extension(
-        'fwdpy11._opaque_generalmutvecs',
-        ['fwdpy11/src/_opaque_generalmutvecs.cc'],
-        library_dirs=LIBRARY_DIRS,
-        include_dirs=INCLUDES,
-        libraries=['gsl', 'gslcblas'],
-        language='c++'
-    ),
+    # Extension(
+    #     'fwdpy11._opaque_generalmutvecs',
+    #     ['fwdpy11/src/_opaque_generalmutvecs.cc'],
+    #     library_dirs=LIBRARY_DIRS,
+    #     include_dirs=INCLUDES,
+    #     libraries=['gsl', 'gslcblas'],
+    #     language='c++'
+    # ),
     Extension(
         'fwdpy11._opaque_diploids',
         ['fwdpy11/src/_opaque_diploids.cc'],

--- a/tests/test_opaque.py
+++ b/tests/test_opaque.py
@@ -123,35 +123,35 @@ class testMlocusPop(unittest.TestCase):
             is fwdpy11.VecGamete)
 
 
-class testVectorGeneralMutVec(unittest.TestCase):
-    """
-    Test that the s,h fields
-    are opaque containers and
-    not converted to lists.
-    """
-    @classmethod
-    def setUp(self):
-        import fwdpy11
-        s = fwdpy11.VecDouble([0.1, -0.1])
-        h = fwdpy11.VecDouble([0., 1.])
-        self.mutations = [fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))]
-
-    def test_opaque(self):
-        self.assertTrue(type(self.mutations[0].s
-                             is fwdpy11.VecDouble))
-        self.assertTrue(type(self.mutations[0].h
-                             is fwdpy11.VecDouble))
-
-    def test_opaque_conversion(self):
-        """
-        This tests something that is quite
-        unsafe to do unless you really
-        know what you are doing.
-        """
-        import numpy as np
-        x = np.array(self.mutations[0].s, copy=False)
-        x[0] = 303.0
-        self.assertEqual(self.mutations[0].s[0], 303.0)
+# class testVectorGeneralMutVec(unittest.TestCase):
+#     """
+#     Test that the s,h fields
+#     are opaque containers and
+#     not converted to lists.
+#     """
+#     @classmethod
+#     def setUp(self):
+#         import fwdpy11
+#         s = fwdpy11.VecDouble([0.1, -0.1])
+#         h = fwdpy11.VecDouble([0., 1.])
+#         self.mutations = [fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))]
+# 
+#     def test_opaque(self):
+#         self.assertTrue(type(self.mutations[0].s
+#                              is fwdpy11.VecDouble))
+#         self.assertTrue(type(self.mutations[0].h
+#                              is fwdpy11.VecDouble))
+# 
+#     def test_opaque_conversion(self):
+#         """
+#         This tests something that is quite
+#         unsafe to do unless you really
+#         know what you are doing.
+#         """
+#         import numpy as np
+#         x = np.array(self.mutations[0].s, copy=False)
+#         x[0] = 303.0
+#         self.assertEqual(self.mutations[0].s[0], 303.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -121,46 +121,46 @@ class testPickleMlocusPop(unittest.TestCase):
         self.assertEqual(pp, self.pop)
 
 
-class testSlocusPopGeneralMut(unittest.TestCase):
-    @classmethod
-    def setUp(self):
-        import fwdpy11
-        self.pop = fwdpy11.SlocusPopGeneralMutVec(100)
-
-    def testPicklePopPy(self):
-        import pickle
-        p = pickle.dumps(self.pop, -1)
-        pp = pickle.loads(p)
-        self.assertEqual(pp, self.pop)
-
-    def testPicklePopCpp(self):
-        import pickle
-        p = pickling_cpp.general_pickler(self.pop)
-        pp = pickle.loads(p)
-        self.assertEqual(pp, self.pop)
-
-
-class testVectorGeneralMutVec(unittest.TestCase):
-    """
-    As of 0.1.4, SlocusPopGeneralMutVec is
-    not used by any sims, and so there
-    is no evolve function to make a pop. Therefore,
-    we test that vectors of the mutation type
-    are pickleable.  We test that by making one.
-    """
-    @classmethod
-    def setUp(self):
-        import fwdpy11
-        s = fwdpy11.VecDouble([0.1, -0.1])
-        h = fwdpy11.VecDouble([0., 1.])
-        self.mutations = [fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))]
-
-    def testPickleVector(self):
-        import pickle
-        p = pickle.dumps(self.mutations)
-        pp = pickle.loads(p)
-        for i, j in zip(pp, self.mutations):
-            self.assertEqual(i, j)
+# class testSlocusPopGeneralMut(unittest.TestCase):
+#     @classmethod
+#     def setUp(self):
+#         import fwdpy11
+#         self.pop = fwdpy11.SlocusPopGeneralMutVec(100)
+# 
+#     def testPicklePopPy(self):
+#         import pickle
+#         p = pickle.dumps(self.pop, -1)
+#         pp = pickle.loads(p)
+#         self.assertEqual(pp, self.pop)
+# 
+#     def testPicklePopCpp(self):
+#         import pickle
+#         p = pickling_cpp.general_pickler(self.pop)
+#         pp = pickle.loads(p)
+#         self.assertEqual(pp, self.pop)
+# 
+# 
+# class testVectorGeneralMutVec(unittest.TestCase):
+#     """
+#     As of 0.1.4, SlocusPopGeneralMutVec is
+#     not used by any sims, and so there
+#     is no evolve function to make a pop. Therefore,
+#     we test that vectors of the mutation type
+#     are pickleable.  We test that by making one.
+#     """
+#     @classmethod
+#     def setUp(self):
+#         import fwdpy11
+#         s = fwdpy11.VecDouble([0.1, -0.1])
+#         h = fwdpy11.VecDouble([0., 1.])
+#         self.mutations = [fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))]
+# 
+#     def testPickleVector(self):
+#         import pickle
+#         p = pickle.dumps(self.mutations)
+#         pp = pickle.loads(p)
+#         for i, j in zip(pp, self.mutations):
+#             self.assertEqual(i, j)
 
 
 if __name__ == "__main__":

--- a/tests/test_popobject_create.py
+++ b/tests/test_popobject_create.py
@@ -66,51 +66,51 @@ class testSlocusPopCreate(unittest.TestCase):
         self.assertEqual(len(ftimes), 0)
 
 
-class testSlocusPopGeneralMutVecCreate(unittest.TestCase):
-    @classmethod
-    def setUp(self):
-        self.mutations = fwdpy11.VecGeneralMutVec()
-        self.fixations = fwdpy11.VecGeneralMutVec()
-        self.gametes = fwdpy11.VecGamete()
-        self.diploids = fwdpy11.VecDiploid()
-        s = fwdpy11.VecDouble([-0.1, 0.1])
-        h = fwdpy11.VecDouble([0.0, 1.0])
-        m = fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))
-        self.mutations.append(m)
-        self.fixations.append(m)
-        self.gametes.append(fwdpy11.Gamete(
-            (2, fwdpy11.VecUint32([]), fwdpy11.VecUint32([0]))))
-        self.diploids.append(fwdpy11.SingleLocusDiploid(0, 0))
-
-    def testConstruction(self):
-        pop = fwdpy11.SlocusPopGeneralMutVec(
-            self.diploids, self.gametes, self.mutations)
-        self.assertTrue(pop.N, 1)
-
-    def testStaticMethod(self):
-        pop = fwdpy11.SlocusPopGeneralMutVec.create(
-            self.diploids, self.gametes, self.mutations)
-        self.assertTrue(type(pop) is fwdpy11.SlocusPopGeneralMutVec)
-        # Test that data were moved and not copied:
-        self.assertEqual(len(self.diploids), 0)
-        self.assertEqual(len(self.gametes), 0)
-        self.assertEqual(len(self.mutations), 0)
-
-    def testStaticMethodWithFixations(self):
-        ftimes = fwdpy11.VecUint32([1])
-        pop = fwdpy11.SlocusPopGeneralMutVec.create(self.diploids,
-                                                    self.gametes,
-                                                    self.mutations,
-                                                    self.fixations,
-                                                    ftimes, 2)
-        self.assertTrue(type(pop) is fwdpy11.SlocusPopGeneralMutVec)
-        self.assertEqual(len(pop.fixations), len(pop.fixation_times))
-        # Test that data were moved and not copied:
-        self.assertEqual(len(self.diploids), 0)
-        self.assertEqual(len(self.gametes), 0)
-        self.assertEqual(len(self.mutations), 0)
-        self.assertEqual(len(self.fixations), 0)
-        self.assertEqual(len(ftimes), 0)
+# class testSlocusPopGeneralMutVecCreate(unittest.TestCase):
+#     @classmethod
+#     def setUp(self):
+#         self.mutations = fwdpy11.VecGeneralMutVec()
+#         self.fixations = fwdpy11.VecGeneralMutVec()
+#         self.gametes = fwdpy11.VecGamete()
+#         self.diploids = fwdpy11.VecDiploid()
+#         s = fwdpy11.VecDouble([-0.1, 0.1])
+#         h = fwdpy11.VecDouble([0.0, 1.0])
+#         m = fwdpy11.GeneralMutVec((s, h, 0.1, 3, 0))
+#         self.mutations.append(m)
+#         self.fixations.append(m)
+#         self.gametes.append(fwdpy11.Gamete(
+#             (2, fwdpy11.VecUint32([]), fwdpy11.VecUint32([0]))))
+#         self.diploids.append(fwdpy11.SingleLocusDiploid(0, 0))
+# 
+#     def testConstruction(self):
+#         pop = fwdpy11.SlocusPopGeneralMutVec(
+#             self.diploids, self.gametes, self.mutations)
+#         self.assertTrue(pop.N, 1)
+# 
+#     def testStaticMethod(self):
+#         pop = fwdpy11.SlocusPopGeneralMutVec.create(
+#             self.diploids, self.gametes, self.mutations)
+#         self.assertTrue(type(pop) is fwdpy11.SlocusPopGeneralMutVec)
+#         # Test that data were moved and not copied:
+#         self.assertEqual(len(self.diploids), 0)
+#         self.assertEqual(len(self.gametes), 0)
+#         self.assertEqual(len(self.mutations), 0)
+# 
+#     def testStaticMethodWithFixations(self):
+#         ftimes = fwdpy11.VecUint32([1])
+#         pop = fwdpy11.SlocusPopGeneralMutVec.create(self.diploids,
+#                                                     self.gametes,
+#                                                     self.mutations,
+#                                                     self.fixations,
+#                                                     ftimes, 2)
+#         self.assertTrue(type(pop) is fwdpy11.SlocusPopGeneralMutVec)
+#         self.assertEqual(len(pop.fixations), len(pop.fixation_times))
+#         # Test that data were moved and not copied:
+#         self.assertEqual(len(self.diploids), 0)
+#         self.assertEqual(len(self.gametes), 0)
+#         self.assertEqual(len(self.mutations), 0)
+#         self.assertEqual(len(self.fixations), 0)
+#         self.assertEqual(len(ftimes), 0)
 
 
 class testMlocusPopCreate(unittest.TestCase):


### PR DESCRIPTION
Comments out all types based on fwdpp's `generalmut_vec`.  Supporting these types creates an unnecessary burden and there's a better way to get the same set of features, which will happen in 0.1.5.

These types have never been used, so this hurts no one.