### PR TITLE
New mutation type

### DIFF
--- a/fwdpy11/headers/fwdpy11/serialization/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization/Mutation.hpp
@@ -1,0 +1,97 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef FWDPY11_SERIALIZATION_MUTATION_HPP__
+#define FWDPY11_SERIALIZATION_MUTATION_HPP__
+
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpp/io/mutation.hpp>
+#include <fwdpp/io/scalar_serialization.hpp>
+
+// Make Mutation compatible with fwdpp's
+// serialization API:
+namespace fwdpp
+{
+    namespace io
+    {
+        template <> struct serialize_mutation<fwdpy11::Mutation>
+        {
+            io::scalar_writer writer;
+            serialize_mutation<fwdpy11::Mutation>() : writer{} {}
+            template <typename streamtype>
+            inline void
+            operator()(streamtype &buffer, const fwdpy11::Mutation &m) const
+            {
+                writer(buffer, &m.g);
+                writer(buffer, &m.pos);
+                writer(buffer, &m.s);
+                writer(buffer, &m.h);
+                writer(buffer, &m.xtra);
+                std::size_t ns = m.esizes.size(), nh = m.heffects.size();
+                writer(buffer, &ns);
+                writer(buffer, &nh);
+                if (ns)
+                    {
+                        writer(buffer, m.esizes.data(), ns);
+                    }
+                if (nh)
+                    {
+                        writer(buffer, m.heffects.data(), nh);
+                    }
+            }
+        };
+
+        template <> struct deserialize_mutation<fwdpy11::Mutation>
+        {
+            io::scalar_reader reader;
+            deserialize_mutation<fwdpy11::Mutation>() : reader{} {}
+            template <typename streamtype>
+            inline fwdpy11::Mutation
+            operator()(streamtype &buffer) const
+            {
+                uint_t g;
+                double pos, s, h;
+                decltype(fwdpy11::Mutation::xtra) xtra;
+                io::scalar_reader reader;
+                reader(buffer, &g);
+                reader(buffer, &pos);
+                reader(buffer, &s);
+                reader(buffer, &h);
+                reader(buffer, &xtra);
+                std::size_t ns, nh;
+                reader(buffer, &ns);
+                reader(buffer, &nh);
+                std::vector<double> ss, hs;
+                if (ns)
+                    {
+                        ss.resize(ns);
+                        reader(buffer, ss.data(), ns);
+                    }
+                if (nh)
+                    {
+                        hs.resize(ns);
+                        reader(buffer, hs.data(), nh);
+                    }
+                return fwdpy11::Mutation(pos, s, h, g, std::move(ss),
+                                         std::move(hs), xtra);
+            }
+        };
+    }
+}
+
+#endif

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -1,0 +1,148 @@
+#ifndef FWDPY11_MUTATION_TYPE_HPP__
+#define FWDPY11_MUTATION_TYPE_HPP__
+
+/*
+ * This file started off via a copy
+ * of fwdpp's popgenmut.hpp
+ * by Kevin Thornton.
+ */
+
+#include <tuple>
+#include <cstdint>
+#include <vector>
+#include <fwdpp/forward_types.hpp>
+#include <fwdpp/io/mutation.hpp>
+#include <fwdpp/io/scalar_serialization.hpp>
+
+namespace fwdpy11
+{
+    struct Mutation : public fwdpp::mutation_base
+    ///! The fwdpy11 mutation type
+    {
+        //! The generation when the mutation arose
+        fwdpp::uint_t g;
+        //! Selection coefficient
+        double s;
+        //! Dominance of the mutation
+        double h;
+        std::vector<double> esizes, heffects;
+        //! Alias for tuple type that can be used for object construction
+        using constructor_tuple
+            = std::tuple<double, double, double, unsigned, std::uint16_t>;
+
+        /*!
+          \brief Constructor
+          \param __pos Mutation position
+          \param __s Selection coefficient
+          \param __h Dominance coefficient
+          \param __g Generation when mutation arose
+          \param __x Value to assign to mutation_base::xtra
+        */
+        Mutation(const double &__pos, const double &__s, const double &__h,
+                 const unsigned &__g, const std::uint16_t x = 0) noexcept
+            : mutation_base(__pos, (__s == 0.) ? true : false, x), g(__g),
+              s(__s), h(__h)
+        {
+        }
+
+        template <typename vectype>
+        Mutation(const double &__pos, const double &__s, const double &__h,
+                 const unsigned &__g, vectype &&esizes_, vectype &&heffects_,
+                 const std::uint16_t x = 0) noexcept
+            : fwdpp::mutation_base(__pos, (__s == 0.) ? true : false, x),
+              g(__g), s(__s), h(__h), esizes(std::forward<vectype>(esizes_)),
+              heffects(std::forward<vectype>(heffects_))
+        {
+        }
+
+        Mutation(constructor_tuple t) noexcept
+            : mutation_base(std::get<0>(t),
+                            (std::get<1>(t) == 0.) ? true : false,
+                            std::get<4>(t)),
+              g(std::get<3>(t)), s(std::get<1>(t)), h(std::get<2>(t))
+        {
+        }
+
+        bool
+        operator==(const Mutation &rhs) const
+        {
+            return std::tie(this->g, this->s, this->h, this->esizes,
+                            this->heffects)
+                       == std::tie(rhs.g, rhs.s, rhs.h, rhs.esizes,
+                                   rhs.heffects)
+                   && is_equal(rhs);
+        }
+    };
+}
+
+// Make Mutation compatible with fwdpp's
+// serialization API:
+namespace fwdpp
+{
+    namespace io
+    {
+        template <> struct serialize_mutation<Mutation>
+        {
+            io::scalar_writer writer;
+            serialize_mutation<Mutation>() : writer{} {}
+            template <typename streamtype>
+            inline void
+            operator()(streamtype &buffer, const Mutation &m) const
+            {
+                writer(buffer, &m.g);
+                writer(buffer, &m.pos);
+                writer(buffer, &m.s);
+                writer(buffer, &m.h);
+                writer(buffer, &m.xtra);
+                std::size_t ns = m.esizes.size(), nh = m.heffects.size();
+                writer(buffer, &ns);
+                writer(buffer, &nh);
+                if (ns)
+                    {
+                        writer(buffer, m.esizes.data(), ns);
+                    }
+                if (nh)
+                    {
+                        writer(buffer, m.heffects.data(), nh);
+                    }
+            }
+        };
+
+        template <> struct deserialize_mutation<Mutation>
+        {
+            io::scalar_reader reader;
+            deserialize_mutation<Mutation>() : reader{} {}
+            template <typename streamtype>
+            inline Mutation
+            operator()(streamtype &buffer) const
+            {
+                uint_t g;
+                double pos, s, h;
+                decltype(Mutation::xtra) xtra;
+                io::scalar_reader reader;
+                reader(buffer, &g);
+                reader(buffer, &pos);
+                reader(buffer, &s);
+                reader(buffer, &h);
+                reader(buffer, &xtra);
+                std::size_t ns, nh;
+                reader(buffer, &ns);
+                reader(buffer, &nh);
+                std::vector<double> ss, hs;
+                if (ns)
+                    {
+                        ss.resize(ns);
+                        reader(buffer, ss.data(), ns);
+                    }
+                if (nh)
+                    {
+                        hs.resize(ns);
+                        reader(buffer, hs.data(), nh);
+                    }
+                return Mutation(pos, s, h, g, std::move(ss), std::move(hs),
+                                xtra);
+            }
+        };
+    }
+}
+#endif

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -31,6 +31,10 @@ namespace fwdpy11
         //! Alias for tuple type that can be used for object construction
         using constructor_tuple
             = std::tuple<double, double, double, unsigned, std::uint16_t>;
+        //! Alias for tuple type that accommodates variable effect sizes
+        using constructor_tuple_variable_effects
+            = std::tuple<double, double, double, unsigned, std::vector<double>,
+                         std::vector<double>, std::uint16_t>;
 
         /*!
           Constructor for constant effect size sims.
@@ -73,6 +77,15 @@ namespace fwdpy11
         }
 
         Mutation(constructor_tuple t) noexcept
+            : mutation_base(std::get<0>(t),
+                            (std::get<1>(t) == 0.) ? true : false,
+                            std::get<6>(t)),
+              g(std::get<3>(t)), s(std::get<1>(t)), h(std::get<2>(t)),
+              esizes(std::get<4>(t)), heffects(std::get<5>(t))
+        {
+        }
+
+        Mutation(constructor_tuple_variable_effects t) noexcept
             : mutation_base(std::get<0>(t),
                             (std::get<1>(t) == 0.) ? true : false,
                             std::get<4>(t)),

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -65,7 +65,7 @@ namespace fwdpy11
         */
         Mutation(const double &pos_, const double &s_, const double &h_,
                  const unsigned &g_, const std::uint16_t x_ = 0) noexcept
-            : mutation_base(pos_, (s_ == 0.) ? true : false, x), g(g_), s(s_),
+            : mutation_base(pos_, (s_ == 0.) ? true : false, x_), g(g_), s(s_),
               h(h_), esizes{}, heffects{}
         {
         }
@@ -97,18 +97,18 @@ namespace fwdpy11
         Mutation(constructor_tuple t) noexcept
             : mutation_base(std::get<0>(t),
                             (std::get<1>(t) == 0.) ? true : false,
-                            std::get<6>(t)),
-              g(std::get<3>(t)), s(std::get<1>(t)), h(std::get<2>(t)),
-              esizes(std::get<4>(t)), heffects(std::get<5>(t))
+                            std::get<4>(t)),
+              g(std::get<3>(t)), s(std::get<1>(t)),
+              h(std::get<2>(t)), esizes{}, heffects{}
         {
         }
 
         Mutation(constructor_tuple_variable_effects t) noexcept
             : mutation_base(std::get<0>(t),
                             (std::get<1>(t) == 0.) ? true : false,
-                            std::get<4>(t)),
-              g(std::get<3>(t)), s(std::get<1>(t)),
-              h(std::get<2>(t)), esizes{}, heffects{}
+                            std::get<6>(t)),
+              g(std::get<3>(t)), s(std::get<1>(t)), h(std::get<2>(t)),
+              esizes(std::get<4>(t)), heffects(std::get<5>(t))
         {
         }
 
@@ -130,13 +130,13 @@ namespace fwdpp
 {
     namespace io
     {
-        template <> struct serialize_mutation<Mutation>
+        template <> struct serialize_mutation<fwdpy11::Mutation>
         {
             io::scalar_writer writer;
-            serialize_mutation<Mutation>() : writer{} {}
+            serialize_mutation<fwdpy11::Mutation>() : writer{} {}
             template <typename streamtype>
             inline void
-            operator()(streamtype &buffer, const Mutation &m) const
+            operator()(streamtype &buffer, const fwdpy11::Mutation &m) const
             {
                 writer(buffer, &m.g);
                 writer(buffer, &m.pos);
@@ -157,17 +157,17 @@ namespace fwdpp
             }
         };
 
-        template <> struct deserialize_mutation<Mutation>
+        template <> struct deserialize_mutation<fwdpy11::Mutation>
         {
             io::scalar_reader reader;
-            deserialize_mutation<Mutation>() : reader{} {}
+            deserialize_mutation<fwdpy11::Mutation>() : reader{} {}
             template <typename streamtype>
-            inline Mutation
+            inline fwdpy11::Mutation
             operator()(streamtype &buffer) const
             {
                 uint_t g;
                 double pos, s, h;
-                decltype(Mutation::xtra) xtra;
+                decltype(fwdpy11::Mutation::xtra) xtra;
                 io::scalar_reader reader;
                 reader(buffer, &g);
                 reader(buffer, &pos);
@@ -188,8 +188,8 @@ namespace fwdpp
                         hs.resize(ns);
                         reader(buffer, hs.data(), nh);
                     }
-                return Mutation(pos, s, h, g, std::move(ss), std::move(hs),
-                                xtra);
+                return fwdpy11::Mutation(pos, s, h, g, std::move(ss),
+                                         std::move(hs), xtra);
             }
         };
     }

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -1,3 +1,21 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef FWDPY11_MUTATION_TYPE_HPP__
 #define FWDPY11_MUTATION_TYPE_HPP__
 

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -23,6 +23,14 @@
  * This file started off via a copy
  * of fwdpp's popgenmut.hpp
  * by Kevin Thornton.
+ *
+ * This file defines the minimal C++ API
+ * for the type.
+ *
+ * To serialize instaces of this type 
+ * using fwdpp's machinery:
+ *
+ * #include <fwdpy11/serialization/Mutation.hpp>
  */
 
 #include <tuple>
@@ -30,8 +38,6 @@
 #include <vector>
 #include <algorithm>
 #include <fwdpp/forward_types.hpp>
-#include <fwdpp/io/mutation.hpp>
-#include <fwdpp/io/scalar_serialization.hpp>
 
 namespace fwdpy11
 {
@@ -124,74 +130,5 @@ namespace fwdpy11
     };
 }
 
-// Make Mutation compatible with fwdpp's
-// serialization API:
-namespace fwdpp
-{
-    namespace io
-    {
-        template <> struct serialize_mutation<fwdpy11::Mutation>
-        {
-            io::scalar_writer writer;
-            serialize_mutation<fwdpy11::Mutation>() : writer{} {}
-            template <typename streamtype>
-            inline void
-            operator()(streamtype &buffer, const fwdpy11::Mutation &m) const
-            {
-                writer(buffer, &m.g);
-                writer(buffer, &m.pos);
-                writer(buffer, &m.s);
-                writer(buffer, &m.h);
-                writer(buffer, &m.xtra);
-                std::size_t ns = m.esizes.size(), nh = m.heffects.size();
-                writer(buffer, &ns);
-                writer(buffer, &nh);
-                if (ns)
-                    {
-                        writer(buffer, m.esizes.data(), ns);
-                    }
-                if (nh)
-                    {
-                        writer(buffer, m.heffects.data(), nh);
-                    }
-            }
-        };
-
-        template <> struct deserialize_mutation<fwdpy11::Mutation>
-        {
-            io::scalar_reader reader;
-            deserialize_mutation<fwdpy11::Mutation>() : reader{} {}
-            template <typename streamtype>
-            inline fwdpy11::Mutation
-            operator()(streamtype &buffer) const
-            {
-                uint_t g;
-                double pos, s, h;
-                decltype(fwdpy11::Mutation::xtra) xtra;
-                io::scalar_reader reader;
-                reader(buffer, &g);
-                reader(buffer, &pos);
-                reader(buffer, &s);
-                reader(buffer, &h);
-                reader(buffer, &xtra);
-                std::size_t ns, nh;
-                reader(buffer, &ns);
-                reader(buffer, &nh);
-                std::vector<double> ss, hs;
-                if (ns)
-                    {
-                        ss.resize(ns);
-                        reader(buffer, ss.data(), ns);
-                    }
-                if (nh)
-                    {
-                        hs.resize(ns);
-                        reader(buffer, hs.data(), nh);
-                    }
-                return fwdpy11::Mutation(pos, s, h, g, std::move(ss),
-                                         std::move(hs), xtra);
-            }
-        };
-    }
-}
 #endif
+


### PR DESCRIPTION
This PR adds a new mutation type, which will replace the use of `fwdpp::popgenmut`.  This is part of what it takes to address #75.