### PR TITLE
Add diploid fields

### DIFF
--- a/doc/pages/types.rst
+++ b/doc/pages/types.rst
@@ -113,7 +113,9 @@ contains the following read-only properties:
     "g", "Genetic value."
     "e", "Random component of trait value."
     "label", "The index of this diploid in the population."
-    "parental_data", "A Python object with information about parents."
+    "deme", "The deme index of this diploid. New in 0.1.5."
+    "sex", "The sex index of this diploid. New in 0.1.5."
+    "parental_data", "A Python object with information about parents. New in 0.1.4."
 
 The information stored in `parental_data` is simulation-dependent.  For models with no population structure, it will
 typically be a Python tuple containing the `label` value for each parent.  See :ref:`parentage` for an example.

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -32,7 +32,7 @@ namespace fwdpy11
         inline constexpr int
         magic()
         {
-            return 1;
+            return 2;
         }
 
         template <typename poptype>

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -41,11 +41,11 @@ namespace fwdpy11
         {
             std::ostringstream buffer;
             buffer << "fp11";
-			auto m = magic();
-			buffer.write(reinterpret_cast<char*>(&m),sizeof(decltype(m)));
+            auto m = magic();
+            buffer.write(reinterpret_cast<char *>(&m), sizeof(decltype(m)));
             buffer.write(reinterpret_cast<const char *>((&pop->generation)),
                          sizeof(unsigned));
-			fwdpp::io::serialize_population(buffer, *pop);
+            fwdpp::io::serialize_population(buffer, *pop);
             return buffer.str();
         }
 
@@ -73,6 +73,14 @@ namespace fwdpy11
                         buffer.read(reinterpret_cast<char *>(&version),
                                     sizeof(int));
                     }
+                if (version == 1)
+                    {
+                        throw std::runtime_error("File format "
+                                                 "incompatibility: this file "
+                                                 "format version "
+                                                 "was last supported in "
+                                                 "fwdpy11 0.1.4");
+                    }
                 buffer.read(reinterpret_cast<char *>(&pop.generation),
                             sizeof(unsigned));
                 fwdpp::io::deserialize_population(buffer, pop);
@@ -80,11 +88,11 @@ namespace fwdpy11
             }
         };
 
-        // template <typename poptype, typename mwriter_t, typename dipwriter_t>
-        // inline int
-        // gzserialize_details(const poptype &pop, const mwriter_t &mwriter,
-        //                     const dipwriter_t &dipwriter, const char *filename,
-        //                     bool append)
+        // template <typename poptype, typename mwriter_t, typename
+        // dipwriter_t> inline int gzserialize_details(const poptype &pop,
+        // const mwriter_t &mwriter,
+        //                     const dipwriter_t &dipwriter, const char
+        //                     *filename, bool append)
         // {
         //     gzFile f;
         //     if (append)
@@ -96,7 +104,8 @@ namespace fwdpy11
         //             f = gzopen(filename, "wb");
         //         }
         //     auto rv
-        //         = gzwrite(f, reinterpret_cast<const char *>(&pop.generation),
+        //         = gzwrite(f, reinterpret_cast<const char
+        //         *>(&pop.generation),
         //                   sizeof(decltype(pop.generation)));
         //     fwdpp::gzserialize s;
         //     rv += s(f, pop, mwriter, dipwriter);
@@ -109,7 +118,8 @@ namespace fwdpy11
         //     template <typename mreader_t, typename dipreader_t,
         //               typename... constructor_data>
         //     inline poptype
-        //     operator()(const mreader_t &mreader, const dipreader_t &dipreader,
+        //     operator()(const mreader_t &mreader, const dipreader_t
+        //     &dipreader,
         //                const char *filename, std::size_t offset,
         //                constructor_data... cdata) const
         //     {

--- a/fwdpy11/headers/fwdpy11/types/diploid.hpp
+++ b/fwdpy11/headers/fwdpy11/types/diploid.hpp
@@ -1,6 +1,7 @@
 #ifndef FWDPY11_TYPES_DIPLOID_HPP__
 #define FWDPY11_TYPES_DIPLOID_HPP__
 
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 #include <pybind11/pybind11.h>
@@ -25,6 +26,8 @@ namespace fwdpy11
         //! 64 bits of data to do stuff with.  Initialized to zero upon
         //! construction
         std::size_t label;
+        std::uint32_t deme;
+        std::int32_t sex;
         //! Genetic component of trait value.  This is not necessarily written
         //! to by a simulation.
         double g;
@@ -37,29 +40,29 @@ namespace fwdpy11
         pybind11::object parental_data;
         //! Constructor
         diploid_t() noexcept
-            : first(first_type()), second(second_type()), label(0), g(0.),
-              e(0.), w(1.), parental_data(pybind11::none())
+            : first(first_type()), second(second_type()), label(0), deme(0),
+              sex(-1), g(0.), e(0.), w(1.), parental_data(pybind11::none())
         {
         }
         //! Construct from two indexes to gametes
         diploid_t(first_type g1, first_type g2) noexcept
-            : first(g1), second(g2), label(0), g(0.), e(0.), w(1.),
-              parental_data(pybind11::none())
+            : first(g1), second(g2), label(0), deme(0), sex(-1), g(0.), e(0.),
+              w(1.), parental_data(pybind11::none())
         {
         }
 
-        diploid_t(first_type g1, first_type g2, std::size_t label_, double g_,
-                  double e_, double w_)
-            : first(g1), second(g2), label(label_), g(g_), e(e_), w(w_),
-              parental_data(pybind11::none())
+        diploid_t(first_type g1, first_type g2, std::size_t label_,
+                  double deme_, double sex_, double g_, double e_, double w_)
+            : first(g1), second(g2), label(label_), deme(deme_), sex(sex_),
+              g(g_), e(e_), w(w_), parental_data(pybind11::none())
         {
         }
 
         static inline diploid_t
-        create(first_type g1, first_type g2, std::size_t label_, double g_,
-               double e_, double w_)
+        create(first_type g1, first_type g2, std::size_t label_, double deme_,
+               double sex_, double g_, double e_, double w_)
         {
-            return diploid_t(g1, g2, label_, g_, e_, w_);
+            return diploid_t(g1, g2, label_, deme_, sex_, g_, e_, w_);
         }
 
         inline bool
@@ -69,7 +72,8 @@ namespace fwdpy11
             auto cpp_data_comparison
                 = this->first == dip.first && this->second == dip.second
                   && this->w == dip.w && this->g == dip.g && this->e == dip.e
-                  && this->label == dip.label;
+                  && this->label == dip.label && this->deme == dip.deme
+                  && this->sex == dip.sex;
             // We now attempt to compare the parental data.
             // pybind11 doesn't have a rich comparison support,
             // so we rely on the __eq__ attribute.  If no
@@ -111,6 +115,8 @@ namespace fwdpp
                 w(buffer, &dip.e);
                 w(buffer, &dip.w);
                 w(buffer, &dip.label);
+                w(buffer, &dip.deme);
+                w(buffer, &dip.sex);
             }
         };
 
@@ -127,6 +133,8 @@ namespace fwdpp
                 r(buffer, &dip.e);
                 r(buffer, &dip.w);
                 r(buffer, &dip.label);
+                r(buffer, &dip.deme);
+                r(buffer, &dip.sex);
             }
         };
     }

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -154,6 +154,18 @@ PYBIND11_MODULE(fwdpy11_types, m)
                       "Random/environmental effects (read-only).")
         .def_readonly("label", &fwdpy11::diploid_t::label,
                       "Index of the diploid in its deme")
+        .def_readonly("deme", &fwdpy11::diploid_t::deme,
+                R"delim(
+                Deme label for individual.
+
+                .. versionadded:: 0.1.5
+                )delim")
+        .def_readonly("sex", &fwdpy11::diploid_t::sex,
+                R"delim(
+                Sex label for individual.
+
+                .. versionadded:: 0.1.5
+                )delim")
         .def_readonly("parental_data", &fwdpy11::diploid_t::parental_data,
                       R"delim(
 				Python object representing information about parents.


### PR DESCRIPTION
Adds two new data fields to diploid metadata:

* `deme`, which is `std::uint32_t`
* `sex`, which is `std::int32_t`

At the moment, this PR breaks backwards compatibility with serialization formats.  Not sure if we need to address that or not.  Currently, an exception is tossed if the old magic number is encountered.

- [x] Make these fields visible to Python

