### PR TITLE
Update fwdpp

### DIFF
--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -198,7 +198,7 @@ PYBIND11_MODULE(fwdpy11_types, m)
 
     // expose the base classes for population types
     py::class_<fwdpp_popgenmut_base>(m, "SlocusPopMutationBase");
-    py::class_<multilocus_popgenmut_base>(m, "MlocusMutationBase");
+    //py::class_<multilocus_popgenmut_base>(m, "MlocusMutationBase");
     py::class_<singlepop_sugar_base, fwdpp_popgenmut_base>(m, "SinglepopBase");
     py::class_<multilocus_sugar_base, multilocus_popgenmut_base>(m,
                                                                  "MlocusBase");


### PR DESCRIPTION
This PR updates the code base to the current fwdpp/dev, which is currently a pre-release of fwdpp 0.6.0.

- [ ] Get unit test and doc tests working.
- [ ] Generate common base class for all population objects.