### PR TITLE
Integrate new mutation type

### DIFF
--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -30,6 +30,7 @@ from ._opaque_mutations import *
 from ._opaque_diploids import *
 from ._Population import VecUint32
 from .fwdpy11_types import SingleLocusDiploid
+from .fwdpy11_types import Mutation
 from ._regions import *
 from ._dev import *
 from ._gslrng import GSLrng

--- a/fwdpy11/headers/fwdpy11/fitness/single_locus_stateless_fitness.hpp
+++ b/fwdpy11/headers/fwdpy11/fitness/single_locus_stateless_fitness.hpp
@@ -52,9 +52,10 @@ namespace fwdpy11
 #define STATELESS_SLOCUS_FUNCTION(FUNCTION)                                   \
     struct FUNCTION                                                           \
     {                                                                         \
-        inline double operator()(const fwdpy11::Diploid& dip,               \
-                                 const fwdpy11::Population::gcont_t& gametes,             \
-                                 const fwdpy11::Population::mcont_t& mutations) const
+        inline double operator()(                                             \
+            const fwdpy11::Diploid& dip,                                      \
+            const fwdpy11::Population::gcont_t& gametes,                      \
+            const fwdpy11::Population::mcont_t& mutations) const
 
 #define END_STRUCT()                                                          \
     }                                                                         \
@@ -70,7 +71,7 @@ namespace fwdpy11
 #define STATELESS_GENOTYPE_POLICY(FUNCTION)                                   \
     struct FUNCTION                                                           \
     {                                                                         \
-        inline void operator()(double& w, const fwdpp::popgenmut& m) const
+        inline void operator()(double& w, const fwdpy11::Mutation& m) const
 
 #define CREATE_STATELESS_SLOCUS_OBJECT(FUNCTION, FUNCNAME, MODOBJ)            \
     pybind11::                                                                \

--- a/fwdpy11/headers/fwdpy11/policies/mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/policies/mutation.hpp
@@ -1,0 +1,84 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWDPY11_POLICIES_HPP__
+#define FWDPY11_POLICIES_HPP__
+
+#include <fwdpy11/types/Population.hpp>
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpp/internal/recycling.hpp>
+
+namespace fwdpy11
+{
+    template <typename position_function, typename effect_size_function,
+              typename dominance_function>
+    std::size_t
+    infsites_Mutation(std::queue<std::size_t> &recycling_bin,
+                      Population::mcont_t &mutations,
+                      Population::lookup_table_type &lookup,
+                      const fwdpp::uint_t &generation, const double pselected,
+                      const position_function &posmaker,
+                      const effect_size_function &esize_maker,
+                      const dominance_function &hmaker,
+                      const decltype(Mutation::xtra) x = 0)
+    /*!
+     * Mutation function to add a fwdpp::Mutation to a population.
+	 *
+	 * Generate mutations with single effect size.
+	 *
+	 * This implementation is a modification of fwdpp::infsites_popgenmut,
+	 * from the fwdpp library
+     *
+     * In order to use this function, it must be bound to a callable
+     * that is a valid mutation function.  See examples for details.
+     *
+     * \param recycling_bin Recycling queue for mutations.
+     * \param mutations Container of mutations
+     * \param lookup Lookup table for mutation positions
+     * \param generation The generation that is being mutated
+     * \param pselected  The probability that a new mutation affects fitness
+     * \param posmaker A function generating a mutation position.  Must be
+     * convertible to std::function<double()>.
+     * \param esize_maker A function to generate an effect size, given that a
+     * mutation affects fitness. Must be convertible to
+     * std::function<double()>.
+     * \param hmaker A function to generate a dominance value, given that a
+     * mutation affects fitness. Must be convertible to
+     * std::function<double()>.
+     *
+     * \note "Neutral" mutations get assigned a dominance of zero.  The xtra
+     * field is not written to.
+     *
+     * \version 0.6.0
+     * Added to library
+     */
+    {
+        auto pos = posmaker();
+        while (lookup.find(pos) != lookup.end())
+            {
+                pos = posmaker();
+            }
+        lookup.insert(pos);
+        return fwdpp_internal::recycle_mutation_helper(
+            recycling_bin, mutations, pos, (selected) ? esize_maker() : 0.,
+            (selected) ? hmaker() : 0., generation, x);
+    }
+}
+
+#endif

--- a/fwdpy11/headers/fwdpy11/policies/mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/policies/mutation.hpp
@@ -31,19 +31,19 @@ namespace fwdpy11
     std::size_t
     infsites_Mutation(std::queue<std::size_t> &recycling_bin,
                       Population::mcont_t &mutations,
-                      Population::lookup_table_type &lookup,
-                      const fwdpp::uint_t &generation, const double pselected,
+                      Population::lookup_table_t &lookup,
+                      const fwdpp::uint_t &generation,
                       const position_function &posmaker,
                       const effect_size_function &esize_maker,
                       const dominance_function &hmaker,
                       const decltype(Mutation::xtra) x = 0)
     /*!
      * Mutation function to add a fwdpp::Mutation to a population.
-	 *
-	 * Generate mutations with single effect size.
-	 *
-	 * This implementation is a modification of fwdpp::infsites_popgenmut,
-	 * from the fwdpp library
+         *
+         * Generate mutations with single effect size.
+         *
+         * This implementation is a modification of fwdpp::infsites_popgenmut,
+         * from the fwdpp library
      *
      * In order to use this function, it must be bound to a callable
      * that is a valid mutation function.  See examples for details.
@@ -75,9 +75,9 @@ namespace fwdpy11
                 pos = posmaker();
             }
         lookup.insert(pos);
-        return fwdpp_internal::recycle_mutation_helper(
-            recycling_bin, mutations, pos, (selected) ? esize_maker() : 0.,
-            (selected) ? hmaker() : 0., generation, x);
+        return fwdpp::fwdpp_internal::recycle_mutation_helper(
+            recycling_bin, mutations, pos, esize_maker(), hmaker(), generation,
+            x);
     }
 }
 

--- a/fwdpy11/headers/fwdpy11/serialization/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization/Mutation.hpp
@@ -67,7 +67,6 @@ namespace fwdpp
                 uint_t g;
                 double pos, s, h;
                 decltype(fwdpy11::Mutation::xtra) xtra;
-                io::scalar_reader reader;
                 reader(buffer, &g);
                 reader(buffer, &pos);
                 reader(buffer, &s);

--- a/fwdpy11/headers/fwdpy11/types/Mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Mutation.hpp
@@ -27,7 +27,7 @@
  * This file defines the minimal C++ API
  * for the type.
  *
- * To serialize instaces of this type 
+ * To serialize instaces of this type
  * using fwdpp's machinery:
  *
  * #include <fwdpy11/serialization/Mutation.hpp>
@@ -95,9 +95,11 @@ namespace fwdpy11
               esizes(std::forward<vectype>(esizes_)),
               heffects(std::forward<vectype>(heffects_))
         {
-            this->neutral = ((s == 0.0)
-                             || std::all_of(std::begin(this->esizes),
-                                            std::end(this->esizes), 0.0));
+            this->neutral
+                = ((s == 0.0)
+                   && std::all_of(std::begin(this->esizes),
+                                  std::end(this->esizes),
+                                  [](const double d) { return d == 0.; }));
         }
 
         Mutation(constructor_tuple t) noexcept
@@ -107,6 +109,11 @@ namespace fwdpy11
               g(std::get<3>(t)), s(std::get<1>(t)),
               h(std::get<2>(t)), esizes{}, heffects{}
         {
+            this->neutral
+                = ((s == 0.0)
+                   && std::all_of(std::begin(this->esizes),
+                                  std::end(this->esizes),
+                                  [](const double d) { return d == 0.; }));
         }
 
         Mutation(constructor_tuple_variable_effects t) noexcept
@@ -116,6 +123,11 @@ namespace fwdpy11
               g(std::get<3>(t)), s(std::get<1>(t)), h(std::get<2>(t)),
               esizes(std::get<4>(t)), heffects(std::get<5>(t))
         {
+            this->neutral
+                = ((s == 0.0)
+                   && std::all_of(std::begin(this->esizes),
+                                  std::end(this->esizes),
+                                  [](const double d) { return d == 0.; }));
         }
 
         bool
@@ -131,4 +143,3 @@ namespace fwdpy11
 }
 
 #endif
-

--- a/fwdpy11/headers/fwdpy11/types/Population.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Population.hpp
@@ -2,17 +2,17 @@
 #define FWDPY11_POPULATION_HPP__
 
 #include "PyPopulation.hpp"
+#include "Mutation.hpp"
 #include <unordered_set>
 #include <fwdpp/fwd_functional.hpp>
-#include <fwdpp/sugar/popgenmut.hpp>
 
 namespace fwdpy11
 {
 	// Population abstract base class based on
 	// fwdpy11's Mutation type.
     using Population
-        = PyPopulation<fwdpp::popgenmut, std::vector<fwdpp::popgenmut>,
-                       std::vector<fwdpp::gamete>, std::vector<fwdpp::popgenmut>,
+        = PyPopulation<Mutation, std::vector<Mutation>,
+                       std::vector<fwdpp::gamete>, std::vector<Mutation>,
                        std::vector<fwdpp::uint_t>,
                        std::unordered_set<double, std::hash<double>,
                                           fwdpp::equal_eps>>;

--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -25,6 +25,7 @@
 #include <fwdpy11/types/MlocusPop.hpp>
 #include <fwdpy11/types/create_pops.hpp>
 #include <fwdpy11/serialization.hpp>
+#include <fwdpy11/serialization/Mutation.hpp>
 #include <fwdpy11/serialization/Diploid.hpp>
 #include <fwdpp/sugar/sampling.hpp>
 #include "get_individuals.hpp"

--- a/fwdpy11/src/_opaque_mutations.cc
+++ b/fwdpy11/src/_opaque_mutations.cc
@@ -20,42 +20,41 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
-#include <fwdpp/sugar/popgenmut.hpp>
+#include <fwdpy11/types/Mutation.hpp>
 
 namespace py = pybind11;
 
-struct flattened_popgenmut
+struct flattened_Mutation
 {
     double pos, s, h;
     fwdpp::uint_t g;
-    decltype(fwdpp::popgenmut::xtra) label;
+    decltype(fwdpy11::Mutation::xtra) label;
     std::int8_t neutral;
 };
 
-PYBIND11_MAKE_OPAQUE(std::vector<fwdpp::popgenmut>);
-PYBIND11_MAKE_OPAQUE(std::vector<flattened_popgenmut>);
+PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Mutation>);
+PYBIND11_MAKE_OPAQUE(std::vector<flattened_Mutation>);
 
 PYBIND11_MODULE(_opaque_mutations, m)
 {
     m.doc()
         = "Expose C++ vectors of Mutation objects to Python without copies.";
 
-    PYBIND11_NUMPY_DTYPE(flattened_popgenmut, pos, s, h, g, label, neutral);
+    PYBIND11_NUMPY_DTYPE(flattened_Mutation, pos, s, h, g, label, neutral);
 
-    py::bind_vector<std::vector<fwdpp::popgenmut>>(
-        m, "VecMutation",
-        "C++ representation of a list of "
-        ":class:`fwdpy11.Mutation`.  "
-        "Typically, access will be read-only.",
+    py::bind_vector<std::vector<fwdpy11::Mutation>>(
+        m, "VecMutation", "C++ representation of a list of "
+                          ":class:`fwdpy11.Mutation`.  "
+                          "Typically, access will be read-only.",
         py::module_local(false))
         .def("array",
-             [](const std::vector<fwdpp::popgenmut>& mc) {
-                 std::vector<flattened_popgenmut> rv;
+             [](const std::vector<fwdpy11::Mutation>& mc) {
+                 std::vector<flattened_Mutation> rv;
                  rv.reserve(mc.size());
                  for (auto&& m : mc)
                      {
-                         rv.push_back(flattened_popgenmut{
-                             m.pos, m.s, m.h, m.g, m.xtra, m.neutral });
+                         rv.push_back(flattened_Mutation{ m.pos, m.s, m.h, m.g,
+                                                          m.xtra, m.neutral });
                      }
                  return rv;
              },
@@ -68,7 +67,7 @@ PYBIND11_MODULE(_opaque_mutations, m)
         .. versionadded: 0.1.2
         )delim")
         .def(py::pickle(
-            [](const std::vector<fwdpp::popgenmut>& mutations) {
+            [](const std::vector<fwdpy11::Mutation>& mutations) {
                 py::list rv;
                 for (auto&& i : mutations)
                     {
@@ -77,15 +76,15 @@ PYBIND11_MODULE(_opaque_mutations, m)
                 return rv;
             },
             [](py::list l) {
-                std::vector<fwdpp::popgenmut> rv;
+                std::vector<fwdpy11::Mutation> rv;
                 for (auto&& i : l)
                     {
-                        rv.push_back(i.cast<fwdpp::popgenmut>());
+                        rv.push_back(i.cast<fwdpy11::Mutation>());
                     }
                 return rv;
             }));
 
-    py::bind_vector<std::vector<flattened_popgenmut>>(
+    py::bind_vector<std::vector<flattened_Mutation>>(
         m, "VecMutationDtype", py::buffer_protocol(), py::module_local(false),
         R"delim(
         Vector of the data fields in a "

--- a/fwdpy11/src/fwdpp_extensions.cc
+++ b/fwdpy11/src/fwdpp_extensions.cc
@@ -24,8 +24,9 @@
 #include <pybind11/stl.h>
 #include <fwdpy11/types/SlocusPop.hpp>
 #include <fwdpy11/types/MlocusPop.hpp>
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpy11/policies/mutation.hpp>
 #include <fwdpy11/rng.hpp>
-#include <fwdpp/sugar/popgenmut.hpp>
 #include <fwdpp/extensions/callbacks.hpp>
 #include <fwdpp/extensions/regions.hpp>
 
@@ -124,132 +125,114 @@ PYBIND11_MODULE(fwdpp_extensions, m)
     // start, stop, weight, label
     using mutregion_tuple = std::tuple<double, double, double,
                                        decltype(fwdpp::mutation_base::xtra)>;
-    using mutfunction = fwdpp::extensions::discrete_mut_model<
-        std::vector<fwdpp::popgenmut>>::function_type;
+    using mutfunction = fwdpp::extensions::
+        discrete_mut_model<std::vector<fwdpy11::Mutation>>::function_type;
 
-    //This is a hack-ish means of doing things.
-    //Once we have a proper base class in place, 
-    //we can reduce what is below to a single function
-    //taking const ref to base.
-    py::class_<
-        fwdpp::extensions::discrete_mut_model<std::vector<fwdpp::popgenmut>>>(
+    // This is a hack-ish means of doing things.
+    // Once we have a proper base class in place,
+    // we can reduce what is below to a single function
+    // taking const ref to base.
+    py::class_<fwdpp::extensions::
+                   discrete_mut_model<std::vector<fwdpy11::Mutation>>>(
         m, "MutationRegions")
-        .def(py::init(
-            [](const fwdpy11::GSLrng_t &r, fwdpy11::SlocusPop &pop,
-               const std::vector<mutregion_tuple> &neutral_mut_regions,
-               const std::vector<mutregion_tuple> &selected_mut_regions,
-               std::vector<fwdpp::extensions::shmodel> &dist_effect_sizes) {
-                std::vector<mutfunction> functions;
-                std::vector<double> weights;
-                for (auto &&i : neutral_mut_regions)
-                    {
-                        auto start = std::get<0>(i);
-                        auto stop = std::get<1>(i);
-                        auto label = std::get<3>(i);
-                        weights.push_back(std::get<2>(i));
-                        auto mf
-                            = [&r, &pop, start, stop, label](
-                                  std::queue<std::size_t> &recbin,
-                                  fwdpy11::SlocusPop::mcont_t &mutations) {
-                                  return fwdpp::infsites_popgenmut(
-                                      recbin, mutations, r.get(),
-                                      pop.mut_lookup, pop.generation, 0,
-                                      [&r, start, stop]() {
-                                          return gsl_ran_flat(r.get(), start,
-                                                              stop);
-                                      },
-                                      []() { return 0.; }, []() { return 1.; },
-                                      label);
-                              };
-                        functions.push_back(std::move(mf));
-                    }
-                for (std::size_t i = 0; i < selected_mut_regions.size(); ++i)
-                    {
-                        auto start = std::get<0>(selected_mut_regions.at(i));
-                        auto stop = std::get<1>(selected_mut_regions.at(i));
-                        auto label = std::get<3>(selected_mut_regions.at(i));
-                        auto sh = dist_effect_sizes.at(i);
-                        weights.push_back(
-                            std::get<2>(selected_mut_regions.at(i)));
-                        auto mf
-                            = [&r, &pop, start, stop, label,
+        .def(py::init([](
+            const fwdpy11::GSLrng_t &r, fwdpy11::SlocusPop &pop,
+            const std::vector<mutregion_tuple> &neutral_mut_regions,
+            const std::vector<mutregion_tuple> &selected_mut_regions,
+            std::vector<fwdpp::extensions::shmodel> &dist_effect_sizes) {
+            std::vector<mutfunction> functions;
+            std::vector<double> weights;
+            for (auto &&i : neutral_mut_regions)
+                {
+                    auto start = std::get<0>(i);
+                    auto stop = std::get<1>(i);
+                    auto label = std::get<3>(i);
+                    weights.push_back(std::get<2>(i));
+                    auto mf = [&r, &pop, start, stop,
+                               label](std::queue<std::size_t> &recbin,
+                                      fwdpy11::SlocusPop::mcont_t &mutations) {
+                        return fwdpy11::infsites_Mutation(
+                            recbin, mutations, pop.mut_lookup, pop.generation,
+                            [&r, start, stop]() {
+                                return gsl_ran_flat(r.get(), start, stop);
+                            },
+                            []() { return 0.; }, []() { return 1.; }, label);
+                    };
+                    functions.push_back(std::move(mf));
+                }
+            for (std::size_t i = 0; i < selected_mut_regions.size(); ++i)
+                {
+                    auto start = std::get<0>(selected_mut_regions.at(i));
+                    auto stop = std::get<1>(selected_mut_regions.at(i));
+                    auto label = std::get<3>(selected_mut_regions.at(i));
+                    auto sh = dist_effect_sizes.at(i);
+                    weights.push_back(std::get<2>(selected_mut_regions.at(i)));
+                    auto mf = [&r, &pop, start, stop, label,
                                sh](std::queue<std::size_t> &recbin,
                                    fwdpy11::SlocusPop::mcont_t &mutations) {
-                                  return fwdpp::infsites_popgenmut(
-                                      recbin, mutations, r.get(),
-                                      pop.mut_lookup, pop.generation, 1.,
-                                      [&r, start, stop]() {
-                                          return gsl_ran_flat(r.get(), start,
-                                                              stop);
-                                      },
-                                      [&r, sh]() { return sh.s(r.get()); },
-                                      [&r, sh]() { return sh.h(r.get()); },
-                                      label);
-                              };
-                        functions.push_back(std::move(mf));
-                    }
-                return fwdpp::extensions::discrete_mut_model<
-                    fwdpy11::SlocusPop::mcont_t>(std::move(functions),
-                                                   std::move(weights));
-            }))
-        .def(py::init(
-            [](const fwdpy11::GSLrng_t &r, fwdpy11::MlocusPop &pop,
-               const std::vector<mutregion_tuple> &neutral_mut_regions,
-               const std::vector<mutregion_tuple> &selected_mut_regions,
-               std::vector<fwdpp::extensions::shmodel> &dist_effect_sizes) {
-                std::vector<mutfunction> functions;
-                std::vector<double> weights;
-                for (auto &&i : neutral_mut_regions)
-                    {
-                        auto start = std::get<0>(i);
-                        auto stop = std::get<1>(i);
-                        auto label = std::get<3>(i);
-                        weights.push_back(std::get<2>(i));
-                        auto mf
-                            = [&r, &pop, start, stop, label](
-                                  std::queue<std::size_t> &recbin,
-                                  fwdpy11::MlocusPop::mcont_t &mutations) {
-                                  return fwdpp::infsites_popgenmut(
-                                      recbin, mutations, r.get(),
-                                      pop.mut_lookup, pop.generation, 0,
-                                      [&r, start, stop]() {
-                                          return gsl_ran_flat(r.get(), start,
-                                                              stop);
-                                      },
-                                      []() { return 0.; }, []() { return 1.; },
-                                      label);
-                              };
-                        functions.push_back(std::move(mf));
-                    }
-                for (std::size_t i = 0; i < selected_mut_regions.size(); ++i)
-                    {
-                        auto start = std::get<0>(selected_mut_regions.at(i));
-                        auto stop = std::get<1>(selected_mut_regions.at(i));
-                        auto label = std::get<2>(selected_mut_regions.at(i));
-                        auto sh = dist_effect_sizes.at(i);
-                        weights.push_back(
-                            std::get<2>(selected_mut_regions.at(i)));
-                        auto mf
-                            = [&r, &pop, start, stop, label,
+                        return fwdpy11::infsites_Mutation(
+                            recbin, mutations, pop.mut_lookup, pop.generation,
+                            [&r, start, stop]() {
+                                return gsl_ran_flat(r.get(), start, stop);
+                            },
+                            [&r, sh]() { return sh.s(r.get()); },
+                            [&r, sh]() { return sh.h(r.get()); }, label);
+                    };
+                    functions.push_back(std::move(mf));
+                }
+            return fwdpp::extensions::
+                discrete_mut_model<fwdpy11::SlocusPop::mcont_t>(
+                    std::move(functions), std::move(weights));
+        }))
+        .def(py::init([](
+            const fwdpy11::GSLrng_t &r, fwdpy11::MlocusPop &pop,
+            const std::vector<mutregion_tuple> &neutral_mut_regions,
+            const std::vector<mutregion_tuple> &selected_mut_regions,
+            std::vector<fwdpp::extensions::shmodel> &dist_effect_sizes) {
+            std::vector<mutfunction> functions;
+            std::vector<double> weights;
+            for (auto &&i : neutral_mut_regions)
+                {
+                    auto start = std::get<0>(i);
+                    auto stop = std::get<1>(i);
+                    auto label = std::get<3>(i);
+                    weights.push_back(std::get<2>(i));
+                    auto mf = [&r, &pop, start, stop,
+                               label](std::queue<std::size_t> &recbin,
+                                      fwdpy11::MlocusPop::mcont_t &mutations) {
+                        return fwdpy11::infsites_Mutation(
+                            recbin, mutations, pop.mut_lookup, pop.generation,
+                            [&r, start, stop]() {
+                                return gsl_ran_flat(r.get(), start, stop);
+                            },
+                            []() { return 0.; }, []() { return 1.; }, label);
+                    };
+                    functions.push_back(std::move(mf));
+                }
+            for (std::size_t i = 0; i < selected_mut_regions.size(); ++i)
+                {
+                    auto start = std::get<0>(selected_mut_regions.at(i));
+                    auto stop = std::get<1>(selected_mut_regions.at(i));
+                    auto label = std::get<2>(selected_mut_regions.at(i));
+                    auto sh = dist_effect_sizes.at(i);
+                    weights.push_back(std::get<2>(selected_mut_regions.at(i)));
+                    auto mf = [&r, &pop, start, stop, label,
                                sh](std::queue<std::size_t> &recbin,
                                    fwdpy11::MlocusPop::mcont_t &mutations) {
-                                  return fwdpp::infsites_popgenmut(
-                                      recbin, mutations, r.get(),
-                                      pop.mut_lookup, pop.generation, 1.,
-                                      [&r, start, stop]() {
-                                          return gsl_ran_flat(r.get(), start,
-                                                              stop);
-                                      },
-                                      [&r, sh]() { return sh.s(r.get()); },
-                                      [&r, sh]() { return sh.h(r.get()); },
-                                      label);
-                              };
-                        functions.push_back(std::move(mf));
-                    }
-                return fwdpp::extensions::discrete_mut_model<
-                    fwdpy11::MlocusPop::mcont_t>(std::move(functions),
-                                                    std::move(weights));
-            }));
+                        return fwdpy11::infsites_Mutation(
+                            recbin, mutations, pop.mut_lookup, pop.generation,
+                            [&r, start, stop]() {
+                                return gsl_ran_flat(r.get(), start, stop);
+                            },
+                            [&r, sh]() { return sh.s(r.get()); },
+                            [&r, sh]() { return sh.h(r.get()); }, label);
+                    };
+                    functions.push_back(std::move(mf));
+                }
+            return fwdpp::extensions::
+                discrete_mut_model<fwdpy11::MlocusPop::mcont_t>(
+                    std::move(functions), std::move(weights));
+        }));
 
     py::class_<fwdpp::extensions::discrete_rec_model>(m,
                                                       "RecombinationRegions")

--- a/fwdpy11/src/fwdpp_types.cc
+++ b/fwdpy11/src/fwdpp_types.cc
@@ -21,7 +21,6 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 #include <fwdpp/forward_types.hpp>
-#include <fwdpp/sugar/popgenmut.hpp>
 
 namespace py = pybind11;
 
@@ -131,99 +130,4 @@ PYBIND11_MODULE(fwdpp_types, m)
         .def("__eq__", [](const fwdpp::gamete &a, const fwdpp::gamete &b) {
             return a == b;
         });
-
-    // Sugar types
-    py::class_<fwdpp::popgenmut, fwdpp::mutation_base>(
-        m, "Mutation", "Mutation with effect size and dominance")
-        .def(py::init<double, double, double, unsigned, std::uint16_t>(),
-             py::arg("pos"), py::arg("s"), py::arg("h"), py::arg("g"),
-             py::arg("label"),
-             R"delim(
-                Construct a mutations.
-
-                :param pos: Mutation position (float)
-                :param s: Effect size (float)
-                :param h: Dominance term (float)
-                :param g: Origin time (unsigned integer)
-                :param label: Label (16 bit integer)
-
-                .. testcode::
-
-                    import fwdpy11
-                    m = fwdpy11.Mutation(1.0, -1.0, 0.25, 0, 0)
-                    print(m.pos)
-                    print(m.s)
-                    print(m.h)
-                    print(m.g)
-                    print(m.label)
-
-                .. testoutput::
-                    
-                    1.0
-                    -1.0
-                    0.25
-                    0
-                    0
-                )delim")
-        .def(py::init<fwdpp::popgenmut::constructor_tuple>(),
-             R"delim(
-                Construct mutation from a tuple.
-
-                The tuple should contain (pos, s, h, g, label)
-
-                .. testcode::
-
-                    import fwdpy11
-                    m = fwdpy11.Mutation((1.0, -1.0, 0.25, 0, 0))
-                    print(m.pos)
-                    print(m.s)
-                    print(m.h)
-                    print(m.g)
-                    print(m.label)
-
-                .. testoutput::
-                    
-                    1.0
-                    -1.0
-                    0.25
-                    0
-                    0
-                )delim")
-        .def_readonly(
-            "g", &fwdpp::popgenmut::g,
-            "Generation when mutation arose (origination time). (read-only)")
-        .def_readonly("s", &fwdpp::popgenmut::s,
-                      "Selection coefficient/effect size. (read-only)")
-        .def_readonly("h", &fwdpp::popgenmut::h,
-                      "Dominance/effect in heterozygotes. (read-only)")
-        .def_property_readonly(
-            "key",
-            [](const fwdpp::popgenmut &m) {
-                return py::make_tuple(m.pos, m.s, m.g);
-            },
-            R"delim(It is often useful to have a unique key for
-                    tracking mutations.  This property returns 
-                    the tuple (pos, esize, origin).
-
-                    .. versionadded:: 0.1.3.a1
-                   )delim")
-        .def(py::pickle(
-            [](const fwdpp::popgenmut &m) {
-                return py::make_tuple(m.pos, m.s, m.h, m.g, m.xtra);
-            },
-            [](py::tuple p) {
-                return std::unique_ptr<fwdpp::popgenmut>(new fwdpp::popgenmut(
-                    p[0].cast<double>(), p[1].cast<double>(),
-                    p[2].cast<double>(), p[3].cast<unsigned>(),
-                    p[4].cast<std::uint16_t>()));
-            }))
-        .def("__str__",
-             [](const fwdpp::popgenmut &m) {
-                 return "Mutation[" + std::to_string(m.pos) + ","
-                        + std::to_string(m.s) + "," + std::to_string(m.h) + ","
-                        + std::to_string(m.g) + "," + std::to_string(m.xtra)
-                        + "]";
-             })
-        .def("__eq__", [](const fwdpp::popgenmut &a,
-                          const fwdpp::popgenmut &b) { return a == b; });
 }

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -101,7 +101,22 @@ PYBIND11_MODULE(fwdpy11_types, m)
                                           std::move(heffects_), label);
              }),
              py::arg("pos"), py::arg("s"), py::arg("h"), py::arg("g"),
-             py::arg("esizes"), py::arg("heffects"), py::arg("label"))
+             py::arg("esizes"), py::arg("heffects"), py::arg("label"),
+             R"delim(
+			 Construct a mutation with both a constant effect and/or
+			 a vector of effects.
+
+			 :param pos: Mutation position (float)
+			 :param s: Effect size (float)
+			 :param h: Dominance term (float)
+			 :param g: Origin time (unsigned integer)
+			 :param esizes: List of effect sizes (list of float)
+			 :param heffects: List of heterozygouse effects (list of float)
+			 :param label: Label (16 bit integer)
+				
+			 .. versionadded:: 0.1.5
+
+			 )delim")
         .def(py::init<fwdpy11::Mutation::constructor_tuple>(),
              R"delim(
                 Construct mutation from a tuple.

--- a/tests/pickling_cpp.cpp
+++ b/tests/pickling_cpp.cpp
@@ -17,13 +17,13 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
 // clang-format on
 
 #include <pybind11/pybind11.h>
-#include <fwdpp/sugar/popgenmut.hpp>
+#include <fwdpy11/types/Mutation.hpp>
 
 namespace py = pybind11;
 
 //Example of pickling a specific C++ type
 py::bytes
-pickle_mutation(const fwdpp::popgenmut& p)
+pickle_mutation(const fwdpy11::Mutation& p)
 {
     py::object m = py::cast<decltype(p)>(p);
     return py::module::import("pickle").attr("dumps")(m);

--- a/tests/test_Mutation.py
+++ b/tests/test_Mutation.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest
+import fwdpy11
+import pickle
+
+
+class testSingleEffectMutation(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.m = fwdpy11.Mutation((1.0, -1.0, 0.25, 0, 13))
+
+    def testConstruct(self):
+        self.assertEqual(self.m.pos, 1.0)
+        self.assertEqual(self.m.s, -1.0)
+        self.assertEqual(self.m.h, 0.25)
+        self.assertEqual(self.m.g, 0)
+        self.assertEqual(self.m.label, 13)
+        self.assertEqual(len(self.m.esizes), 0)
+        self.assertEqual(len(self.m.heffects), 0)
+
+    def testPickle(self):
+        p = pickle.dumps(self.m)
+        up = pickle.loads(p)
+        self.assertEqual(up, self.m)
+
+
+class testMultiEffectMutation(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.m = fwdpy11.Mutation(1.0, -1.0, 0.25, 0, [1., 2.], [-1.0, 1./3.], 13)
+
+    def testConstruct(self):
+        self.assertEqual(self.m.pos, 1.0)
+        self.assertEqual(self.m.s, -1.0)
+        self.assertEqual(self.m.h, 0.25)
+        self.assertEqual(self.m.g, 0)
+        self.assertEqual(self.m.label, 13)
+        self.assertEqual(len(self.m.esizes), 2)
+        self.assertEqual(len(self.m.heffects), 2)
+
+    def testPickle(self):
+        p = pickle.dumps(self.m)
+        up = pickle.loads(p)
+        self.assertEqual(up, self.m)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_Mutation.py
+++ b/tests/test_Mutation.py
@@ -45,7 +45,8 @@ class testSingleEffectMutation(unittest.TestCase):
 class testMultiEffectMutation(unittest.TestCase):
     @classmethod
     def setUp(self):
-        self.m = fwdpy11.Mutation(1.0, -1.0, 0.25, 0, [1., 2.], [-1.0, 1./3.], 13)
+        self.m = fwdpy11.Mutation(
+            1.0, -1.0, 0.25, 0, [1., 2.], [-1.0, 1. / 3.], 13)
 
     def testConstruct(self):
         self.assertEqual(self.m.pos, 1.0)
@@ -60,6 +61,61 @@ class testMultiEffectMutation(unittest.TestCase):
         p = pickle.dumps(self.m)
         up = pickle.loads(p)
         self.assertEqual(up, self.m)
+
+
+class testMultiEffectMutationSlocusPopPickling(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        mutations = fwdpy11.VecMutation()
+        fixations = fwdpy11.VecMutation()
+        gametes = fwdpy11.VecGamete()
+        diploids = fwdpy11.VecDiploid()
+        mutations.append(fwdpy11.Mutation(
+            0.1, -0.01, 1.0, 0, [-1., 2.], [5., 4.], 0))
+        fixations.append(fwdpy11.Mutation(
+            0.1, -0.01, 1.0, 0, [-1., 2.], [5., 4.], 0))
+        gametes.append(fwdpy11.Gamete(
+            (2, fwdpy11.VecUint32([]), fwdpy11.VecUint32([0]))))
+        diploids.append(fwdpy11.SingleLocusDiploid(0, 0))
+        ftimes = fwdpy11.VecUint32([1])
+        self.pop = fwdpy11.SlocusPop.create(diploids,
+                                            gametes,
+                                            mutations,
+                                            fixations,
+                                            ftimes, 2)
+
+    def testPickle(self):
+        p = pickle.dumps(self.pop)
+        up = pickle.loads(p)
+        self.assertEqual(self.pop, up)
+
+
+class testMultiEffectMutationMlocusPopPickling(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        mutations = fwdpy11.VecMutation()
+        fixations = fwdpy11.VecMutation()
+        gametes = fwdpy11.VecGamete()
+        diploids = fwdpy11.VecVecDiploid()
+        mutations.append(fwdpy11.Mutation(
+            0.1, -0.01, 1.0, 0, [-1., 2.], [5., 4.], 0))
+        fixations.append(fwdpy11.Mutation(
+            0.1, -0.01, 1.0, 0, [-1., 2.], [5., 4.], 0))
+        gametes.append(fwdpy11.Gamete(
+            (4, fwdpy11.VecUint32([]), fwdpy11.VecUint32([0]))))
+        diploids.append(fwdpy11.VecDiploid(
+            [fwdpy11.SingleLocusDiploid(0, 0)] * 2))
+        ftimes = fwdpy11.VecUint32([1])
+        self.pop = fwdpy11.MlocusPop.create(diploids,
+                                            gametes,
+                                            mutations,
+                                            fixations,
+                                            ftimes, 2)
+
+    def testPickle(self):
+        p = pickle.dumps(self.pop)
+        up = pickle.loads(p)
+        self.assertEqual(self.pop, up)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_genetic_values.py
+++ b/tests/test_python_genetic_values.py
@@ -48,7 +48,7 @@ class testCustomAdditive(unittest.TestCase):
         our C++ implementation.
         """
         for i in self.pop.diploids:
-            self.assertEqual(self.acpp(i, self.pop), self.a(i, self.pop))
+            self.assertAlmostEqual(self.acpp(i, self.pop), self.a(i, self.pop))
 
 
 class testAdditiveEvolution(unittest.TestCase):


### PR DESCRIPTION
This replaces `fwdpp::popgenmut` with `fwdpy11::Mutation` as fwdpy11's `Mutation` type.  #75