### PR TITLE
make VecUint32 opaque and bound via buffer protocol for [S|M]locusPop

### DIFF
--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -55,12 +55,33 @@ PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Diploid>);
 PYBIND11_MAKE_OPAQUE(std::vector<std::vector<fwdpy11::Diploid>>);
 PYBIND11_MAKE_OPAQUE(fwdpy11::SlocusPop::gcont_t);
 PYBIND11_MAKE_OPAQUE(fwdpy11::SlocusPop::mcont_t);
-PYBIND11_MAKE_OPAQUE(fwdpy11::SlocusPop::mcount_t);
+PYBIND11_MAKE_OPAQUE(std::vector<fwdpp::uint_t>);
 
 PYBIND11_MODULE(_Populations, m)
 {
     py::object base_class_module
         = (pybind11::object)pybind11::module::import("fwdpy11._Population");
+
+    py::bind_vector<std::vector<fwdpp::uint_t>>(
+        m, "VecUint32", "Vector of unsigned 32-bit integers.",
+        py::buffer_protocol())
+        .def(py::pickle(
+            [](const std::vector<fwdpp::uint_t>& v) {
+                py::list rv;
+                for (auto&& i : v)
+                    {
+                        rv.append(i);
+                    }
+                return rv;
+            },
+            [](py::list l) {
+                std::vector<fwdpp::uint_t> rv;
+                for (auto&& i : l)
+                    {
+                        rv.push_back(i.cast<fwdpp::uint_t>());
+                    }
+                return rv;
+            }));
 
     py::class_<fwdpy11::SlocusPop, fwdpy11::Population>(
         m, "_SlocusPop", "Representation of a single-locus population")


### PR DESCRIPTION
Updates some modules so that opaque containers and buffer protocols give the performance boost that is expected.