### PR TITLE
Refactor long tests

### DIFF
--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -97,10 +97,12 @@ namespace fwdpy11
             : Population(static_cast<fwdpp::uint_t>(d.size()),
                          std::forward<gametes_input>(g),
                          std::forward<mutations_input>(m), 100),
-              diploids(std::forward<diploids_input>(d))
+              diploids(std::forward<diploids_input>(d)),
+			  nloci{}
         //! Constructor for pre-determined population status
         {
             this->process_individual_input();
+			nloci = diploids.at(0).size();
         }
 
         bool

--- a/tests/fixation_properties.cpp
+++ b/tests/fixation_properties.cpp
@@ -1,0 +1,38 @@
+// clang-format off
+<% 
+setup_pybind11(cfg) 
+#import fwdpy11 so we can find its C++ headers
+import fwdpy11 as fp11 
+#add fwdpy11 header locations to the include path
+cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
+#On OS X using clang, there is more work to do.  Using gcc on OS X
+#gets rid of these requirements. The specifics sadly depend on how
+#you initially built fwdpy11, and what is below assumes you used
+#the provided setup.py + OS X + clang:
+#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
+#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
+#An alternative to the above is to add the first line to CPPFLAGS
+#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+%>
+// clang-format on
+
+#include <fwdpy11/sim_functions.hpp>
+#include <fwdpy11/types/SlocusPop.hpp>
+#include <fwdpy11/types/MlocusPop.hpp>
+
+    namespace py = pybind11;
+
+void
+update_mutations(fwdpy11::Population& pop, const unsigned generation,
+                 const unsigned twoN, const bool remove_selected_fixations)
+// Expose some of fwdpy11's internal workings for unit testing
+{
+    fwdpy11::update_mutations(pop.mutations, pop.fixations, pop.fixation_times,
+                              pop.mut_lookup, pop.mcounts, generation, twoN,
+                              remove_selected_fixations);
+}
+
+PYBIND11_MODULE(fixation_properties, m)
+{
+    m.def("update_mutations", &update_mutations);
+}

--- a/tests/test_fixation_properties.py
+++ b/tests/test_fixation_properties.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Test behavior of fixations in simulations.
 # As of 0.1.3a1, fixations are to be sorted by position
 # for all types of simulations, allowing for easier lookup.

--- a/tests/test_fixation_properties.py
+++ b/tests/test_fixation_properties.py
@@ -19,128 +19,128 @@
 # Test behavior of fixations in simulations.
 # As of 0.1.3a1, fixations are to be sorted by position
 # for all types of simulations, allowing for easier lookup.
+#
+# In 0.1.5, this unit test was refactored to skip simulation.
+# Instead, we use pybind11 + cppimport to expose the underlying
+# C++ API to Python, create pops manually, and test the API.
 
 import unittest
 import os
 import fwdpy11
-import fwdpy11.util
-import fwdpy11.wright_fisher_qtrait
-import numpy as np
-from quick_pops import quick_nonneutral_slocus
-from quick_pops import quick_slocus_qtrait_pop_params
-from quick_pops import quick_mlocus_qtrait_change_optimum
+import cppimport
+cppimport.force_rebuild()
+fp = cppimport.imp("fixation_properties")
 
 
-class testFixationsAreSorted(unittest.TestCase):
-    def test_fixations_SlocusPop(self):
-        from fwdpy11 import ExpS
-        pop = quick_nonneutral_slocus(N=1000,
-                                      simlen=10000,
-                                      dfe=ExpS(0, 1, 1, 0.05))
-        self.assertTrue(len(pop.fixations) > 0)
-        self.assertEqual(len(pop.fixations), len(pop.fixation_times))
-        fpos = [i.pos for i in pop.fixations]
-        self.assertTrue(sorted(fpos))
-        non_neutral_fixations = [
-            i.key for i in pop.fixations if i.neutral is False]
-        # If this test fails, we have sim parameters
-        # that are not useful for testing:
-        self.assertTrue(len(non_neutral_fixations) > 0)
-        for ni in non_neutral_fixations:
-            for i, j in zip(pop.mutations, pop.mcounts):
-                if ni == i.key:
-                    self.assertEqual(j, 0)
-
-
-class testFixationsAreSortedQtraitSim(unittest.TestCase):
-    """
-    In sims of quantitative traits, selected mutations are
-    retained, as they still affect mean trait value, and thus
-    mean distance from optimum, and thus mean fitness.
-    However, they are entered into pop.fixations so that
-    their fixation times may be recorded.
-    """
-
-    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
-                     "Skipping this test on Travis CI.")
-    def test_sorted_fixations_MlocusPopQtrait_without_pruning(self):
-        pop = quick_mlocus_qtrait_change_optimum(N=1000, simlen=10000)
-        self.assertTrue(len(pop.fixations) > 0)
-        self.assertEqual(len(pop.fixations), len(pop.fixation_times))
-        fpos = [i.pos for i in pop.fixations]
-        self.assertTrue(sorted(fpos))
-        non_neutral_fixations = [
-            i.key for i in pop.fixations if i.neutral is False]
-        # If this test fails, we have sim parameters
-        # that are not useful for testing:
-        self.assertTrue(len(non_neutral_fixations) > 0)
-        for ni in non_neutral_fixations:
-            # These non-neutral fixations
-            # must still be found in the pop.
-            for i, j in zip(pop.mutations, pop.mcounts):
-                if i.key == ni:
-                    self.assertEqual(j, 2*pop.N)
-        neutral_fixations = [i.key for i in pop.fixations if i.neutral is True]
-        self.assertTrue(len(neutral_fixations) > 0)
-        for ni in neutral_fixations:
-            for i, j in zip(pop.mutations, pop.mcounts):
-                if i.key == ni:
-                    self.assertEqual(j, 0)
-
-    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
-                     "Skipping this test on Travis CI.")
-    def test_sorted_fixations_MlocusPopQtrait_with_pruning(self):
-        import warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            pop = quick_mlocus_qtrait_change_optimum(
-                N=1000, simlen=10000, prune_selected=True)
-            self.assertTrue(len(pop.fixations) > 0)
-            self.assertEqual(len(pop.fixations), len(pop.fixation_times))
-            fpos = [i.pos for i in pop.fixations]
-            self.assertTrue(sorted(fpos))
-            non_neutral_fixations = [
-                i.key for i in pop.fixations if i.neutral is False]
-            # If this test fails, we have sim parameters
-            # that are not useful for testing:
-            self.assertTrue(len(non_neutral_fixations) > 0)
-            for ni in non_neutral_fixations:
-                for i, j in zip(pop.mutations, pop.mcounts):
-                    if i.key == ni:
-                        self.assertEqual(j, 0)
-            neutral_fixations = [
-                i.key for i in pop.fixations if i.neutral is True]
-            self.assertTrue(len(neutral_fixations) > 0)
-            for ni in neutral_fixations:
-                for i, j in zip(pop.mutations, pop.mcounts):
-                    if i.key == ni:
-                        self.assertEqual(j, 0)
-
-
-class tests_MultipleFixationsAtPosition(unittest.TestCase):
+class testFixationsAreSortedSlocusPop(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
-        from fwdpy11.model_params import SlocusParamsQ
-        self.pop, self.pdict = quick_slocus_qtrait_pop_params()
-        self.params = SlocusParamsQ(**self.pdict)
-        self.params.demography = np.array([self.pop.N], dtype=np.uint32)
-        self.params.mutrate_n = 0.0  # disallow neutral mutations
-        self.rng = fwdpy11.GSLrng(42)
-        fwdpy11.util.add_mutation(
-            self.rng, self.pop, 2 * self.pop.N, (0.1, 0.0, 0.0), 0)
+    def setUp(self):
+        mutations = fwdpy11.VecMutation()
+        fixations = fwdpy11.VecMutation()
+        gametes = fwdpy11.VecGamete()
+        diploids = fwdpy11.VecDiploid()
+        mutations.append(fwdpy11.Mutation(0.1, -0.01, 1.0, 0, 0))
+        mutations.append(fwdpy11.Mutation(0.2, 0.0, 1.0, 0, 0))
+        gametes.append(fwdpy11.Gamete(
+            (4, fwdpy11.VecUint32([1]), fwdpy11.VecUint32([0]))))
+        diploids.append(fwdpy11.SingleLocusDiploid(0, 0))
+        diploids.append(fwdpy11.SingleLocusDiploid(0, 0))
+        self.pop = fwdpy11.SlocusPop(diploids, gametes, mutations)
 
-    def test_two_neutral_fixations(self):
-        # Evolve pop for 1 gen.
-        # This will push mutation into fixations:
-        fwdpy11.wright_fisher_qtrait.evolve(self.rng, self.pop, self.params)
-        self.assertEqual(len(self.pop.fixations), 1)
-        # Add back the exact same mutation:
-        fwdpy11.util.add_mutation(
-            self.rng, self.pop, 2 * self.pop.N, (0.1, 0.0, 0.0), 0)
-        # Evolve again for 1 gen:
-        fwdpy11.wright_fisher_qtrait.evolve(self.rng, self.pop, self.params)
+    def testSetup(self):
+        self.assertEqual(len(self.pop.mutations), 2)
+        self.assertEqual(len(self.pop.gametes), 1)
+        self.assertEqual(len(self.pop.diploids), 2)
+        for g in self.pop.gametes:
+            self.assertEqual(len(g.mutations), 1)
+            self.assertEqual(len(g.smutations), 1)
+        for mc in self.pop.mcounts:
+            self.assertEqual(mc, 4)
+
+    def testWithPruneSelected(self):
+        fp.update_mutations(self.pop, 1, 2 * len(self.pop.diploids), True)
         self.assertEqual(len(self.pop.fixations), 2)
-        self.assertEqual(list(self.pop.fixation_times), [1, 2])
+        self.assertEqual(len(self.pop.fixation_times), 2)
+        self.assertEqual(len([i for i in self.pop.mcounts if i == 0]), 2)
+        self.assertTrue(sorted(self.pop.fixations, key=lambda x: x.pos))
+        for mc in self.pop.mcounts:
+            self.assertEqual(mc, 0)
+
+    def testWithoutPruneSelected(self):
+        fp.update_mutations(self.pop, 1, 2 * len(self.pop.diploids), False)
+        self.assertEqual(len(self.pop.fixations), 2)
+        self.assertEqual(len(self.pop.fixation_times), 2)
+        self.assertEqual(len([i for i in self.pop.mcounts if i == 0]), 1)
+        self.assertTrue(sorted(self.pop.fixations, key=lambda x: x.pos))
+        for m, mc in zip(self.pop.mutations, self.pop.mcounts):
+            if m.neutral is True:
+                self.assertEqual(mc, 0)
+            else:
+                self.assertEqual(mc, 4)
+
+
+class testFixationsAreSortedMlocusPop(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        mutations = fwdpy11.VecMutation()
+        fixations = fwdpy11.VecMutation()
+        gametes = fwdpy11.VecGamete()
+        diploids = fwdpy11.VecVecDiploid()
+        mutations.append(fwdpy11.Mutation(0.25, -0.01, 1.0, 0, 0))
+        mutations.append(fwdpy11.Mutation(0.75, 0.0, 1.0, 0, 0))
+        mutations.append(fwdpy11.Mutation(1.25, 0.0, 1.0, 0, 0))
+        mutations.append(fwdpy11.Mutation(1.75, 0.25, 1.0, 0, 0))
+        gametes.append(fwdpy11.Gamete(
+            (4, fwdpy11.VecUint32([1]), fwdpy11.VecUint32([0]))))
+        gametes.append(fwdpy11.Gamete(
+            (4, fwdpy11.VecUint32([2]), fwdpy11.VecUint32([3]))))
+        dip = fwdpy11.VecDiploid(
+            [fwdpy11.SingleLocusDiploid(0, 0), fwdpy11.SingleLocusDiploid(1, 1)])
+        diploids.append(dip)
+        diploids.append(dip)
+        self.pop = fwdpy11.MlocusPop(diploids, gametes, mutations)
+        self.pop.locus_boundaries = [(0, 1), (1, 2)]
+
+    def testSetup(self):
+        self.assertEqual(len(self.pop.mutations), 4)
+        self.assertEqual(len(self.pop.gametes), 2)
+        self.assertEqual(len(self.pop.diploids), 2)
+        for d in self.pop.diploids:
+            self.assertEqual(len(d), 2)
+            for l in d:
+                self.assertEqual(len(self.pop.gametes[l.first].mutations), 1)
+                self.assertEqual(len(self.pop.gametes[l.first].smutations), 1)
+                self.assertEqual(len(self.pop.gametes[l.second].mutations), 1)
+                self.assertEqual(len(self.pop.gametes[l.second].smutations), 1)
+
+        self.assertEqual(len(self.pop.locus_boundaries), 2)
+        self.assertEqual(self.pop.nloci, 2)
+        for g in self.pop.gametes:
+            self.assertEqual(len(g.mutations), 1)
+            self.assertEqual(len(g.smutations), 1)
+        for mc in self.pop.mcounts:
+            self.assertEqual(mc, 4)
+
+    def testWithPruneSelected(self):
+        fp.update_mutations(self.pop, 1, 2 * len(self.pop.diploids), True)
+        self.assertEqual(len(self.pop.fixations), 4)
+        self.assertEqual(len(self.pop.fixation_times), 4)
+        self.assertEqual(len([i for i in self.pop.mcounts if i == 0]), 4)
+        self.assertTrue(sorted(self.pop.fixations, key=lambda x: x.pos))
+        for mc in self.pop.mcounts:
+            self.assertEqual(mc, 0)
+
+    def testWithoutPruneSelected(self):
+        fp.update_mutations(self.pop, 1, 2 * len(self.pop.diploids), False)
+        self.assertEqual(len(self.pop.fixations), 4)
+        self.assertEqual(len(self.pop.fixation_times), 4)
+        self.assertEqual(len([i for i in self.pop.mcounts if i == 0]), 2)
+        self.assertTrue(sorted(self.pop.fixations, key=lambda x: x.pos))
+        for m, mc in zip(self.pop.mutations, self.pop.mcounts):
+            if m.neutral is True:
+                self.assertEqual(mc, 0)
+            else:
+                self.assertEqual(mc, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_popobject_create.py
+++ b/tests/test_popobject_create.py
@@ -97,7 +97,8 @@ class testMlocusPopCreate(unittest.TestCase):
 
     def testConstruction(self):
         pop = fwdpy11.MlocusPop(self.diploids, self.gametes, self.mutations)
-        self.assertTrue(pop.N, 1)
+        self.assertEqual(pop.N, 1)
+        self.assertEqual(pop.nloci, 2)
 
     def testStaticMethod(self):
         pop = fwdpy11.MlocusPop.create(


### PR DESCRIPTION
This addresses #86 and also fixes a bug in assigning `MlocusPop.nloci` that was  introduced in #85.