### PR TITLE
Locus boundaries

### DIFF
--- a/fwdpy11/MlocusPop.py
+++ b/fwdpy11/MlocusPop.py
@@ -24,7 +24,7 @@ class MlocusPop(_MlocusPop):
     Representation of a multi-locus system.
     """
     @staticmethod
-    def create(diploids, gametes, mutations, *args):
+    def create(diploids, gametes, mutations, locus_boundaries, *args):
         """
         Create a new object from input data.
         Unlike the constructor method, this method results
@@ -33,6 +33,7 @@ class MlocusPop(_MlocusPop):
         :param diplods: A :class:`fwdpy11.VecVecDiploid`
         :param gametes: A :class:`fwdpy11.VecGamete`
         :param mutations: A :class:`fwdpy11.VecMutation`
+        :param locus_boundaries: Positional boundaries of each locus
         :param args: Fixations, fixation times, and generation
 
         :rtype: :class:`fwdpy11.MlocusPop`
@@ -54,4 +55,4 @@ class MlocusPop(_MlocusPop):
         .. versionadded:: 0.1.4
 
         """
-        return MlocusPop(_MlocusPop.create(diploids, gametes, mutations, args))
+        return MlocusPop(_MlocusPop.create(diploids, gametes, mutations, locus_boundaries, args))

--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -66,6 +66,7 @@ namespace fwdpy11
                 {
                     throw std::invalid_argument("number of loci must be > 0");
                 }
+            validate_locus_boundaries(locus_boundaries);
             std::size_t label = 0;
             for (auto &&d : this->diploids)
                 {
@@ -82,10 +83,11 @@ namespace fwdpy11
                          std::forward<gametes_input>(g),
                          std::forward<mutations_input>(m), 100),
               diploids(std::forward<diploids_input>(d)),
-              nloci{ static_cast<fwdpp::uint_t>(locus_boundaries_.size()) }, locus_boundaries{ std::move(
-                                                     locus_boundaries_) }
+              nloci{ static_cast<fwdpp::uint_t>(locus_boundaries_.size()) },
+              locus_boundaries{ std::move(locus_boundaries_) }
         //! Constructor for pre-determined population status
         {
+            validate_locus_boundaries(locus_boundaries);
             if (diploids.at(0).size() != nloci)
                 {
                     throw std::invalid_argument("diploid genotypes "
@@ -165,6 +167,58 @@ namespace fwdpy11
                     this->mut_lookup.insert(pos);
                 }
             return rv;
+        }
+
+        void
+        validate_locus_boundaries(
+            const std::vector<std::pair<double, double>> &lb) const
+        {
+            if (lb.empty())
+                return;
+            if (!std::is_sorted(
+                    std::begin(lb), std::end(lb),
+                    [](const std::pair<double, double> &a,
+                       const std::pair<double, double> &b) { return a < b; }))
+                {
+                    throw std::invalid_argument("locus boundaries not sorted");
+                }
+            for (auto &i : lb)
+                {
+                    if (i.second <= i.first)
+                        {
+                            throw std::invalid_argument("a locus boundary "
+                                                        "must be an interval "
+                                                        "[a,b) with a<b");
+                        }
+                }
+            for (std::size_t i = 0; i < lb.size() - 1; ++i)
+                {
+                    if (lb[i].second > lb[i + 1].first)
+                        {
+                            throw std::invalid_argument(
+                                "adjacent intervals cannot overlap");
+                        }
+                }
+            // if (!std::is_sorted(std::begin(lb), std::end(lb),
+            //                    [](const std::pair<double, double> &a,
+            //                       const std::pair<double, double> &b) {
+            //                        return a.second < b.second;
+            //                    }))
+            //    {
+            //        throw std::invalid_argument(
+            //            "locus boundaries not sorted by second element");
+            //    }
+            // for (std::size_t i = 0; i < lb.size(); ++i)
+            //    {
+            //        if (lb[i].second <= lb[i].first)
+            //            {
+            //                throw std::invalid_argument(
+            //                    "locus boundaries must be [a,b) and a < b");
+            //            }
+            //		if(i<lb.size()-1)
+            //		{
+            //		}
+            //    }
         }
     };
 }

--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -175,10 +175,7 @@ namespace fwdpy11
         {
             if (lb.empty())
                 return;
-            if (!std::is_sorted(
-                    std::begin(lb), std::end(lb),
-                    [](const std::pair<double, double> &a,
-                       const std::pair<double, double> &b) { return a < b; }))
+            if (!std::is_sorted(std::begin(lb), std::end(lb)))
                 {
                     throw std::invalid_argument("locus boundaries not sorted");
                 }

--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -199,26 +199,6 @@ namespace fwdpy11
                                 "adjacent intervals cannot overlap");
                         }
                 }
-            // if (!std::is_sorted(std::begin(lb), std::end(lb),
-            //                    [](const std::pair<double, double> &a,
-            //                       const std::pair<double, double> &b) {
-            //                        return a.second < b.second;
-            //                    }))
-            //    {
-            //        throw std::invalid_argument(
-            //            "locus boundaries not sorted by second element");
-            //    }
-            // for (std::size_t i = 0; i < lb.size(); ++i)
-            //    {
-            //        if (lb[i].second <= lb[i].first)
-            //            {
-            //                throw std::invalid_argument(
-            //                    "locus boundaries must be [a,b) and a < b");
-            //            }
-            //		if(i<lb.size()-1)
-            //		{
-            //		}
-            //    }
         }
     };
 }

--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -51,32 +51,12 @@ namespace fwdpy11
         MlocusPop &operator=(const MlocusPop &) = default;
 
         // Constructors for Python
-        MlocusPop(const fwdpp::uint_t N, fwdpp::uint_t nloci_)
-            : Population{ N },
-              diploids(N, diploid_t(nloci_, Diploid{ 0, 0 })), nloci{ nloci_ },
-              locus_boundaries{}
-        {
-            if (!N)
-                {
-                    throw std::invalid_argument("population size must be > 0");
-                }
-            if (!nloci)
-                {
-                    throw std::invalid_argument("number of loci must be > 0");
-                }
-            std::size_t label = 0;
-            for (auto &&d : this->diploids)
-                {
-                    d[0].label = label++;
-                }
-        }
-
-        MlocusPop(
-            const fwdpp::uint_t N, fwdpp::uint_t nloci_,
-            const std::vector<std::pair<double, double>> &locus_boundaries_)
-            : Population{ N },
-              diploids(N, diploid_t(nloci_, Diploid{ 0, 0 })), nloci{ nloci_ },
-              locus_boundaries{ locus_boundaries_ }
+        MlocusPop(const fwdpp::uint_t N,
+                  std::vector<std::pair<double, double>> locus_boundaries_)
+            : Population{ N }, diploids(N, diploid_t(locus_boundaries_.size(),
+                                                     Diploid{ 0, 0 })),
+              nloci{ static_cast<fwdpp::uint_t>(locus_boundaries_.size()) },
+              locus_boundaries{ std::move(locus_boundaries_) }
         {
             if (!N)
                 {
@@ -95,16 +75,24 @@ namespace fwdpy11
 
         template <typename diploids_input, typename gametes_input,
                   typename mutations_input>
-        explicit MlocusPop(diploids_input &&d, gametes_input &&g,
-                           mutations_input &&m)
+        explicit MlocusPop(
+            diploids_input &&d, gametes_input &&g, mutations_input &&m,
+            std::vector<std::pair<double, double>> locus_boundaries_)
             : Population(static_cast<fwdpp::uint_t>(d.size()),
                          std::forward<gametes_input>(g),
                          std::forward<mutations_input>(m), 100),
-              diploids(std::forward<diploids_input>(d)), nloci{}
+              diploids(std::forward<diploids_input>(d)),
+              nloci{ static_cast<fwdpp::uint_t>(locus_boundaries_.size()) }, locus_boundaries{ std::move(
+                                                     locus_boundaries_) }
         //! Constructor for pre-determined population status
         {
+            if (diploids.at(0).size() != nloci)
+                {
+                    throw std::invalid_argument("diploid genotypes "
+                                                "inconsistent wit number of "
+                                                "locus boundaries");
+                }
             this->process_individual_input();
-            nloci = diploids.at(0).size();
         }
 
         bool
@@ -119,6 +107,7 @@ namespace fwdpy11
         clear()
         {
             diploids.clear();
+            locus_boundaries.clear();
             popbase_t::clear_containers();
         }
 

--- a/fwdpy11/headers/fwdpy11/types/create_pops.hpp
+++ b/fwdpy11/headers/fwdpy11/types/create_pops.hpp
@@ -22,6 +22,20 @@ namespace fwdpy11
         template <typename diploids_input, typename gametes_input,
                   typename mutations_input>
         inline poptype
+        operator()(
+            diploids_input &&diploids, gametes_input &&gametes,
+            mutations_input &&mutations,
+            std::vector<std::pair<double, double>> &&locus_boundaries) const
+        {
+            return poptype(std::forward<diploids_input>(diploids),
+                           std::forward<gametes_input>(gametes),
+                           std::forward<mutations_input>(mutations),
+                           std::move(locus_boundaries));
+        }
+
+        template <typename diploids_input, typename gametes_input,
+                  typename mutations_input>
+        inline poptype
         operator()(diploids_input &&diploids, gametes_input &&gametes,
                    mutations_input &&mutations, mutations_input &&fixations,
                    std::vector<fwdpp::uint_t> &&fixation_times,
@@ -31,6 +45,28 @@ namespace fwdpy11
                 = this->operator()(std::forward<diploids_input>(diploids),
                                    std::forward<gametes_input>(gametes),
                                    std::forward<mutations_input>(mutations));
+
+            rv.fixations.swap(fixations);
+            rv.fixation_times.swap(fixation_times);
+            rv.generation = generation;
+            return rv;
+            return rv;
+        }
+        template <typename diploids_input, typename gametes_input,
+                  typename mutations_input>
+        inline poptype
+        operator()(diploids_input &&diploids, gametes_input &&gametes,
+                   mutations_input &&mutations,
+                   std::vector<std::pair<double, double>> &&locus_boundaries,
+                   mutations_input &&fixations,
+                   std::vector<fwdpp::uint_t> &&fixation_times,
+                   fwdpp::uint_t generation) const
+        {
+            auto rv
+                = this->operator()(std::forward<diploids_input>(diploids),
+                                   std::forward<gametes_input>(gametes),
+                                   std::forward<mutations_input>(mutations),
+                                   std::move(locus_boundaries));
 
             rv.fixations.swap(fixations);
             rv.fixation_times.swap(fixation_times);

--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -220,14 +220,12 @@ PYBIND11_MODULE(_Populations, m)
 
     py::class_<fwdpy11::MlocusPop, fwdpy11::Population>(
         m, "_MlocusPop", "Representation of a multi-locus population")
-        .def(py::init<fwdpp::uint_t, fwdpp::uint_t>(), py::arg("N"),
-             py::arg("nloci"))
-        .def(py::init<fwdpp::uint_t, fwdpp::uint_t,
-                      const std::vector<std::pair<double, double>>&>(),
-             py::arg("N"), py::arg("nloci"), py::arg("locus_boundaries"))
+        .def(py::init<fwdpp::uint_t, std::vector<std::pair<double, double>>>(),
+             py::arg("N"), py::arg("locus_boundaries"))
         .def(py::init<const fwdpy11::MlocusPop::dipvector_t&,
                       const fwdpy11::MlocusPop::gcont_t&,
-                      const fwdpy11::MlocusPop::mcont_t&>(),
+                      const fwdpy11::MlocusPop::mcont_t&,
+                      std::vector<std::pair<double, double>>>(),
              R"delim(
              Construct with tuple of (diploids, gametes, mutations).
              
@@ -255,20 +253,21 @@ PYBIND11_MODULE(_Populations, m)
             [](fwdpy11::MlocusPop::dipvector_t& diploids,
                fwdpy11::MlocusPop::gcont_t& gametes,
                fwdpy11::MlocusPop::mcont_t& mutations,
+               std::vector<std::pair<double, double>> locus_boundaries,
                py::tuple args) -> fwdpy11::MlocusPop {
                 if (args.size() == 0)
                     {
                         return fwdpy11::create_wrapper<fwdpy11::MlocusPop>()(
                             std::move(diploids), std::move(gametes),
-                            std::move(mutations));
+                            std::move(mutations), std::move(locus_boundaries));
                     }
                 auto& fixations = args[0].cast<fwdpy11::MlocusPop::mcont_t&>();
                 auto& ftimes = args[1].cast<std::vector<fwdpp::uint_t>&>();
                 auto g = args[2].cast<fwdpp::uint_t>();
                 return fwdpy11::create_wrapper<fwdpy11::MlocusPop>()(
                     std::move(diploids), std::move(gametes),
-                    std::move(mutations), std::move(fixations),
-                    std::move(ftimes), g);
+                    std::move(mutations), std::move(locus_boundaries),
+                    std::move(fixations), std::move(ftimes), g);
             })
         .def(py::pickle(
             [](const fwdpy11::MlocusPop& pop) -> py::object {
@@ -282,7 +281,9 @@ PYBIND11_MODULE(_Populations, m)
                     {
                         auto s = pickled.cast<py::bytes>();
                         return fwdpy11::serialization::
-                            deserialize_details<fwdpy11::MlocusPop>()(s, 1, 1);
+                            deserialize_details<fwdpy11::MlocusPop>()(
+                                s, 1,
+                                std::vector<std::pair<double, double>>{});
                     }
                 catch (std::runtime_error& eas)
                     {
@@ -296,7 +297,8 @@ PYBIND11_MODULE(_Populations, m)
                     }
                 auto s = t[0].cast<py::bytes>();
                 auto rv = fwdpy11::serialization::
-                    deserialize_details<fwdpy11::MlocusPop>()(s, 1, 1);
+                    deserialize_details<fwdpy11::MlocusPop>()(
+                        s, 1, std::vector<std::pair<double, double>>{});
                 rv.popdata = t[1];
                 rv.popdata_user = t[2];
                 return rv;

--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -282,8 +282,8 @@ PYBIND11_MODULE(_Populations, m)
                         auto s = pickled.cast<py::bytes>();
                         return fwdpy11::serialization::
                             deserialize_details<fwdpy11::MlocusPop>()(
-                                s, 1,
-                                std::vector<std::pair<double, double>>{});
+                                s, 1, std::vector<std::pair<double, double>>{
+                                          { 0., 1 } });
                     }
                 catch (std::runtime_error& eas)
                     {
@@ -298,7 +298,8 @@ PYBIND11_MODULE(_Populations, m)
                 auto s = t[0].cast<py::bytes>();
                 auto rv = fwdpy11::serialization::
                     deserialize_details<fwdpy11::MlocusPop>()(
-                        s, 1, std::vector<std::pair<double, double>>{});
+                        s, 1,
+                        std::vector<std::pair<double, double>>{ { 0., 1 } });
                 rv.popdata = t[1];
                 rv.popdata_user = t[2];
                 return rv;

--- a/tests/quick_pops.py
+++ b/tests/quick_pops.py
@@ -111,7 +111,7 @@ def quick_mlocus_qtrait_pop_params(N=1000, simlen=100):
                   'demography': nlist,
                   'prune_selected': False
                   }
-    pop = MlocusPop(N, nloci, locus_boundaries)
+    pop = MlocusPop(N, locus_boundaries)
     return (pop, param_dict)
 
 
@@ -169,6 +169,6 @@ def quick_mlocus_qtrait_change_optimum(N=1000, simlen=100, prune_selected=False)
                   'demography': nlist,
                   'prune_selected': prune_selected}
     params = MlocusParamsQ(**param_dict)
-    pop = MlocusPop(N, nloci, locus_boundaries)
+    pop = MlocusPop(N, locus_boundaries)
     evolve(rng, pop, params)
     return pop

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -23,7 +23,7 @@ import fwdpy11 as fp11
 class testMlocusPop(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.pop = fp11.MlocusPop(1000, [(i,i+1) for i in range(5)])
+        self.pop = fp11.MlocusPop(1000, [(i, i + 1) for i in range(5)])
 
     def test_N(self):
         self.assertEqual(self.pop.N, 1000)
@@ -53,7 +53,7 @@ class testMlocusPop(unittest.TestCase):
 class testMlocusPopExceptions(unittest.TestCase):
     def testNzero(self):
         with self.assertRaises(ValueError):
-            fp11.MlocusPop(0, [(i,i+1) for i in range(5)])
+            fp11.MlocusPop(0, [(i, i + 1) for i in range(5)])
 
     def testNoLoci(self):
         with self.assertRaises(ValueError):
@@ -93,20 +93,38 @@ class testSampling(unittest.TestCase):
             self.pop.sample(rng=self.rng, nsam=10, remove_fixed=False)
 
     def testDefinedSample(self):
-        x = self.pop.sample(individuals = range(10))
+        x = self.pop.sample(individuals=range(10))
         self.assertEqual(len(x), self.pop.nloci)
         with self.assertRaises(IndexError):
             """
             fwdpp catches case where i >= N
             """
-            self.pop.sample(individuals = range(self.pop.N, self.pop.N + 10))
+            self.pop.sample(individuals=range(self.pop.N, self.pop.N + 10))
 
         with self.assertRaises(Exception):
             """
             pybind11 disallows conversion of negative
             numbers to a list of unsigned types.
             """
-            self.pop.sample(individuals = range(-10, 10))
+            self.pop.sample(individuals=range(-10, 10))
+
+
+class testBadLocusBoundaries(unittest.TestCase):
+    def testUnsorted(self):
+        with self.assertRaises(ValueError):
+            pop = fp11.MlocusPop(100, [(1, 2), (0, 1)])
+
+    def testBadInterval(self):
+        with self.assertRaises(ValueError):
+            pop = fp11.MlocusPop(100, [(0, 1), (1, 1)])
+        with self.assertRaises(ValueError):
+            pop = fp11.MlocusPop(100, [(0, 1), (2, 1)])
+
+    def testOverlap(self):
+        with self.assertRaises(ValueError):
+            pop = fp11.MlocusPop(100, [(0, 1.1), (1, 2)])
+        with self.assertRaises(ValueError):
+            pop = fp11.MlocusPop(100, [(0, 3), (1, 2)])
 
 
 if __name__ == "__main__":

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -87,11 +87,6 @@ class testSampling(unittest.TestCase):
                             separate=True, remove_fixed=True)
         self.assertEqual(len(x), self.pop.nloci)
 
-        self.pop.locus_boundaries = []
-
-        with self.assertRaises(ValueError):
-            self.pop.sample(rng=self.rng, nsam=10, remove_fixed=False)
-
     def testDefinedSample(self):
         x = self.pop.sample(individuals=range(10))
         self.assertEqual(len(x), self.pop.nloci)
@@ -126,6 +121,19 @@ class testBadLocusBoundaries(unittest.TestCase):
         with self.assertRaises(ValueError):
             pop = fp11.MlocusPop(100, [(0, 3), (1, 2)])
 
+class testSettingLocusBoundaries(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.pop = fp11.MlocusPop(100,[(0,1),(1,2)])
+
+    def testReassign(self):
+        self.pop.locus_boundaries = [(2,3),(11,45)]
+
+    def testBadReassign(self):
+        with self.assertRaises(ValueError):
+            self.pop.locus_boundaries = []
+        with self.assertRaises(ValueError):
+            self.pop.locus_boundaries = [(1,2.),(1,3)]
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -121,19 +121,21 @@ class testBadLocusBoundaries(unittest.TestCase):
         with self.assertRaises(ValueError):
             pop = fp11.MlocusPop(100, [(0, 3), (1, 2)])
 
+
 class testSettingLocusBoundaries(unittest.TestCase):
     @classmethod
     def setUp(self):
-        self.pop = fp11.MlocusPop(100,[(0,1),(1,2)])
+        self.pop = fp11.MlocusPop(100, [(0, 1), (1, 2)])
 
     def testReassign(self):
-        self.pop.locus_boundaries = [(2,3),(11,45)]
+        self.pop.locus_boundaries = [(2, 3), (11, 45)]
 
     def testBadReassign(self):
         with self.assertRaises(ValueError):
             self.pop.locus_boundaries = []
         with self.assertRaises(ValueError):
-            self.pop.locus_boundaries = [(1,2.),(1,3)]
+            self.pop.locus_boundaries = [(1, 2.), (1, 3)]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -23,7 +23,7 @@ import fwdpy11 as fp11
 class testMlocusPop(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.pop = fp11.MlocusPop(1000, 5)
+        self.pop = fp11.MlocusPop(1000, [(i,i+1) for i in range(5)])
 
     def test_N(self):
         self.assertEqual(self.pop.N, 1000)
@@ -53,11 +53,11 @@ class testMlocusPop(unittest.TestCase):
 class testMlocusPopExceptions(unittest.TestCase):
     def testNzero(self):
         with self.assertRaises(ValueError):
-            fp11.MlocusPop(0, 5)
+            fp11.MlocusPop(0, [(i,i+1) for i in range(5)])
 
     def testNoLoci(self):
         with self.assertRaises(ValueError):
-            fp11.MlocusPop(1000, 0)
+            fp11.MlocusPop(1000, [])
 
 
 class testSampling(unittest.TestCase):

--- a/tests/test_Mutation.py
+++ b/tests/test_Mutation.py
@@ -109,6 +109,7 @@ class testMultiEffectMutationMlocusPopPickling(unittest.TestCase):
         self.pop = fwdpy11.MlocusPop.create(diploids,
                                             gametes,
                                             mutations,
+                                            [(0, 1), (1, 2)],
                                             fixations,
                                             ftimes, 2)
 

--- a/tests/test_add_mutation.py
+++ b/tests/test_add_mutation.py
@@ -25,7 +25,7 @@ class testSlocusPopAddMutations(unittest.TestCase):
     @classmethod
     def setUp(self):
         self.pop = fwdpy11.SlocusPop(1000)
-        self.mpop = fwdpy11.MlocusPop(1000, 2, [(0, 1), (1, 2)])
+        self.mpop = fwdpy11.MlocusPop(1000, [(0, 1), (1, 2)])
         self.mvec = fwdpy11.VecMutation()
         self.nmut = fwdpy11.Mutation(0.1, 0.0, 0.0, 0, 0)
         self.smut = fwdpy11.Mutation(1.2, -0.01, 0.0, 0, 0)

--- a/tests/test_fixation_properties.py
+++ b/tests/test_fixation_properties.py
@@ -98,7 +98,8 @@ class testFixationsAreSortedMlocusPop(unittest.TestCase):
             [fwdpy11.SingleLocusDiploid(0, 0), fwdpy11.SingleLocusDiploid(1, 1)])
         diploids.append(dip)
         diploids.append(dip)
-        self.pop = fwdpy11.MlocusPop(diploids, gametes, mutations)
+        self.pop = fwdpy11.MlocusPop(
+            diploids, gametes, mutations, [(0, 1), (1, 2)])
         self.pop.locus_boundaries = [(0, 1), (1, 2)]
 
     def testSetup(self):

--- a/tests/test_fixation_properties.py
+++ b/tests/test_fixation_properties.py
@@ -100,7 +100,6 @@ class testFixationsAreSortedMlocusPop(unittest.TestCase):
         diploids.append(dip)
         self.pop = fwdpy11.MlocusPop(
             diploids, gametes, mutations, [(0, 1), (1, 2)])
-        self.pop.locus_boundaries = [(0, 1), (1, 2)]
 
     def testSetup(self):
         self.assertEqual(len(self.pop.mutations), 4)

--- a/tests/test_multilocus.py
+++ b/tests/test_multilocus.py
@@ -8,7 +8,7 @@ import pickle
 class testMultiLocusFitness(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.pop = fp11.MlocusPop(1000, 5)
+        self.pop = fp11.MlocusPop(1000, [(i,i+1) for i in range(5)])
         self.all_additive = [fp11w.SlocusAdditive()] * 5
         self.all_mult = [fp11w.SlocusMult()] * 5
         self.agg_add_w = fp11m.AggAddFitness()

--- a/tests/test_opaque.py
+++ b/tests/test_opaque.py
@@ -92,7 +92,7 @@ class testSlocusPopSampler(unittest.TestCase):
 class testMlocusPop(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.pop = fwdpy11.MlocusPop(1000, 5)
+        self.pop = fwdpy11.MlocusPop(1000, [(i, i + 1) for i in range(5)])
 
     def test_mutations(self):
         self.assertTrue(

--- a/tests/test_popobject_create.py
+++ b/tests/test_popobject_create.py
@@ -123,13 +123,14 @@ class testMlocusPopCreate(unittest.TestCase):
             [fwdpy11.SingleLocusDiploid(0, 0)] * 2))
 
     def testConstruction(self):
-        pop = fwdpy11.MlocusPop(self.diploids, self.gametes, self.mutations)
+        pop = fwdpy11.MlocusPop(
+            self.diploids, self.gametes, self.mutations, [(0, 1), (1, 2)])
         self.assertEqual(pop.N, 1)
         self.assertEqual(pop.nloci, 2)
 
     def testStaticMethod(self):
         pop = fwdpy11.MlocusPop.create(
-            self.diploids, self.gametes, self.mutations)
+            self.diploids, self.gametes, self.mutations, [(0, 1), (1, 2)])
         self.assertTrue(type(pop) is fwdpy11.MlocusPop)
         # Test that data were moved and not copied:
         self.assertEqual(len(self.diploids), 0)
@@ -141,6 +142,7 @@ class testMlocusPopCreate(unittest.TestCase):
         pop = fwdpy11.MlocusPop.create(self.diploids,
                                        self.gametes,
                                        self.mutations,
+                                       [(0., 1.), (1., 2.)],
                                        self.fixations,
                                        ftimes, 2)
         self.assertTrue(type(pop) is fwdpy11.MlocusPop)


### PR DESCRIPTION
Forces locus_boundaries to be defined when an MlocusPop is constructed.  Fixes #95.  These changes represent a big improvement in safety and in enforcing object consistency/sanity.