### PR TITLE
add _init module to disable GSL error handling when using fwdpy11.

### DIFF
--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -22,6 +22,7 @@ import sys
 if sys.version_info[0] < 3:
     raise ValueError("Python3 required!")
 
+from fwdpy11._init import * # NOQA
 from fwdpy11._version import __version__ # NOQA
 
 from .fwdpp_types import *

--- a/fwdpy11/src/_init.cc
+++ b/fwdpy11/src/_init.cc
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <pybind11/pybind11.h>
+#include <gsl/gsl_errno.h>
+
+PYBIND11_MODULE(_init, m)
+{
+    m.doc() = "Module executing some setup code when fwdpy11 is imported.";
+
+    auto handler = gsl_set_error_handler_off();
+}

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,14 @@ LIBRARY_DIRS = [
 
 ext_modules = [
     Extension(
+        'fwdpy11._init',
+        ['fwdpy11/src/_init.cc'],
+        library_dirs=LIBRARY_DIRS,
+        include_dirs=INCLUDES,
+        libraries=['gsl', 'gslcblas'],
+        language='c++'
+    ),
+        Extension(
         'fwdpy11.fwdpp_types',
         ['fwdpy11/src/fwdpp_types.cc'],
         library_dirs=LIBRARY_DIRS,

--- a/setup.py.in
+++ b/setup.py.in
@@ -72,6 +72,14 @@ LIBRARY_DIRS = [
 
 ext_modules = [
     Extension(
+        'fwdpy11._init',
+        ['fwdpy11/src/_init.cc'],
+        library_dirs=LIBRARY_DIRS,
+        include_dirs=INCLUDES,
+        libraries=['gsl', 'gslcblas'],
+        language='c++'
+    ),
+        Extension(
         'fwdpy11.fwdpp_types',
         ['fwdpy11/src/fwdpp_types.cc'],
         library_dirs=LIBRARY_DIRS,

--- a/tests/gsl_error.cpp
+++ b/tests/gsl_error.cpp
@@ -1,0 +1,25 @@
+// clang-format off
+<% 
+setup_pybind11(cfg) 
+cfg['libraries'].extend(['gsl','gslcblas'])
+%>
+// clang-format on
+
+#include <pybind11/pybind11.h>
+#include <gsl/gsl_matrix.h>
+
+    namespace py = pybind11;
+
+PYBIND11_MODULE(gsl_error, m)
+{
+    m.def("trigger_error", []() {
+        gsl_matrix* m = gsl_matrix_alloc(2, 3); //non-square
+        int rv = gsl_matrix_transpose(m);
+        if (rv != GSL_SUCCESS)
+            {
+                throw std::runtime_error("non-square matrix");
+                gsl_matrix_free(m);
+            }
+        gsl_matrix_free(m);
+    });
+}

--- a/tests/test_GSLerror.py
+++ b/tests/test_GSLerror.py
@@ -1,0 +1,13 @@
+import fwdpy11
+import cppimport
+cppimport.force_rebuild()
+gsl = cppimport.imp("gsl_error")
+import unittest
+
+class testGSLerror(unittest.TestCase):
+    def testErrorHandler(self):
+        with self.assertRaises(RuntimeError):
+            gsl.trigger_error()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses #100.