### PR TITLE
Mut lookup

### DIFF
--- a/doc/pages/manip_mutations.rst
+++ b/doc/pages/manip_mutations.rst
@@ -26,6 +26,13 @@ to the second gamete of the third individual in the population:
 
 See the unit test file tests/test_add_mutations.py for more examples.
 
+.. note::
+
+    Attempting to add a mutation at an already-mutation position will raise an exception,
+    because you are violating the infinitely-many sites assumption of the simulation engine.
+    To guard against this, you may check the current set of mutation positions via
+    :attr:`fwdpy11._Population.mut_lookup`.  See :ref:`mpos` for details.
+
 Changing the effect size of a mutation
 ======================================================================
 

--- a/doc/pages/types.rst
+++ b/doc/pages/types.rst
@@ -69,6 +69,16 @@ Mutation objects to not track their own frequencies.  Rather, they are stored in
     Indices with values 0 zero correspond to the locations of extinct mutations in a mutation 
     container.
 
+.. _mpos:
+
+Mutation positions
+-----------------------------------------------------------
+
+.. versionadded:: 0.1.5
+
+The positions of all extant variants, and their locations in the mutation container, are tracked via a list of tuples.
+The first element in each tuple is the mutation position (a float) and the second it its location (an unsigned integer).
+
 .. _gametes:
 
 Gametes
@@ -150,6 +160,7 @@ Rather, you work with the derived classes :class:`fwdpy11.SlocusPop` and :class:
     "generation", "Current generation."
     "mutations", "A :class:`fwdpy11.VecMutation`. See :ref:`popgenmuts`."
     "mcounts", "See :ref:`mcounts`."
+    "mut_lookup", "See :ref:`mpos`. The locations refer to the mutations container."
     "gametes", "A :class:`fwdpy11.VecGamete`.  See :ref:`gametes`."
     "fixations", "A :class:`fwdpy11.VecMutation` storing fixations. See :ref:`popgenmuts`."
     "fixation_times", "A :class:`fwdpy11.VecUint32` storing fixation times."

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -61,7 +61,7 @@ namespace
 
     static const auto POPDATA_USER_DOCSTRING
         = "A Python object with read-write access.\n\n.. versionadded:: 0.1.4";
-}
+} // namespace
 
 PYBIND11_MAKE_OPAQUE(fwdpy11::Population::gcont_t);
 PYBIND11_MAKE_OPAQUE(fwdpy11::Population::mcont_t);
@@ -102,6 +102,16 @@ PYBIND11_MODULE(_Population, m)
                       MUTATIONS_DOCSTRING)
         .def_readonly("mcounts", &fwdpy11::Population::mcounts,
                       MCOUNTS_DOCSTRING)
+        .def_property_readonly("mut_lookup",
+                      [](const fwdpy11::Population& pop) {
+                          py::list rv;
+                          for (auto&& i : pop.mut_lookup)
+                              {
+                                  rv.append(py::make_tuple(i.first, i.second));
+                              }
+                          return rv;
+                      },
+                      "Mutation position lookup table.")
         .def_readonly("gametes", &fwdpy11::Population::gametes,
                       GAMETES_DOCSTRING)
         .def_readonly("fixations", &fwdpy11::Population::fixations,
@@ -111,5 +121,5 @@ PYBIND11_MODULE(_Population, m)
         .def_readonly("popdata", &fwdpy11::Population::popdata,
                       POPDATA_DOCSTRING)
         .def_readwrite("popdata_user", &fwdpy11::Population::popdata_user,
-                      POPDATA_USER_DOCSTRING);
+                       POPDATA_USER_DOCSTRING);
 }

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -143,6 +143,10 @@ class testPythonObjects(unittest.TestCase):
         self.assertEqual(up.popdata_user, self.pop.generation)
         self.assertEqual(self.pop, up)
 
+    def testMutationLookupTable(self):
+        for i in self.pop.mut_lookup:
+            self.assertEqual(i[0], pop.mutations[i[1]].pos)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -144,8 +144,12 @@ class testPythonObjects(unittest.TestCase):
         self.assertEqual(self.pop, up)
 
     def testMutationLookupTable(self):
+        from fwdpy11.model_params import SlocusParamsQ
+        from fwdpy11.wright_fisher_qtrait import evolve
+        params = SlocusParamsQ(**self.pdict)
+        evolve(self.rng, self.pop, params)
         for i in self.pop.mut_lookup:
-            self.assertEqual(i[0], pop.mutations[i[1]].pos)
+            self.assertEqual(i[0], self.pop.mutations[i[1]].pos)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes `fwdpy11::Population::mut_lookup` a read-only property of `fwdpy11.Population`.

- [x] Document this in the Sphinx pages.
- [x] Document how you can use this to help when adding mutations.