### PR TITLE
Multiply Pr(mutation class) to each weight.  

### DIFF
--- a/fwdpy11/wright_fisher.py
+++ b/fwdpy11/wright_fisher.py
@@ -41,7 +41,9 @@ def evolve(rng, pop, params, recorder=None):
         params.validate()
 
     from .internal import makeMutationRegions, makeRecombinationRegions
-    mm = makeMutationRegions(rng, pop, params.nregions, params.sregions)
+    pneutral = params.mutrate_n/(params.mutrate_n+params.mutrate_s)
+    mm = makeMutationRegions(rng, pop, params.nregions,
+                             params.sregions, pneutral)
     rm = makeRecombinationRegions(rng, params.recrate, params.recregions)
 
     if recorder is None:

--- a/fwdpy11/wright_fisher_qtrait.py
+++ b/fwdpy11/wright_fisher_qtrait.py
@@ -126,7 +126,9 @@ def _evolve_slocus(rng, pop, params, recorder=None):
         params.validate()
     from .internal import makeMutationRegions, makeRecombinationRegions
     from functools import partial
-    mm = makeMutationRegions(rng, pop, params.nregions, params.sregions)
+    pneutral = params.mutrate_n/(params.mutrate_n+params.mutrate_s)
+    mm = makeMutationRegions(rng, pop, params.nregions,
+                             params.sregions, pneutral)
     rm = makeRecombinationRegions(rng, params.recrate, params.recregions)
 
     noise = None
@@ -170,8 +172,10 @@ def _evolve_mlocus(rng, pop, params, recorder=None):
         noise = GaussianNoise(rng, 0.)
     else:
         noise = params.noise
-    mm = [makeMutationRegions(rng, pop, i, j) for i, j in zip(params.nregions,
-                                                              params.sregions)]
+    mm = [makeMutationRegions(rng, pop, i, j, n/(n+s)) for
+          i, j, n, s in zip(params.nregions,
+                            params.sregions,
+                            params.mutrates_n, params.mutrates_s)]
     rm = [makeRecombinationRegions(rng, i, j) for i, j in zip(
         params.recrates, params.recregions)]
     updater = None


### PR DESCRIPTION
This fixes something missed in PR #84. In that PR, we did not account for the difference
in mutation rates to neutral vs selected mutations when building the
collection of callbacks.  This is now done entirely on the Python
side.