### PR TITLE
Mutation index access

### DIFF
--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -136,7 +136,7 @@ PYBIND11_MODULE(_Population, m)
             population, the value of this property is
             None.
             )delim")
-        .def("mutation_indices",
+        .def("mutation_indexes",
              [](const fwdpy11::Population& pop,
                 const double pos) -> py::object {
                  auto r = pop.mut_lookup.equal_range(pos);
@@ -153,7 +153,7 @@ PYBIND11_MODULE(_Population, m)
                  return rv;
              },
              R"delim(
-             Get indices associated with a mutation position.
+             Get indexes associated with a mutation position.
              
              :param pos: A position
              :type pos: float

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -127,7 +127,15 @@ PYBIND11_MODULE(_Population, m)
                     }
                 return rv;
             },
-            "Mutation position lookup table.")
+            R"delim(
+            Mutation position lookup table.
+            The format is a dict whose keys 
+            are mutation positions and values
+            are lists of indexes.  If no
+            extant mutations are present in the 
+            population, the value of this property is
+            None.
+            )delim")
         .def("mutation_indices",
              [](const fwdpy11::Population& pop,
                 const double pos) -> py::object {
@@ -143,21 +151,34 @@ PYBIND11_MODULE(_Population, m)
                      }
                  rv.attr("sort")();
                  return rv;
-             })
+             },
+             R"delim(
+             Get indices associated with a mutation position.
+             
+             :param pos: A position
+             :type pos: float
+             :return: Indexes in mutation/mutation counts container associated with pos.
+             :rtype: object
+             
+             Returns None if pos does not refer to an extant variant.  Otherwise, 
+             returns a list.
+             )delim",
+             py::arg("pos"))
         .def_readonly("gametes", &fwdpy11::Population::gametes,
                       GAMETES_DOCSTRING)
-        .def_readonly("fixations", &fwdpy11::Population::fixations,
-                      FIXATIONS_DOCSTRING)
-        .def_readonly("fixation_times", &fwdpy11::Population::fixation_times,
-                      FIXATION_TIMES_DOCSTRING)
-        .def("find_mutation_by_key",
-             [](const fwdpy11::Population& pop,
-                const std::tuple<double, double, fwdpp::uint_t>& key,
-                const std::int64_t offset) {
-                 return pop.find_mutation_by_key(key, offset);
-             },
-             py::arg("pop"), py::arg("offset") = 0,
-             R"delim(
+            .def_readonly("fixations", &fwdpy11::Population::fixations,
+                          FIXATIONS_DOCSTRING)
+            .def_readonly("fixation_times",
+                          &fwdpy11::Population::fixation_times,
+                          FIXATION_TIMES_DOCSTRING)
+            .def("find_mutation_by_key",
+                 [](const fwdpy11::Population& pop,
+                    const std::tuple<double, double, fwdpp::uint_t>& key,
+                    const std::int64_t offset) {
+                     return pop.find_mutation_by_key(key, offset);
+                 },
+                 py::arg("pop"), py::arg("offset") = 0,
+                 R"delim(
              Find a mutation by key.
              
              :param key: A mutation key. See :func:`fwdpy11.Mutation.key`.
@@ -171,14 +192,14 @@ PYBIND11_MODULE(_Population, m)
 
              .. versionadded:: 0.2.0
              )delim")
-        .def("find_fixation_by_key",
-             [](const fwdpy11::Population& pop,
-                const std::tuple<double, double, fwdpp::uint_t>& key,
-                const std::int64_t offset) {
-                 return pop.find_fixation_by_key(key, offset);
-             },
-             py::arg("pop"), py::arg("offset") = 0,
-             R"delim(
+            .def("find_fixation_by_key",
+                 [](const fwdpy11::Population& pop,
+                    const std::tuple<double, double, fwdpp::uint_t>& key,
+                    const std::int64_t offset) {
+                     return pop.find_fixation_by_key(key, offset);
+                 },
+                 py::arg("pop"), py::arg("offset") = 0,
+                 R"delim(
              Find a fixation by key.
              
              :param key: A mutation key. See :func:`fwdpy11.Mutation.key`.

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -96,15 +96,34 @@ PYBIND11_MODULE(_Population, m)
         .def_readonly("mcounts", &fwdpy11::Population::mcounts,
                       MCOUNTS_DOCSTRING)
         .def_readwrite("diploid_metadata",
-                      &fwdpy11::Population::diploid_metadata,
-                      "Container of diploid metadata.")
+                       &fwdpy11::Population::diploid_metadata,
+                       "Container of diploid metadata.")
         .def_property_readonly(
             "mut_lookup",
-            [](const fwdpy11::Population& pop) {
-                py::list rv;
-                for (auto&& i : pop.mut_lookup)
+            [](const fwdpy11::Population& pop) -> py::object {
+                py::dict rv;
+                for (std::size_t i = 0; i < pop.mutations.size(); ++i)
                     {
-                        rv.append(py::make_tuple(i.first, i.second));
+                        if (pop.mcounts[i])
+                            {
+                                auto pos_handle
+                                    = py::cast(pop.mutations[i].pos);
+                                if (rv.contains(pos_handle))
+                                    {
+                                        py::list l = rv[pos_handle];
+                                        l.append(i);
+                                    }
+                                else
+                                    {
+                                        py::list l;
+                                        l.append(i);
+                                        rv[pos_handle] = l;
+                                    }
+                            }
+                    }
+                if (rv.size() == 0)
+                    {
+                        return py::none();
                     }
                 return rv;
             },

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -128,6 +128,22 @@ PYBIND11_MODULE(_Population, m)
                 return rv;
             },
             "Mutation position lookup table.")
+        .def("mutation_indices",
+             [](const fwdpy11::Population& pop,
+                const double pos) -> py::object {
+                 auto r = pop.mut_lookup.equal_range(pos);
+                 if (r.first == r.second)
+                     {
+                         return py::none();
+                     }
+                 py::list rv;
+                 for (auto i = r.first; i != r.second; ++i)
+                     {
+                         rv.append(i->second);
+                     }
+                 rv.attr("sort")();
+                 return rv;
+             })
         .def_readonly("gametes", &fwdpy11::Population::gametes,
                       GAMETES_DOCSTRING)
         .def_readonly("fixations", &fwdpy11::Population::fixations,

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -123,9 +123,9 @@ class testPythonObjects(unittest.TestCase):
         evolve(self.rng, self.pop, params)
         lookup = self.pop.mut_lookup
         for key, val in lookup.items():
-            indices = self.pop.mutation_indices(key)
-            self.assertTrue(indices is not None)
-            for i in indices:
+            indexes = self.pop.mutation_indexes(key)
+            self.assertTrue(indexes is not None)
+            for i in indexes:
                 self.assertTrue(i in val)
 
     def testEmptyMutationLookupTable(self):

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -110,8 +110,11 @@ class testPythonObjects(unittest.TestCase):
         from fwdpy11.wright_fisher import evolve
         params = ModelParams(**self.pdict)
         evolve(self.rng, self.pop, params)
-        for i in self.pop.mut_lookup:
-            self.assertEqual(i[0], self.pop.mutations[i[1]].pos)
+        lookup = self.pop.mut_lookup
+        for i in range(len(self.pop.mcounts)):
+            if self.pop.mcounts[i] > 0:
+                self.assertTrue(self.pop.mutations[i].pos in lookup)
+                self.assertTrue(i in lookup[self.pop.mutations[i].pos])
 
 
 if __name__ == "__main__":

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -116,6 +116,18 @@ class testPythonObjects(unittest.TestCase):
                 self.assertTrue(self.pop.mutations[i].pos in lookup)
                 self.assertTrue(i in lookup[self.pop.mutations[i].pos])
 
+    def testMutationIndices(self):
+        from fwdpy11.model_params import ModelParams
+        from fwdpy11.wright_fisher import evolve
+        params = ModelParams(**self.pdict)
+        evolve(self.rng, self.pop, params)
+        lookup = self.pop.mut_lookup
+        for key, val in lookup.items():
+            indices = self.pop.mutation_indices(key)
+            self.assertTrue(indices is not None)
+            for i in indices:
+                self.assertTrue(i in val)
+
     def testEmptyMutationLookupTable(self):
         """
         This test does not use the class fixture.

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -116,6 +116,14 @@ class testPythonObjects(unittest.TestCase):
                 self.assertTrue(self.pop.mutations[i].pos in lookup)
                 self.assertTrue(i in lookup[self.pop.mutations[i].pos])
 
+    def testEmptyMutationLookupTable(self):
+        """
+        This test does not use the class fixture.
+        Instead, we use an empty pop object.
+        """
+        pop = fp11.SlocusPop(100)
+        self.assertTrue(pop.mut_lookup is None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR addresses #120.

* `Population.mut_lookup` now returns a dict.
* Adds `Population.mutation_indexes` to return the indexes corresponding to a mutation position.

cc @DL42