### PR TITLE
Do not allow setup to continue on py3.7 or greater with pybind11 < 2.…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ if sys.version_info < (3, 3):
 if pybind11.__version__ < '2.2.2':
     raise RuntimeError("pybind11 >= " + '2.2.2' + " required")
 
+if sys.version_info >= (3,7):
+    if pybind11.__version__ < '2.3.0':
+        raise RuntimeError("Python 3.7 and newer required pybind11 2.3 or greater")
+
 
 # clang/llvm is default for OS X builds.
 # can over-ride darwin-specific options

--- a/setup.py.in
+++ b/setup.py.in
@@ -18,6 +18,10 @@ if sys.version_info < (3, 3):
 if pybind11.__version__ < '@PYBIND11@':
     raise RuntimeError("pybind11 >= " + '@PYBIND11@' + " required")
 
+if sys.version_info >= (3,7):
+    if pybind11.__version__ < '2.3.0':
+        raise RuntimeError("Python 3.7 and newer required pybind11 2.3 or greater")
+
 
 # clang/llvm is default for OS X builds.
 # can over-ride darwin-specific options


### PR DESCRIPTION
This PR will fix #122 by not allowing setup.py to proceed.  For now, folks will have to install pybind11 from github if they want this combo to work.

cc @vancleve
