### PR TITLE
Simplify matrix to sample

### DIFF
--- a/doc/examples/sampling.rst
+++ b/doc/examples/sampling.rst
@@ -57,8 +57,7 @@ need to convert the matrix format to a list of tuples:
 
     # Need a haplotype matrix
     s = pop.sample(individuals = [0,1,2,3])
-    neutral = fwdpy11.sampling.matrix_to_sample(s)
-    selected = fwdpy11.sampling.matrix_to_sample(s, False)
+    neutral, selected = fwdpy11.sampling.matrix_to_sample(s)
     print(neutral[0])
 
 The format of each tuple element is `(position, genotypes)`, where the genotypes are 0 = ancestral, 1 = derived, and the

--- a/fwdpy11/src/fwdpy11_sampling.cc
+++ b/fwdpy11/src/fwdpy11_sampling.cc
@@ -278,28 +278,34 @@ PYBIND11_MODULE(sampling, m)
     HAPLOTYPE_MATRIX(fwdpy11::MlocusPop, "fwdpy11.MlocusPop");
 
     m.def("matrix_to_sample",
-          [](const fwdpp::data_matrix &m, const bool neutral)
+          [](const fwdpp::data_matrix &m)
 
           {
-              return (neutral) ? fwdpy11::matrix_to_sample(
-                                     m.neutral, m.neutral_positions, m.ncol)
-                               : fwdpy11::matrix_to_sample(
-                                     m.selected, m.selected_positions, m.ncol);
+              auto neutral = fwdpy11::matrix_to_sample(
+                  m.neutral, m.neutral_positions, m.ncol);
+              auto selected = fwdpy11::matrix_to_sample(
+                  m.selected, m.selected_positions, m.ncol);
+              return py::make_tuple(std::move(neutral), std::move(selected));
           },
           R"delim(
-          Convert a :class:`fwdpy11.sampling.DataMatrix` into a
-          list of tuples (float,string).
+          Convert a :class:`fwdpy11.sampling.DataMatrix` into a tuple representing the
+          neutral and selected data, resepectively, as a list of (positon, string) tuples.
+
+          See :ref:`sampling` and :ref:`datamatrix` for more details.
 
           .. versionadded:: 0.1.1
 
+          .. versionchanged:: 0.2.0
+                
+              The return value is now a tuple (neutral, selected)
+
           :param m: A data matrix
           :type m: :class:`fwdpy11.sampling.DataMatrix`
-          :param neutral: Return data for neutral or selected sites. Default is True.
-          :type neutral: bool
 
-          :rtype: list of tuples
+          :rtype: tuple
 
-          :return: The data in list format.  Positions are in same order 
+          :return: A tuple of the (neutral, selected) mutations. Each element of the tuple holds data in list format.
+              Positions are in same order 
               as the original matrix.  The genotypes are represented as strings
               with elements 0 through nrow-1 being in the same order as the original matrix.
 
@@ -313,7 +319,7 @@ PYBIND11_MODULE(sampling, m)
 			into separate lists for each locus.
 
           )delim",
-          py::arg("m"), py::arg("neutral") = true);
+          py::arg("m"));
 
     m.def("separate_samples_by_loci", &fwdpy11::separate_samples_by_loci,
           R"delim(

--- a/tests/test_DataMatrix.py
+++ b/tests/test_DataMatrix.py
@@ -93,8 +93,7 @@ class test_DataMatrixFromSlocusPop(unittest.TestCase):
             j += 1
 
     def testHapMatToSample(self):
-        neut_sample = fwdpy11.sampling.matrix_to_sample(self.hm, True)
-        sel_sample = fwdpy11.sampling.matrix_to_sample(self.hm, False)
+        neut_sample, sel_sample = fwdpy11.sampling.matrix_to_sample(self.hm)
         rowSums = self.hm_neutral.sum(axis=1)
         rowSumsSel = self.hm_selected.sum(axis=1)
         self.assertEqual(len(neut_sample), self.hm_neutral.shape[0])
@@ -132,7 +131,7 @@ class test_DataMatrixFromMlocusPop(unittest.TestCase):
             buffer=self.gm.selected, dtype=np.int8)
 
     def testConvertHapMatrixToSample(self):
-        nsample = fwdpy11.sampling.matrix_to_sample(self.hm, True)
+        nsample, ssample = fwdpy11.sampling.matrix_to_sample(self.hm)
         nsample_split = fwdpy11.sampling.separate_samples_by_loci(
             self.pop.locus_boundaries, nsample)
         self.assertEqual(len(nsample_split), len(self.pop.locus_boundaries))
@@ -145,7 +144,7 @@ class test_DataMatrixFromMlocusPop(unittest.TestCase):
             key += 1
 
     def testConvertGenoMatrixToSample(self):
-        nsample = fwdpy11.sampling.matrix_to_sample(self.gm, True)
+        nsample, ssample = fwdpy11.sampling.matrix_to_sample(self.gm)
         nsample_split = fwdpy11.sampling.separate_samples_by_loci(
             self.pop.locus_boundaries, nsample)
         self.assertEqual(len(nsample_split), len(self.pop.locus_boundaries))

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -63,12 +63,6 @@ class testSampling(unittest.TestCase):
         self.pop = quick_nonneutral_slocus()
         self.rng = fp11.GSLrng(42)
 
-    def testRandomSample(self):
-        import fwdpy11.sampling
-        s = self.pop.sample(rng=self.rng, nsam=10)
-        x = fwdpy11.sampling.matrix_to_sample(s)
-        self.assertTrue(type(x) is list)
-
     def testDefinedSample(self):
         self.pop.sample(individuals=range(10))
 


### PR DESCRIPTION
Changes `fwdpy11.samples.matrix_to_sample` to return a tuple containing the (neutral, selected) data.