### PR TITLE
Implement (minimal?) changes to make noise objects support pickling:

### DIFF
--- a/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <queue>
 #include <tuple>
+#include <pybind11/pybind11.h>
 #include <fwdpy11/types/SlocusPop.hpp>
 #include <fwdpy11/types/MlocusPop.hpp>
 #include <fwdpy11/genetic_values/default_update.hpp>
@@ -40,6 +41,7 @@ namespace fwdpy11
         virtual void update(const SlocusPop & /*pop*/) = 0;
         virtual void update(const MlocusPop & /*pop*/) = 0;
         virtual std::unique_ptr<GeneticValueToFitnessMap> clone() const = 0;
+        virtual pybind11::object pickle() const = 0;
     };
 
     struct GeneticValueIsFitness : public GeneticValueToFitnessMap
@@ -58,6 +60,12 @@ namespace fwdpy11
         {
             return std::unique_ptr<GeneticValueIsFitness>(
                 new GeneticValueIsFitness());
+        }
+
+        virtual pybind11::object
+        pickle() const
+        {
+            return pybind11::bytes("GeneticValueIsFitness");
         }
     };
 
@@ -96,6 +104,12 @@ namespace fwdpy11
         clone() const
         {
             return std::unique_ptr<GSS>(new GSS(opt, VS));
+        }
+
+        virtual pybind11::object
+        pickle() const
+        {
+            return pybind11::make_tuple(opt, VS);
         }
     };
 
@@ -181,6 +195,12 @@ namespace fwdpy11
         clone() const
         {
             return std::unique_ptr<GSSmo>(new GSSmo(*this));
+        }
+
+        virtual pybind11::object
+        pickle() const
+        {
+            return pybind11::make_tuple(opt, VS, current_optimum, optima);
         }
     };
 } //namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusAdditive.hpp
@@ -20,9 +20,11 @@
 #define FWDPY11_GENETIC_VALUES_MLOCUSADDITIVE_HPP__
 
 #include "fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp"
+#include "details/pickle_additive.hpp"
 
 namespace fwdpy11
 {
-    using MlocusAdditive = fwdpp_mlocus_gvalue<fwdpp::additive_diploid>;
+    using MlocusAdditive
+        = fwdpp_mlocus_gvalue<fwdpp::additive_diploid, pickle_additive>;
 } // namespace fwdpy11
 #endif

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusGBR.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusGBR.hpp
@@ -20,12 +20,11 @@
 #define FWDPY11_GENETIC_VALUES_MLOCUSGBR_HPP__
 
 #include "details/GBR.hpp"
+#include "details/pickle_GBR.hpp"
 #include "fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp"
 
 namespace fwdpy11
 {
-    using MlocusGBR = fwdpp_mlocus_gvalue<GBR>;
+    using MlocusGBR = fwdpp_mlocus_gvalue<GBR, pickle_GBR>;
 } // namespace fwdpy11
 #endif
-
-

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusMult.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusMult.hpp
@@ -19,11 +19,12 @@
 #ifndef FWDPY11_GENETIC_VALUES_MLOCUSMULT_HPP__
 #define FWDPY11_GENETIC_VALUES_MLOCUSMULT_HPP__
 
+#include "details/pickle_multiplicative.hpp"
 #include "fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp"
 
 namespace fwdpy11
 {
-    using MlocusMult = fwdpp_mlocus_gvalue<fwdpp::multiplicative_diploid>;
+    using MlocusMult = fwdpp_mlocus_gvalue<fwdpp::multiplicative_diploid,
+                                           pickle_multiplicative>;
 } // namespace fwdpy11
 #endif
-

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
@@ -39,6 +39,7 @@ namespace fwdpy11
                              const std::size_t /*parent2*/,
                              const MlocusPop& /*pop*/) const = 0;
         virtual void update(const fwdpy11::MlocusPop& /*pop*/) = 0;
+        virtual pybind11::object pickle() const = 0;
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusAdditive.hpp
@@ -20,11 +20,12 @@
 #define FWDPY11_GENETIC_VALUES_SLOCUSADDITIVE_HPP__
 
 #include <fwdpp/fitness_models.hpp>
+#include "details/pickle_additive.hpp"
 #include "fwdpp_wrappers/fwdpp_slocus_gvalue.hpp"
 
 namespace fwdpy11
 {
-    using SlocusAdditive = fwdpp_slocus_gvalue<fwdpp::additive_diploid>;
+    using SlocusAdditive = fwdpp_slocus_gvalue<fwdpp::additive_diploid,pickle_additive>;
 } // namespace fwdpy11
 
 #endif

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusGBR.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusGBR.hpp
@@ -21,10 +21,11 @@
 
 #include "fwdpp_wrappers/fwdpp_slocus_gvalue.hpp"
 #include "details/GBR.hpp"
+#include "details/pickle_GBR.hpp"
 
 namespace fwdpy11
 {
-    using SlocusGBR = fwdpp_slocus_gvalue<GBR>;
+    using SlocusGBR = fwdpp_slocus_gvalue<GBR,pickle_GBR>;
 } // namespace fwdpy11
 
 #endif

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusMult.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusMult.hpp
@@ -20,10 +20,12 @@
 #define FWDPY11_GENETIC_VALUES_SLOCUSMULT_HPP__
 
 #include <fwdpp/fitness_models.hpp>
+#include "details/pickle_multiplicative.hpp"
 #include "fwdpp_wrappers/fwdpp_slocus_gvalue.hpp"
 
 namespace fwdpy11
 {
-    using SlocusMult = fwdpp_slocus_gvalue<fwdpp::multiplicative_diploid>;
+    using SlocusMult = fwdpp_slocus_gvalue<fwdpp::multiplicative_diploid,
+                                           pickle_multiplicative>;
 } // namespace fwdpy11
 #endif

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
@@ -20,6 +20,7 @@
 #define FWDPY11_SLOCUSPOP_GENETIC_VALUE_HPP__
 
 #include <cstdint>
+#include <pybind11/pybind11.h>
 #include <fwdpy11/rng.hpp>
 #include <fwdpy11/types/SlocusPop.hpp>
 #include "GeneticValueToFitness.hpp"
@@ -54,6 +55,7 @@ namespace fwdpy11
                              const std::size_t /*parent2*/,
                              const SlocusPop& /*pop*/) const = 0;
         virtual void update(const SlocusPop& /*pop*/) = 0;
+        virtual pybind11::object pickle() const = 0;
     };
 } //namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_GBR.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_GBR.hpp
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_GBR_HPP
+#define FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_GBR_HPP
+
+#include <pybind11/pybind11.h>
+#include <fwdpp/fitness_models.hpp>
+#include "GBR.hpp"
+
+namespace fwdpy11
+{
+    struct pickle_GBR
+    {
+        inline pybind11::object
+        operator()(const GBR& g) const
+        {
+            return pybind11::bytes("GBR");
+        }
+    };
+} // namespace fwdpy11
+
+#endif
+

--- a/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_additive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_additive.hpp
@@ -1,0 +1,43 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_ADDITIVE_HPP
+#define FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_ADDITIVE_HPP
+
+#include <pybind11/pybind11.h>
+#include <fwdpp/fitness_models.hpp>
+
+namespace fwdpy11
+{
+    struct pickle_additive
+    {
+        inline pybind11::object
+        operator()(const fwdpp::additive_diploid& a) const
+        {
+            int p = 0;
+            if (a.p == fwdpp::additive_diploid::policy::atrait)
+                {
+                    p = 1;
+                }
+            return pybind11::make_tuple(p, a.scaling);
+        }
+    };
+} // namespace fwdpy11
+
+#endif

--- a/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_multiplicative.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/details/pickle_multiplicative.hpp
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_MULTIPLICATIVE_HPP
+#define FWDPY11_GENETIC_VALUES_DETAILS_PICKLE_MULTIPLICATIVE_HPP
+
+#include <pybind11/pybind11.h>
+#include <fwdpp/fitness_models.hpp>
+
+namespace fwdpy11
+{
+    struct pickle_multiplicative
+    {
+        inline pybind11::object
+        operator()(const fwdpp::multiplicative_diploid& m) const
+        {
+            int p = 0;
+            if (m.p == fwdpp::multiplicative_diploid::policy::mtrait)
+                {
+                    p = 1;
+                }
+            return pybind11::make_tuple(p, m.scaling);
+        }
+    };
+} // namespace fwdpy11
+
+#endif
+

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
@@ -31,7 +31,7 @@ namespace fwdpy11
             : MlocusPopGeneticValueWithMapping{ GeneticValueIsFitness() },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
               agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
-              pickle_fxn{ pickleFunction() }
+              pickle_fxn(pickleFunction())
         {
         }
 
@@ -41,7 +41,7 @@ namespace fwdpy11
             : MlocusPopGeneticValueWithMapping{ gv2w_ },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
               agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
-              pickle_fxn{ pickleFunction() }
+              pickle_fxn(pickleFunction())
 
         {
         }
@@ -53,7 +53,7 @@ namespace fwdpy11
             : MlocusPopGeneticValueWithMapping{ gv2w_, noise_ },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
               agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
-              pickle_fxn{ pickleFunction() }
+              pickle_fxn(pickleFunction())
         {
         }
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
@@ -2,6 +2,7 @@
 #define FWDPY11_GENETIC_VALUES_WRAPPERS_FWDPP_MLOCUS_GVALUE_HPP__
 
 #include <vector>
+#include <type_traits>
 #include <functional>
 #include <algorithm>
 #include "../MlocusPopGeneticValueWithMapping.hpp"
@@ -9,21 +10,28 @@
 
 namespace fwdpy11
 {
-    template <typename fwdppT>
+    template <typename fwdppT, typename pickleFunction>
     struct fwdpp_mlocus_gvalue
         : public fwdpy11::MlocusPopGeneticValueWithMapping
     {
+        static_assert(
+            std::is_convertible<pickleFunction, std::function<pybind11::object(
+                                                    const fwdppT&)>>::value,
+            "pickling function must be convertible to "
+            "std::function<pybind11::object(const fwdppT*)>");
         using gvalue_map_ptr
             = std::unique_ptr<fwdpy11::GeneticValueToFitnessMap>;
         const fwdppT gv;
         std::function<double(const std::vector<double>&)> agg;
         mutable std::vector<double> per_locus_genetic_values;
+        const pickleFunction pickle_fxn;
 
         template <typename forwarded_fwdppT, typename agg_t>
         fwdpp_mlocus_gvalue(forwarded_fwdppT&& gv_, agg_t&& agg_)
             : MlocusPopGeneticValueWithMapping{ GeneticValueIsFitness() },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
-              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{}
+              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
+              pickle_fxn{ pickleFunction() }
         {
         }
 
@@ -32,7 +40,9 @@ namespace fwdpy11
                             const GeneticValueToFitnessMap& gv2w_)
             : MlocusPopGeneticValueWithMapping{ gv2w_ },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
-              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{}
+              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
+              pickle_fxn{ pickleFunction() }
+
         {
         }
 
@@ -42,8 +52,8 @@ namespace fwdpy11
                             const GeneticValueNoise& noise_)
             : MlocusPopGeneticValueWithMapping{ gv2w_, noise_ },
               gv{ std::forward<forwarded_fwdppT>(gv_) },
-              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{}
-
+              agg{ std::forward<agg_t>(agg_) }, per_locus_genetic_values{},
+              pickle_fxn{ pickleFunction() }
         {
         }
 
@@ -53,7 +63,8 @@ namespace fwdpy11
         {
             per_locus_genetic_values.clear();
             // Back inserter amoritizes memory allocations very quickly.
-            std::transform(pop.diploids[diploid_index].begin(), pop.diploids[diploid_index].end(),
+            std::transform(pop.diploids[diploid_index].begin(),
+                           pop.diploids[diploid_index].end(),
                            std::back_inserter(per_locus_genetic_values),
                            [this, &pop](const DiploidGenotype& g) {
                                return gv(g, pop.gametes, pop.mutations);
@@ -66,6 +77,11 @@ namespace fwdpy11
         {
             gv2w->update(pop);
             noise_fxn->update(pop);
+        }
+        virtual pybind11::object
+        pickle() const
+        {
+            return pickle_fxn(gv);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
@@ -25,9 +25,8 @@ namespace fwdpy11
         template <typename forwarded_fwdppT>
         fwdpp_slocus_gvalue(forwarded_fwdppT&& gv_)
             : SlocusPopGeneticValueWithMapping{ GeneticValueIsFitness() },
-              gv{ std::forward<forwarded_fwdppT>(gv_) }, pickle_fxn{
-                  pickleFunction{}
-              }
+              gv{ std::forward<forwarded_fwdppT>(gv_) },
+              pickle_fxn(pickleFunction{})
         {
         }
 
@@ -35,9 +34,8 @@ namespace fwdpy11
         fwdpp_slocus_gvalue(forwarded_fwdppT&& gv_,
                             const GeneticValueToFitnessMap& gv2w_)
             : SlocusPopGeneticValueWithMapping{ gv2w_ },
-              gv{ std::forward<forwarded_fwdppT>(gv_) }, pickle_fxn{
-                  pickleFunction()
-              }
+              gv{ std::forward<forwarded_fwdppT>(gv_) },
+              pickle_fxn(pickleFunction())
         {
         }
 
@@ -49,7 +47,7 @@ namespace fwdpy11
               gv{ std::forward<forwarded_fwdppT>(gv_)
 
               },
-              pickle_fxn{ pickleFunction() }
+              pickle_fxn(pickleFunction())
 
         {
         }

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
@@ -1,23 +1,32 @@
 #ifndef FWDPY11_GENETIC_VALUES_WRAPPERS_FWDPP_SLOCUS_GVALUE_HPP__
 #define FWDPY11_GENETIC_VALUES_WRAPPERS_FWDPP_SLOCUS_GVALUE_HPP__
 
+#include <type_traits>
+#include <functional>
 #include "../SlocusPopGeneticValueWithMapping.hpp"
 #include "../noise.hpp"
 
 namespace fwdpy11
 {
-    template <typename fwdppT>
+    template <typename fwdppT, typename pickleFunction>
     struct fwdpp_slocus_gvalue
         : public fwdpy11::SlocusPopGeneticValueWithMapping
     {
         using gvalue_map_ptr
             = std::unique_ptr<fwdpy11::GeneticValueToFitnessMap>;
         const fwdppT gv;
+        const pickleFunction pickle_fxn;
+        static_assert(
+            std::is_convertible<pickleFunction, std::function<pybind11::object(
+                                                    const fwdppT&)>>::value,
+            "pickling function must be convertible to "
+            "std::function<pybind11::object(const fwdppT*)>");
 
         template <typename forwarded_fwdppT>
         fwdpp_slocus_gvalue(forwarded_fwdppT&& gv_)
-            : SlocusPopGeneticValueWithMapping{ GeneticValueIsFitness() }, gv{
-                  std::forward<forwarded_fwdppT>(gv_)
+            : SlocusPopGeneticValueWithMapping{ GeneticValueIsFitness() },
+              gv{ std::forward<forwarded_fwdppT>(gv_) }, pickle_fxn{
+                  pickleFunction{}
               }
         {
         }
@@ -25,8 +34,9 @@ namespace fwdpy11
         template <typename forwarded_fwdppT>
         fwdpp_slocus_gvalue(forwarded_fwdppT&& gv_,
                             const GeneticValueToFitnessMap& gv2w_)
-            : SlocusPopGeneticValueWithMapping{ gv2w_ }, gv{
-                  std::forward<forwarded_fwdppT>(gv_)
+            : SlocusPopGeneticValueWithMapping{ gv2w_ },
+              gv{ std::forward<forwarded_fwdppT>(gv_) }, pickle_fxn{
+                  pickleFunction()
               }
         {
         }
@@ -35,9 +45,11 @@ namespace fwdpy11
         fwdpp_slocus_gvalue(forwarded_fwdppT&& gv_,
                             const GeneticValueToFitnessMap& gv2w_,
                             const GeneticValueNoise& noise_)
-            : SlocusPopGeneticValueWithMapping{ gv2w_, noise_ }, gv{
-                  std::forward<forwarded_fwdppT>(gv_)
-              }
+            : SlocusPopGeneticValueWithMapping{ gv2w_, noise_ },
+              gv{ std::forward<forwarded_fwdppT>(gv_)
+
+              },
+              pickle_fxn{ pickleFunction() }
 
         {
         }
@@ -54,6 +66,12 @@ namespace fwdpy11
         {
             gv2w->update(pop);
             noise_fxn->update(pop);
+        }
+
+        virtual pybind11::object
+        pickle() const
+        {
+            return pickle_fxn(gv);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
@@ -20,6 +20,7 @@
 #define FWDPY11_GENETIC_VALUES_NOISE_HPP__
 
 #include <memory>
+#include <pybind11/pybind11.h>
 #include <fwdpy11/types/Diploid.hpp>
 #include <fwdpy11/types/SlocusPop.hpp>
 #include <fwdpy11/types/MlocusPop.hpp>
@@ -31,19 +32,22 @@ namespace fwdpy11
     struct GeneticValueNoise
     ///ABC for random effects on trait values
     {
-        virtual double operator()(const GSLrng_t& /* rng */,
-                                  const DiploidMetadata& /*offspring_metadata*/,
-                                  const std::size_t /*parent1*/,
-                                  const std::size_t /*parent2*/,
-                                  const SlocusPop& /*pop*/) const = 0;
-        virtual double operator()(const GSLrng_t& /* rng */,
-                                  const DiploidMetadata& /*offspring_metadata*/,
-                                  const std::size_t /*parent1*/,
-                                  const std::size_t /*parent2*/,
-                                  const MlocusPop& /*pop*/) const = 0;
-                virtual void update(const SlocusPop& /*pop*/) = 0;
+        virtual double
+        operator()(const GSLrng_t& /* rng */,
+                   const DiploidMetadata& /*offspring_metadata*/,
+                   const std::size_t /*parent1*/,
+                   const std::size_t /*parent2*/,
+                   const SlocusPop& /*pop*/) const = 0;
+        virtual double
+        operator()(const GSLrng_t& /* rng */,
+                   const DiploidMetadata& /*offspring_metadata*/,
+                   const std::size_t /*parent1*/,
+                   const std::size_t /*parent2*/,
+                   const MlocusPop& /*pop*/) const = 0;
+        virtual void update(const SlocusPop& /*pop*/) = 0;
         virtual void update(const MlocusPop& /*pop*/) = 0;
         virtual std::unique_ptr<GeneticValueNoise> clone() const = 0;
+        virtual pybind11::object pickle() const = 0;
     };
 
     struct NoNoise : public GeneticValueNoise
@@ -73,6 +77,18 @@ namespace fwdpy11
         clone() const
         {
             return std::unique_ptr<NoNoise>(new NoNoise());
+        }
+
+        virtual pybind11::object
+        pickle() const
+        {
+            return pybind11::none();
+        }
+
+        static inline NoNoise
+        unpickle(pybind11::object& o)
+        {
+            return NoNoise();
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
@@ -82,12 +82,17 @@ namespace fwdpy11
         virtual pybind11::object
         pickle() const
         {
-            return pybind11::none();
+            return pybind11::bytes("NoNoise");
         }
 
-        static inline NoNoise
+        static inline const NoNoise
         unpickle(pybind11::object& o)
         {
+            auto s = o.cast<std::string>();
+            if (s != "NoNoise")
+                {
+                    throw std::runtime_error("invalid object state");
+                }
             return NoNoise();
         }
     };

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -55,7 +55,7 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     virtual pybind11::object
     pickle() const
     {
-        return py::make_tuple(mean, sd);
+        return py::make_tuple(sd, mean);
     }
 
     static inline GaussianNoise

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -70,6 +70,35 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     }
 };
 
+// Mocking what it takes to get pickling support for a class structure
+// and then an object that is composed of unique_ptr to base classes
+struct Base
+{
+    virtual std::string repr() const = 0;
+    virtual std::unique_ptr<Base> clone() const = 0;
+};
+
+struct Derived : public Base
+{
+    virtual std::string
+    repr() const
+    {
+        return std::string("fwdpy11.genetic_value_noise.Derived");
+    }
+    virtual std::unique_ptr<Base>
+    clone() const
+    {
+        return std::unique_ptr<Base>(new Derived(*this));
+    }
+};
+
+struct Composed
+{
+    double x;
+    std::unique_ptr<Base> b;
+    template <typename X> Composed(double a, X&& b_) : x(a), b{ b_.clone() } {}
+};
+
 PYBIND11_MODULE(genetic_value_noise, m)
 {
     m.doc() = "\"Noise\" added to genetic values.";
@@ -97,4 +126,59 @@ PYBIND11_MODULE(genetic_value_noise, m)
         .def(py::pickle(
             [](const GaussianNoise& o) -> py::object { return o.pickle(); },
             [](py::object& o) { return GaussianNoise::unpickle(o); }));
+
+    // This is an ABC
+    py::class_<Base>(m, "Base");
+
+    // This is a concrete class that can be pickled.
+    py::class_<Derived, Base>(m, "Derived")
+        .def(py::pickle(
+            [](const Derived& o) -> py::object {
+                return py::make_tuple(py::bytes(o.repr()));
+            },
+            [](py::object o) -> Derived {
+                py::tuple t(o);
+                if (t.size() != 1)
+                    {
+                        throw std::runtime_error("invalid object state");
+                    }
+                auto s = t[0].cast<std::string>();
+                if (s.find("Derived") == std::string::npos)
+                    {
+                        throw std::runtime_error("invalid obect state");
+                    }
+                return Derived();
+            }))
+        .def(py::init<>());
+
+    py::class_<Composed>(m, "Composed")
+        .def(py::init(
+            [](const double d, const Base& b) { return Composed(d, b); }))
+        .def_property_readonly("b",
+                               [](const Composed& c) { return c.b->repr(); })
+        .def(py::pickle(
+            // In order to pickle,
+            // we return a tuple of c's data plus
+            // the result of pickling c.b
+            [](const Composed& c) {
+                auto x = py::module::import("pickle");
+                auto y = x.attr("dumps")(c.b->clone(), -1);
+                return py::make_tuple(c.x, y);
+            },
+            // Unpickling requires some casting magic
+            [](py::tuple t) {
+                if (t.size() != 2)
+                    {
+                        throw std::runtime_error("invalid object state");
+                    }
+                auto x = py::module::import("pickle");
+                auto b = x.attr("loads")(t[1]);
+                // We take a const reference to our abstract
+                // base in order to compose a new object
+                // from the pickled member data.
+                // This ONLY works if pickling of classes in
+                // our ABC hierarchy is working.
+                const Base& br = b.cast<const Base&>();
+                return Composed(t[0].cast<double>(), br);
+            }));
 }

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -70,35 +70,6 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     }
 };
 
-// Mocking what it takes to get pickling support for a class structure
-// and then an object that is composed of unique_ptr to base classes
-struct Base
-{
-    virtual std::string repr() const = 0;
-    virtual std::unique_ptr<Base> clone() const = 0;
-};
-
-struct Derived : public Base
-{
-    virtual std::string
-    repr() const
-    {
-        return std::string("fwdpy11.genetic_value_noise.Derived");
-    }
-    virtual std::unique_ptr<Base>
-    clone() const
-    {
-        return std::unique_ptr<Base>(new Derived(*this));
-    }
-};
-
-struct Composed
-{
-    double x;
-    std::unique_ptr<Base> b;
-    template <typename X> Composed(double a, X&& b_) : x(a), b{ b_.clone() } {}
-};
-
 PYBIND11_MODULE(genetic_value_noise, m)
 {
     m.doc() = "\"Noise\" added to genetic values.";
@@ -130,52 +101,4 @@ PYBIND11_MODULE(genetic_value_noise, m)
         .def(py::pickle(
             [](const GaussianNoise& o) -> py::object { return o.pickle(); },
             [](py::object& o) { return GaussianNoise::unpickle(o); }));
-
-    // This is an ABC
-    py::class_<Base>(m, "Base");
-
-    // This is a concrete class that can be pickled.
-    py::class_<Derived, Base>(m, "Derived")
-        .def(py::pickle(
-            [](const Derived& o) -> py::object { return py::bytes(o.repr()); },
-            [](py::object o) -> Derived {
-                auto s = o.cast<std::string>();
-                if (s.find("Derived") == std::string::npos)
-                    {
-                        throw std::runtime_error("invalid obect state");
-                    }
-                return Derived();
-            }))
-        .def(py::init<>());
-
-    py::class_<Composed>(m, "Composed")
-        .def(py::init(
-            [](const double d, const Base& b) { return Composed(d, b); }))
-        .def_property_readonly("b",
-                               [](const Composed& c) { return c.b->repr(); })
-        .def(py::pickle(
-            // In order to pickle,
-            // we return a tuple of c's data plus
-            // the result of pickling c.b
-            [](const Composed& c) {
-                auto x = py::module::import("pickle");
-                auto y = x.attr("dumps")(c.b->clone(), -1);
-                return py::make_tuple(c.x, y);
-            },
-            // Unpickling requires some casting magic
-            [](py::tuple t) {
-                if (t.size() != 2)
-                    {
-                        throw std::runtime_error("invalid object state");
-                    }
-                auto x = py::module::import("pickle");
-                auto b = x.attr("loads")(t[1]);
-                // We take a const reference to our abstract
-                // base in order to compose a new object
-                // from the pickled member data.
-                // This ONLY works if pickling of classes in
-                // our ABC hierarchy is working.
-                const Base& br = b.cast<const Base&>();
-                return Composed(t[0].cast<double>(), br);
-            }));
 }

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -123,6 +123,8 @@ PYBIND11_MODULE(genetic_value_noise, m)
                 :param mean: Mean value of noise.
                 :type mean: float
                 )delim")
+        .def_readonly("mean", &GaussianNoise::mean)
+        .def_readonly("sd", &GaussianNoise::sd)
         .def(py::pickle(
             [](const GaussianNoise& o) -> py::object { return o.pickle(); },
             [](py::object& o) { return GaussianNoise::unpickle(o); }));

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -112,7 +112,9 @@ PYBIND11_MODULE(genetic_value_noise, m)
         .def(py::init<>())
         .def(py::pickle(
             [](const fwdpy11::NoNoise& o) -> py::object { return o.pickle(); },
-            [](py::object& o) { return fwdpy11::NoNoise::unpickle(o); }));
+            [](py::object& o) {
+                return fwdpy11::NoNoise::unpickle(o);
+            }));
 
     py::class_<GaussianNoise, fwdpy11::GeneticValueNoise>(
         m, "GaussianNoise", "Gaussian noise added to genetic values.")

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -133,16 +133,9 @@ PYBIND11_MODULE(genetic_value_noise, m)
     // This is a concrete class that can be pickled.
     py::class_<Derived, Base>(m, "Derived")
         .def(py::pickle(
-            [](const Derived& o) -> py::object {
-                return py::make_tuple(py::bytes(o.repr()));
-            },
+            [](const Derived& o) -> py::object { return py::bytes(o.repr()); },
             [](py::object o) -> Derived {
-                py::tuple t(o);
-                if (t.size() != 1)
-                    {
-                        throw std::runtime_error("invalid object state");
-                    }
-                auto s = t[0].cast<std::string>();
+                auto s = o.cast<std::string>();
                 if (s.find("Derived") == std::string::npos)
                     {
                         throw std::runtime_error("invalid obect state");

--- a/fwdpy11/src/genetic_value_noise.cc
+++ b/fwdpy11/src/genetic_value_noise.cc
@@ -51,6 +51,23 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     {
         return std::unique_ptr<GaussianNoise>(new GaussianNoise(*this));
     }
+
+    virtual pybind11::object
+    pickle() const
+    {
+        return py::make_tuple(mean, sd);
+    }
+
+    static inline GaussianNoise
+    unpickle(pybind11::object& o)
+    {
+        py::tuple t(o);
+        if (t.size() != 2)
+            {
+                throw std::runtime_error("invalid object state");
+            }
+        return GaussianNoise(t[0].cast<double>(), t[1].cast<double>());
+    }
 };
 
 PYBIND11_MODULE(genetic_value_noise, m)
@@ -63,7 +80,10 @@ PYBIND11_MODULE(genetic_value_noise, m)
 
     py::class_<fwdpy11::NoNoise, fwdpy11::GeneticValueNoise>(
         m, "NoNoise", "Type implying no random effects on genetic values.")
-        .def(py::init<>());
+        .def(py::init<>())
+        .def(py::pickle(
+            [](const fwdpy11::NoNoise& o) -> py::object { return o.pickle(); },
+            [](py::object& o) { return fwdpy11::NoNoise::unpickle(o); }));
 
     py::class_<GaussianNoise, fwdpy11::GeneticValueNoise>(
         m, "GaussianNoise", "Gaussian noise added to genetic values.")
@@ -73,5 +93,8 @@ PYBIND11_MODULE(genetic_value_noise, m)
                 :type sd: float
                 :param mean: Mean value of noise.
                 :type mean: float
-                )delim");
+                )delim")
+        .def(py::pickle(
+            [](const GaussianNoise& o) -> py::object { return o.pickle(); },
+            [](py::object& o) { return GaussianNoise::unpickle(o); }));
 }

--- a/fwdpy11/src/genetic_values.cc
+++ b/fwdpy11/src/genetic_values.cc
@@ -522,6 +522,9 @@ PYBIND11_MODULE(genetic_values, m)
             Each element of optima must be a tuple of 
             (generation, optimal trait value, VS)
             )delim")
+        .def_readonly("VS",&fwdpy11::GSSmo::VS)
+        .def_readonly("opt",&fwdpy11::GSSmo::opt)
+        .def_readonly("optima",&fwdpy11::GSSmo::optima)
         .def(py::pickle(
             [](const fwdpy11::GSSmo& g) { return g.pickle(); },
             [](py::object o) {

--- a/tests/custom_additive.cpp
+++ b/tests/custom_additive.cpp
@@ -56,6 +56,11 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
         return 0.0;
     }
 
+    pybind11::object
+    pickle() const
+    {
+        return pybind11::bytes("custom_additive");
+    }
     DEFAULT_SLOCUSPOP_UPDATE();
 };
 
@@ -66,5 +71,16 @@ PYBIND11_MODULE(custom_additive, m)
         = pybind11::module::import("fwdpy11.genetic_values")
               .attr("SlocusPopGeneticValue");
     pybind11::class_<additive, fwdpy11::SlocusPopGeneticValue>(m, "additive")
-        .def(pybind11::init<>());
+        .def(pybind11::init<>())
+        .def(pybind11::pickle([](const additive& a) { return a.pickle(); },
+                              [](pybind11::object o) {
+                                  pybind11::bytes b(o);
+                                  auto s = b.cast<std::string>();
+                                  if (s != "custom_additive")
+                                      {
+                                          throw std::runtime_error(
+                                              "invalid object state");
+                                      }
+                                  return additive();
+                              }));
 }

--- a/tests/custom_stateless_genotype.cpp
+++ b/tests/custom_stateless_genotype.cpp
@@ -56,6 +56,12 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
         return 0.0;
     }
 
+    pybind11::object
+    pickle() const
+    {
+        return pybind11::bytes("custom_stateless_genotype");
+    }
+
     DEFAULT_SLOCUSPOP_UPDATE();
 };
 
@@ -66,5 +72,16 @@ PYBIND11_MODULE(custom_stateless_genotype, m)
         = pybind11::module::import("fwdpy11.genetic_values")
               .attr("SlocusPopGeneticValue");
     pybind11::class_<GeneralW, fwdpy11::SlocusPopGeneticValue>(m, "GeneralW")
-        .def(pybind11::init<>());
+        .def(pybind11::init<>())
+        .def(pybind11::pickle([](const GeneralW& g) { return g.pickle(); },
+                              [](pybind11::object o) {
+                                  pybind11::bytes b(o);
+                                  auto s = b.cast<std::string>();
+                                  if (s != "custom_stateless_genotype")
+                                      {
+                                          throw std::runtime_error(
+                                              "invalid object state");
+                                      }
+                                  return GeneralW();
+                              }));
 }

--- a/tests/pickling_composed_classes.cpp
+++ b/tests/pickling_composed_classes.cpp
@@ -1,0 +1,101 @@
+// clang-format off
+<% 
+setup_pybind11(cfg) 
+#import fwdpy11 so we can find its C++ headers
+import fwdpy11 as fp11 
+#add fwdpy11 header locations to the include path
+cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
+%>
+// clang-format on
+
+// Mocking what it takes to get pickling support for a class structure
+// and then an object that is composed of unique_ptr to base classes
+
+#include <pybind11/pybind11.h>
+#include <string>
+#include <memory>
+
+    namespace py = pybind11;
+
+struct Base
+{
+    virtual py::object repr() const = 0;
+    virtual std::unique_ptr<Base> clone() const = 0;
+};
+
+struct Derived : public Base
+{
+    virtual py::object
+    repr() const
+    {
+        return py::bytes("Derived");
+    }
+
+    virtual std::unique_ptr<Base>
+    clone() const
+    {
+        return std::unique_ptr<Base>(new Derived(*this));
+    }
+};
+
+struct Composed
+// This type is a composition of a double
+// and an object in the Base class hierarchy.
+// This roughly mocks how things like genetic
+// value objects are implemented on the C++ side.
+{
+    double x;
+    std::unique_ptr<Base> b;
+    template <typename X> Composed(double a, X&& b_) : x(a), b{ b_.clone() } {}
+};
+
+PYBIND11_MODULE(pickling_composed_classes, m)
+{
+    // This is an ABC
+    py::class_<Base>(m, "Base");
+
+    // This is a concrete class that can be pickled.
+    py::class_<Derived, Base>(m, "Derived")
+        .def(py::pickle(
+            [](const Derived& o) -> py::object { return py::bytes(o.repr()); },
+            [](py::object o) -> Derived {
+                auto s = o.cast<std::string>();
+                if (s.find("Derived") == std::string::npos)
+                    {
+                        throw std::runtime_error("invalid obect state");
+                    }
+                return Derived();
+            }))
+        .def(py::init<>());
+
+    py::class_<Composed>(m, "Composed")
+        .def(py::init(
+            [](const double d, const Base& b) { return Composed(d, b); }))
+        .def_property_readonly("b",
+                               [](const Composed& c) { return c.b->repr(); })
+        .def(py::pickle(
+            // In order to pickle,
+            // we return a tuple of c's data plus
+            // the result of pickling c.b
+            [](const Composed& c) {
+                auto x = py::module::import("pickle");
+                auto y = x.attr("dumps")(c.b->clone(), -1);
+                return py::make_tuple(c.x, y);
+            },
+            // Unpickling requires some casting magic
+            [](py::tuple t) {
+                if (t.size() != 2)
+                    {
+                        throw std::runtime_error("invalid object state");
+                    }
+                auto x = py::module::import("pickle");
+                auto b = x.attr("loads")(t[1]);
+                // We take a const reference to our abstract
+                // base in order to compose a new object
+                // from the pickled member data.
+                // This ONLY works if pickling of classes in
+                // our ABC hierarchy is working.
+                const Base& br = b.cast<const Base&>();
+                return Composed(t[0].cast<double>(), br);
+            }));
+}

--- a/tests/test_custom_stateless_fitness.py
+++ b/tests/test_custom_stateless_fitness.py
@@ -1,15 +1,14 @@
 import cppimport
-cppimport.force_rebuild()
-ca = cppimport.imp("custom_additive")
-general = cppimport.imp("custom_stateless_genotype")
 import fwdpy11
 import fwdpy11.ezparams
 import fwdpy11.model_params
 import fwdpy11.wright_fisher
 import fwdpy11.fwdpy11_types
-import copy
 import pickle
 import unittest
+cppimport.force_rebuild()
+ca = cppimport.imp("custom_additive")
+general = cppimport.imp("custom_stateless_genotype")
 
 
 class testCustomAdditive(unittest.TestCase):
@@ -25,6 +24,12 @@ class testCustomAdditive(unittest.TestCase):
 
     def testEvolve(self):
         fwdpy11.wright_fisher.evolve(self.rng, self.pop, self.params)
+
+    def testPickle(self):
+        a = self.params.make_gvalue()
+        p = pickle.dumps(a, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(a), type(up))
 
     # TODO: test this once built-in SlocusAdditive is callable
     # def testCorrectNess(self):
@@ -45,6 +50,12 @@ class testGeneralModule(unittest.TestCase):
         self.pdict['gvalue'] = (general.GeneralW, )
         self.rng = fwdpy11.GSLrng(42)
         self.params = fwdpy11.model_params.ModelParams(**self.pdict)
+
+    def testPickle(self):
+        a = self.params.make_gvalue()
+        p = pickle.dumps(a, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(a), type(up))
 
     def testEvolve(self):
         fwdpy11.wright_fisher.evolve(self.rng, self.pop, self.params)

--- a/tests/test_genetic_value_noise.py
+++ b/tests/test_genetic_value_noise.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your meanion) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+
+# Main goal is to test pickling
+
+import unittest
+
+
+class testNoNoise(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_value_noise
+        self.n = fwdpy11.genetic_value_noise.NoNoise()
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.n, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(up), type(self.n))
+
+
+class testNoNoisePackageAlias(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_value_noise as fancyname
+        self.n = fancyname.NoNoise()
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.n, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(up), type(self.n))
+
+
+class testGaussianNoise(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_value_noise
+        self.sd = 1.0
+        self.mean = 0.0
+        self.n = fwdpy11.genetic_value_noise.GaussianNoise(
+            sd=self.sd, mean=self.mean)
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.n, -1)
+        up = pickle.loads(p)
+        self.assertEqual(up.sd, self.sd)
+        self.assertEqual(up.mean, self.mean)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_genetic_value_to_fitness.py
+++ b/tests/test_genetic_value_to_fitness.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your meanion) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+
+# Main goal is to test pickling
+
+import unittest
+
+
+class testGeneticValueIsFitness(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_values
+        self.g = fwdpy11.genetic_values.GeneticValueIsFitness()
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.g, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(up), type(self.g))
+
+
+class testGSS(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_values
+        self.VS = 1.0
+        self.opt = 0.0
+        self.g = fwdpy11.genetic_values.GSS(VS=self.VS, opt=self.opt)
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.g, -1)
+        up = pickle.loads(p)
+        self.assertEqual(up.VS, self.VS)
+        self.assertEqual(up.opt, self.opt)
+
+
+class testGSSmo(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_values
+        self.optima = [(0, 0.0, 1.0), (100, 1.0, 1.0)]
+        self.g = fwdpy11.genetic_values.GSSmo(self.optima)
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.g)
+        up = pickle.loads(p)
+        self.assertEqual(up.VS, 1.0)
+        self.assertEqual(up.opt, 0.0)
+        self.assertEqual(up.optima, self.optima)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -46,6 +46,15 @@ class testSlocusAdditive(unittest.TestCase):
         self.assertEqual(type(up.gvalue_to_fitness),
                          type(self.t.gvalue_to_fitness))
 
+    def testPickleTraitWithNoise(self):
+        import pickle
+        p = pickle.dumps(self.tn)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.tn.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.tn.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.tn.gvalue_to_fitness))
 
 class testMlocusAdditive(unittest.TestCase):
     @classmethod

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -79,6 +79,36 @@ class testMlocusAdditive(unittest.TestCase):
         self.assertEqual(self.t.is_fitness, False)
         self.assertEqual(self.tn.is_fitness, False)
 
+    def testPickleFitness(self):
+        import pickle
+        p = pickle.dumps(self.w)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.w.scaling)
+        self.assertTrue(up.is_fitness)
+        self.assertEqual(type(up.noise), type(self.w.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.w.gvalue_to_fitness))
+
+    def testPickleTraitNoNoise(self):
+        import pickle
+        p = pickle.dumps(self.t)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.t.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.t.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.t.gvalue_to_fitness))
+
+    def testPickleTraitWithNoise(self):
+        import pickle
+        p = pickle.dumps(self.tn)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.tn.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.tn.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.tn.gvalue_to_fitness))
+
 
 class testSlocusMult(unittest.TestCase):
     @classmethod
@@ -154,6 +184,36 @@ class testMlocusMult(unittest.TestCase):
         self.assertEqual(self.w.is_fitness, True)
         self.assertEqual(self.t.is_fitness, False)
         self.assertEqual(self.tn.is_fitness, False)
+
+    def testPickleFitness(self):
+        import pickle
+        p = pickle.dumps(self.w)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.w.scaling)
+        self.assertTrue(up.is_fitness)
+        self.assertEqual(type(up.noise), type(self.w.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.w.gvalue_to_fitness))
+
+    def testPickleTraitNoNoise(self):
+        import pickle
+        p = pickle.dumps(self.t)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.t.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.t.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.t.gvalue_to_fitness))
+
+    def testPickleTraitWithNoise(self):
+        import pickle
+        p = pickle.dumps(self.tn)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.tn.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.tn.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.tn.gvalue_to_fitness))
 
 
 class testSlocusGBR(unittest.TestCase):

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -96,6 +96,31 @@ class testMlocusMult(unittest.TestCase):
         self.assertEqual(self.tn.is_fitness, False)
 
 
+class testSlocusGBR(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.gss = fwdpy11.genetic_values.GSS(0.0, 1.0)
+        self.gnoise = fwdpy11.genetic_value_noise.GaussianNoise(
+            mean=0.0, sd=1.0)
+        self.nonoise = fwdpy11.genetic_value_noise.NoNoise()
+
+    def testPicklingGSS(self):
+        import pickle
+        gbr = fwdpy11.genetic_values.SlocusGBR(self.gss)
+        p = pickle.dumps(gbr, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(self.nonoise), type(up.noise))
+        self.assertEqual(type(self.gss), type(up.gvalue_to_fitness))
+
+    def testPicklingGSSGaussianNoise(self):
+        import pickle
+        gbr = fwdpy11.genetic_values.SlocusGBR(self.gss, self.gnoise)
+        p = pickle.dumps(gbr, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(self.gnoise), type(up.noise))
+        self.assertEqual(type(self.gss), type(up.gvalue_to_fitness))
+
+
 class testGSS(unittest.TestCase):
     @classmethod
     def setUp(self):

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -56,6 +56,19 @@ class testSlocusAdditive(unittest.TestCase):
         self.assertEqual(type(up.gvalue_to_fitness),
                          type(self.tn.gvalue_to_fitness))
 
+    def testPickleTraitWithNoiseToFile(self):
+        import pickle
+        with open("ptest.pickle", "wb") as f:
+            pickle.dump( self.tn)
+
+        with open("ptest.pickle", "rb") as f:
+            up = pickle.load(f)
+        self.assertEqual(up.scaling, self.tn.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.tn.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.tn.gvalue_to_fitness))
+
 
 class testMlocusAdditive(unittest.TestCase):
     @classmethod

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -56,6 +56,7 @@ class testSlocusAdditive(unittest.TestCase):
         self.assertEqual(type(up.gvalue_to_fitness),
                          type(self.tn.gvalue_to_fitness))
 
+
 class testMlocusAdditive(unittest.TestCase):
     @classmethod
     def setUp(self):
@@ -100,6 +101,36 @@ class testSlocusMult(unittest.TestCase):
         self.assertEqual(self.w.is_fitness, True)
         self.assertEqual(self.t.is_fitness, False)
         self.assertEqual(self.tn.is_fitness, False)
+
+    def testPickleFitness(self):
+        import pickle
+        p = pickle.dumps(self.w)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.w.scaling)
+        self.assertTrue(up.is_fitness)
+        self.assertEqual(type(up.noise), type(self.w.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.w.gvalue_to_fitness))
+
+    def testPickleTraitNoNoise(self):
+        import pickle
+        p = pickle.dumps(self.t)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.t.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.t.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.t.gvalue_to_fitness))
+
+    def testPickleTraitWithNoise(self):
+        import pickle
+        p = pickle.dumps(self.tn)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.tn.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.tn.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.tn.gvalue_to_fitness))
 
 
 class testMlocusMult(unittest.TestCase):

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -59,7 +59,7 @@ class testSlocusAdditive(unittest.TestCase):
     def testPickleTraitWithNoiseToFile(self):
         import pickle
         with open("ptest.pickle", "wb") as f:
-            pickle.dump( self.tn)
+            pickle.dump(self.tn, f)
 
         with open("ptest.pickle", "rb") as f:
             up = pickle.load(f)
@@ -248,6 +248,31 @@ class testSlocusGBR(unittest.TestCase):
     def testPicklingGSSGaussianNoise(self):
         import pickle
         gbr = fwdpy11.genetic_values.SlocusGBR(self.gss, self.gnoise)
+        p = pickle.dumps(gbr, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(self.gnoise), type(up.noise))
+        self.assertEqual(type(self.gss), type(up.gvalue_to_fitness))
+
+
+class testMlocusGBR(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.gss = fwdpy11.genetic_values.GSS(0.0, 1.0)
+        self.gnoise = fwdpy11.genetic_value_noise.GaussianNoise(
+            mean=0.0, sd=1.0)
+        self.nonoise = fwdpy11.genetic_value_noise.NoNoise()
+
+    def testPicklingGSS(self):
+        import pickle
+        gbr = fwdpy11.genetic_values.MlocusGBR(self.gss)
+        p = pickle.dumps(gbr, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(self.nonoise), type(up.noise))
+        self.assertEqual(type(self.gss), type(up.gvalue_to_fitness))
+
+    def testPicklingGSSGaussianNoise(self):
+        import pickle
+        gbr = fwdpy11.genetic_values.MlocusGBR(self.gss, self.gnoise)
         p = pickle.dumps(gbr, -1)
         up = pickle.loads(p)
         self.assertEqual(type(self.gnoise), type(up.noise))

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -26,6 +26,26 @@ class testSlocusAdditive(unittest.TestCase):
         self.assertEqual(self.t.is_fitness, False)
         self.assertEqual(self.tn.is_fitness, False)
 
+    def testPickleFitness(self):
+        import pickle
+        p = pickle.dumps(self.w)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.w.scaling)
+        self.assertTrue(up.is_fitness)
+        self.assertEqual(type(up.noise), type(self.w.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.w.gvalue_to_fitness))
+
+    def testPickleTraitNoNoise(self):
+        import pickle
+        p = pickle.dumps(self.t)
+        up = pickle.loads(p)
+        self.assertEqual(up.scaling, self.t.scaling)
+        self.assertTrue(up.is_fitness is False)
+        self.assertEqual(type(up.noise), type(self.t.noise))
+        self.assertEqual(type(up.gvalue_to_fitness),
+                         type(self.t.gvalue_to_fitness))
+
 
 class testMlocusAdditive(unittest.TestCase):
     @classmethod

--- a/tests/test_pickling_composed_classes.py
+++ b/tests/test_pickling_composed_classes.py
@@ -1,0 +1,23 @@
+import unittest
+import cppimport
+cppimport.force_rebuild()
+cppimport.set_quiet(False)
+PC = cppimport.imp("pickling_composed_classes")
+
+
+class testPickleComposedClass(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.D = PC.Derived()
+        self.C = PC.Composed(2.0, self.D)
+
+    def testPickle(self):
+        import pickle
+        p = pickle.dumps(self.C, -1)
+        up = pickle.loads(p)
+        self.assertEqual(type(up), type(self.C))
+        self.assertEqual(type(up.b), type(self.C.b))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stateful_fitness.py
+++ b/tests/test_stateful_fitness.py
@@ -3,18 +3,17 @@
 # a rebuild every time, but that clearly
 # wouldn't be needed for normal use.
 import cppimport
-cppimport.force_rebuild()
-cppimport.set_quiet(False)
-snowdrift = cppimport.imp("snowdrift")
 import unittest
 import pickle
 import numpy as np
 import fwdpy11 as fp11
 import fwdpy11.model_params
-import fwdpy11.temporal_samplers as fp11ts
 import fwdpy11.genetic_values
 import fwdpy11.wright_fisher
 import fwdpy11.ezparams
+cppimport.force_rebuild()
+cppimport.set_quiet(False)
+snowdrift = cppimport.imp("snowdrift")
 
 
 class SamplePhenotypes(object):
@@ -67,11 +66,19 @@ def evolve_snowdrift(args):
 
 
 class testSnowdrift(unittest.TestCase):
-    def test_create(self):
-        f = snowdrift.SlocusSnowdrift(1, -1, 0.1, 0.2)
+    @classmethod
+    def setUp(self):
+        self.f = snowdrift.SlocusSnowdrift(1, -1, 0.1, 0.2)
+
+    def testPickle(self):
+        self.f.phenotypes = [1, 2, 3, 4]
+        p = pickle.dumps(self.f, -1)
+        up = pickle.loads(p)
+        self.assertEqual(up.phenotypes, self.f. phenotypes)
 
     def test_evolve(self):
         p = evolve_snowdrift((1000, 42))
+        p
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a WIP to see if the new genetic value types can support pickling.  Part of the impetus here is #130.  But, it would also be nice to get `fwdpy11.model_params.ModelParams` to store _objects_ rather than abstractions to compose objects.

**Note** this PR may "fail" and not get merged if it proves too complex.

However, the challenges are the following:

* The 0.2.0 code base relies on composition idioms to create genetic value (GV) objects.  This means that a GV object store pointers to base classes of function-like objects.  These function-like objects are implemented using a specific abstract base class  (ABC) hierarchy.
* At first glance, it seems quite difficult to come up with an idiomatic OO solution to pickling that handles both the ABC structure and satisfies pybind11's casting machinery.
* An interim solution is to make foo::pickle() a pure virtual function in each ABC.  And then define a static class function in each derived class to unpickle an instance.

All of the above would need to be done for:

- [x] noise classes
- [x] genetic-value-to-w classes
- [x] genetic value classes

The latter is the hardest, as it is the class hierarchy using composition.  I'm not 100% confident that pickling the composed object will be straightforward.
