### PR TITLE
Fix bug updating GSSmo during simulation.

### DIFF
--- a/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
@@ -157,7 +157,7 @@ namespace fwdpy11
         {
             if (current_optimum < optima.size())
                 {
-                    if (pop.generation >= std::get<0>(optima.front()))
+                    if (pop.generation >= std::get<0>(optima[current_optimum]))
                         {
                             opt = std::get<1>(optima[current_optimum]);
                             VS = std::get<2>(optima[current_optimum++]);


### PR DESCRIPTION
Fixes an error causing GSSmo to constantly update.  This error was introduced, in [this commit](https://github.com/molpopgen/fwdpy11/commit/32229a2c9c7116f57a8c00636309f4e401031fbd), when refactoring the type to not "pop" the data as we go along.