### PR TITLE
Refactor model params

### DIFF
--- a/doc/advanced/heritability.rst
+++ b/doc/advanced/heritability.rst
@@ -42,17 +42,17 @@ Thus, when we parameterize objects for our simulations, we should only pass :mat
     rng = fwdpy11.GSLrng(42)
     # Parameters dict with some
     # arbitrary stuff in there:
+    # Set VS = 1-VE
+    gv2w = fwdpy11.genetic_values.GSS(VS=1-VE,opt=0)
+    # Set sigma of noise function to square root of VE
+    noise = fwdpy11.genetic_value_noise.GaussianNoise(mean=0,sd=np.sqrt(VE))
     p = {'nregions': [fwdpy11.Region(0,1,1)],
          'sregions': [fwdpy11.ExpS(0, 1, 1, 0.25)],
          'recregions': [fwdpy11.Region(0, 1, 1)],
          'rates': (1e-3, 2e-3, 1e-3),
-         'gvalue': (fwdpy11.genetic_values.SlocusAdditive,(2.0,)),
+         'gvalue': fwdpy11.genetic_values.SlocusAdditive(2.0,gv2w,noise),
          'prune_selected': False,
          }
-    # Set VS = 1-VE
-    p['gv2w'] = (fwdpy11.genetic_values.GSS,{'VS':1-VE,'opt':0})
-    # Set sigma of noise function to square root of VE
-    p['noise'] = (fwdpy11.genetic_value_noise.GaussianNoise,{'mean':0,'sd':np.sqrt(VE)})
     params = fwdpy11.model_params.ModelParams(**p)
 
 Note that `gv2w` and `noise` would normally be written into `p` along with everything else.  However, Sphinx suppresses

--- a/doc/advanced/manip.rst
+++ b/doc/advanced/manip.rst
@@ -28,7 +28,7 @@ gives me a place to put examples based on specific questions from users.
             'recregions':recregions,
             'demography':nlist,
             'rates':(theta/float(4*N),1e-2,rho/float(4*N)),
-            'gvalue':(fwdpy11.genetic_values.SlocusMult,(2.,))
+            'gvalue':fwdpy11.genetic_values.SlocusMult(2.)
             }
     params = fwdpy11.model_params.ModelParams(**pdict)
 

--- a/doc/examples/DataMatrix.rst
+++ b/doc/examples/DataMatrix.rst
@@ -59,7 +59,7 @@ The following example is a tour of the API:
        'recregions':[fp11.Region(0,1,1)],
        'sregions':[fp11.ExpS(0,1,1,0.25,0.25)],
        'rates':(theta/float(4*N),0.0,rho/float(4*N)),
-       'gvalue':(fwdpy11.genetic_values.SlocusMult,(2.0,))
+       'gvalue':fwdpy11.genetic_values.SlocusMult(2.0)
        }
     rng=fp11.GSLrng(42)
     params = fp11.model_params.ModelParams(**p)

--- a/doc/examples/DataMatrix.rst
+++ b/doc/examples/DataMatrix.rst
@@ -193,6 +193,7 @@ It is possible to get a thin wrapper that is not writeable.  Doing so lets you h
        'recregions':[fp11.Region(0,1,1)],
        'sregions':[fp11.ExpS(0,1,1,0.25,0.25)],
        'rates':(theta/float(4*N),0.0,rho/float(4*N))
+       'gvalue':fwdpy11.genetic_values.SlocusMult(2.0)
        }
     rng=fp11.GSLrng(42)
     params = fp11.model_params.ModelParams(**p)

--- a/doc/examples/parallel_simulation.rst
+++ b/doc/examples/parallel_simulation.rst
@@ -68,7 +68,7 @@ Here is our function:
             nregions=[fwdpy11.Region(0,1,1)],
             sregions=[fwdpy11.ExpS(0,1,1,-0.1,1.0)],
             recregions=[fwdpy11.Region(0,1,1)],
-            gvalue=(fwdpy11.genetic_values.SlocusAdditive,(2.0,)),
+            gvalue=fwdpy11.genetic_values.SlocusAdditive(2.0),
             #Only simulate 10 generations so 
             #that example runs quickly:
             demography=numpy.array([N]*10,dtype=np.uint32),

--- a/doc/examples/qtrait.rst
+++ b/doc/examples/qtrait.rst
@@ -107,8 +107,8 @@ The following code block represents the following model:
     'recregions':[fp11.Region(0,1,1)],
     'rates':(0.0,2e-3,1e-3),
     'demography':np.array([N]*N,dtype=np.uint32),
-    'gvalue':(fwdpy11.genetic_values.SlocusAdditive,(2.0,)),
-    'gv2w':(fwdpy11.genetic_values.GSSmo,(gss_params,)),
+    'gvalue':fwdpy11.genetic_values.SlocusAdditive(2.0,
+                                                   fwdpy11.genetic_values.GSSmo(gss_params))
     }
 
     params = fp11.model_params.ModelParams(**p)

--- a/doc/pages/model_params.rst
+++ b/doc/pages/model_params.rst
@@ -51,7 +51,7 @@ The following example sets up a standard population simulation with multiplicati
                 'recregions': [fwdpy11.Region(0,1,1)],
                 'rates': (theta/(4.*popsize),1e-4,rho/(4.*popsize)),
                 'demography': np.array([popsize]*10, dtype = np.uint32),
-                'gvalue': (fwdpy11.genetic_values.SlocusMult, (1.0, ))
+                'gvalue': fwdpy11.genetic_values.SlocusMult(1.0)
             }
     params = fwdpy11.model_params.ModelParams(**pdict)
     params.validate()
@@ -80,11 +80,15 @@ effects:
     import fwdpy11.wright_fisher
     import fwdpy11.multilocus
     import numpy as np
-
+    import inspect
     popsize = 1e4
     theta = 10000
     rho = theta
     locus_boundaries = [(float(i),float(i)+1.0) for i in range(5)]
+
+    gv2w = fwdpy11.genetic_values.GSS(VS=1.0,opt=0.0)
+    noise = fwdpy11.genetic_value_noise.GaussianNoise(mean=0.0, sd=0.1)
+    gvalue = fwdpy11.genetic_values.MlocusAdditive(1.0,gv2w,noise)
     pdict = {'nregions': [[fwdpy11.Region(i[0],i[1],1)] for i in locus_boundaries],
                 'sregions': [[fwdpy11.GaussianS(i[0],i[1],1,0.1)] for i in locus_boundaries],
                 'recregions': [[fwdpy11.Region(i[0],i[1],1)] for i in locus_boundaries],
@@ -93,10 +97,8 @@ effects:
                         [rho/(4.*popsize)]*len(locus_boundaries)),
                 'interlocus_rec': fwdpy11.multilocus.binomial_rec([0.5]*(len(locus_boundaries)-1)),
                 'demography': np.array([popsize]*10, dtype = np.uint32),
-                'gvalue': (fwdpy11.genetic_values.MlocusAdditive, (1.0, )),
-                'gv2w': (fwdpy11.genetic_values.GSS, {'VS':1.0, 'opt': 0.0}),
-                'noise': (fwdpy11.genetic_value_noise.GaussianNoise, {'mean': 0.0, 'sd':0.1}),
                 'prune_selected':False,
+                'gvalue':gvalue
             }
     params = fwdpy11.model_params.ModelParams(**pdict)
     params.validate()

--- a/fwdpy11/ezparams.py
+++ b/fwdpy11/ezparams.py
@@ -54,7 +54,7 @@ def mslike(pop, **kwargs):
                         ((1.0-defaults['pneutral'])*defaults['theta']) /
                         (4.0*pop.N),
                         defaults['rho']/(4.0*float(pop.N))),
-              'gvalue': (fwdpy11.genetic_values.SlocusMult, (2.0,))
+              'gvalue': fwdpy11.genetic_values.SlocusMult(2.0)
               }
     if defaults['dfe'] is None:
         params['sregions'] = []

--- a/fwdpy11/model_params.py
+++ b/fwdpy11/model_params.py
@@ -40,8 +40,6 @@
         will segfault if we copy.deepcopy the params objects.
 """
 
-import warnings
-
 
 def _validate_types(data, typename, strict):
     for i in data:
@@ -253,8 +251,6 @@ class ModelParams(object):
             raise TypeError("prune_selected cannot be None")
         if self.gvalue is None:
             raise TypeError("gvalue cannot be None")
-        # if self.noise is None:
-        #     raise TypeError("noise cannot be None")
         if self.rates is None:
             raise TypeError("rates cannot be None")
 

--- a/fwdpy11/model_params.py
+++ b/fwdpy11/model_params.py
@@ -64,7 +64,6 @@ class ModelParams(object):
     """
 
     def __init__(self, **kwargs):
-        from fwdpy11.genetic_value_noise import NoNoise
         self.__nregions = None
         self.__sregions = None
         self.__recregions = None
@@ -73,8 +72,6 @@ class ModelParams(object):
         self.__prune_selected = True
         self.__rates = None
         self.__gvalue = None
-        self.__gv2w = None
-        self.__noise = None
         self.__pself = 0.0
         for key, value in kwargs.items():
             if key in dir(self) and key[:1] != "_":
@@ -159,30 +156,6 @@ class ModelParams(object):
     @gvalue.setter
     def gvalue(self, gvalue_):
         self.__gvalue = gvalue_
-
-    @property
-    def gv2w(self):
-        """
-        Get/set the type name and constructor arguments
-        for the genetic value to fitness (w) map.
-        """
-        return self.__gv2w
-
-    @gv2w.setter
-    def gv2w(self, x):
-        self.__gv2w = x
-
-    @property
-    def noise(self):
-        """
-        Get/set the type name and constructor arguments
-        for the noise object.
-        """
-        return self.__noise
-
-    @noise.setter
-    def noise(self, x):
-        self.__noise = x
 
     @property
     def rates(self):
@@ -284,43 +257,6 @@ class ModelParams(object):
         #     raise TypeError("noise cannot be None")
         if self.rates is None:
             raise TypeError("rates cannot be None")
-
-    def make_gvalue(self):
-        if self.gv2w is None:
-            gv2wmap = None
-        elif len(self.gv2w) == 1:
-            gv2wmap = self.gv2w[0]()
-        elif self.gv2w[1].__class__ is tuple:
-            gv2wmap = self.gv2w[0](*self.gv2w[1])
-        else:
-            gv2wmap = self.gv2w[0](**self.gv2w[1])
-        if self.noise is None:
-            noisefxn = None
-        elif len(self.noise) == 1:
-            noisefxn = self.noise[0]()
-        elif self.noise[1].__class__ is tuple:
-            noisefxn = self.noise[0](*self.noise[1])
-        else:
-            noisefxn = self.noise[0](**self.noise[1])
-        if len(self.gvalue) == 1:
-            if gv2wmap is None and noisefxn is None:
-                return self.gvalue[0]()
-            elif gv2wmap is not None and noisefxn is None:
-                return self.gvalue[0](gv2wmap)
-            elif gv2wmap is None and noisefxn is not None:
-                return self.gvalue[0](noisefxn)
-            else:
-                return self.gvalue[0](gv2wmap, noisefxn)
-        elif self.gvalue[1].__class__ is tuple:
-            if gv2wmap is None and noisefxn is None:
-                return self.gvalue[0](*self.gvalue[1])
-            elif gv2wmap is not None and noisefxn is None:
-                return self.gvalue[0](*self.gvalue[1], gv2wmap)
-            elif gv2wmap is None and noisefxn is not None:
-                return self.gvalue[0](*self.gvalue[1], noisefxn)
-            else:
-                return self.gvalue[0](*self.gvalue[1], gv2wmap, noisefxn)
-        return self.gvalue[0](**self.gvalue[1], gv2w=gv2wmap, noise=noisefxn)
 
 
 def _validate_single_deme_demography(value):

--- a/fwdpy11/wright_fisher.py
+++ b/fwdpy11/wright_fisher.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
-#from .wfevolve import evolve_singlepop_regions_cpp
 
 
 def evolve(rng, pop, params, recorder=None):
@@ -54,8 +53,10 @@ def evolve(rng, pop, params, recorder=None):
             from fwdpy11.temporal_samplers import RecordNothing
             recorder = RecordNothing()
 
-        WFSlocusPop(rng, pop, params.demography, params.mutrate_n, params.mutrate_s,
-                    params.recrate, mm, rm, params.gvalue, recorder, params.pself, params.prune_selected)
+        WFSlocusPop(rng, pop, params.demography,
+                    params.mutrate_n, params.mutrate_s,
+                    params.recrate, mm, rm, params.gvalue,
+                    recorder, params.pself, params.prune_selected)
     else:
         from .wright_fisher_mlocus import WFMlocusPop
         mm = [makeMutationRegions(rng, pop, i, j, n/(n+s)) for
@@ -69,5 +70,7 @@ def evolve(rng, pop, params, recorder=None):
             from fwdpy11.temporal_samplers import RecordNothing
             recorder = RecordNothing()
 
-        WFMlocusPop(rng, pop, params.demography, params.mutrates_n, params.mutrates_s, mm, rm, params.interlocus_rec,
-                    params.gvalue, recorder, params.pself, params.prune_selected)
+        WFMlocusPop(rng, pop, params.demography, params.mutrates_n,
+                    params.mutrates_s, mm, rm, params.interlocus_rec,
+                    params.gvalue, recorder, params.pself,
+                    params.prune_selected)

--- a/fwdpy11/wright_fisher.py
+++ b/fwdpy11/wright_fisher.py
@@ -55,7 +55,7 @@ def evolve(rng, pop, params, recorder=None):
             recorder = RecordNothing()
 
         WFSlocusPop(rng, pop, params.demography, params.mutrate_n, params.mutrate_s,
-                    params.recrate, mm, rm, params.make_gvalue(), recorder, params.pself, params.prune_selected)
+                    params.recrate, mm, rm, params.gvalue, recorder, params.pself, params.prune_selected)
     else:
         from .wright_fisher_mlocus import WFMlocusPop
         mm = [makeMutationRegions(rng, pop, i, j, n/(n+s)) for
@@ -70,4 +70,4 @@ def evolve(rng, pop, params, recorder=None):
             recorder = RecordNothing()
 
         WFMlocusPop(rng, pop, params.demography, params.mutrates_n, params.mutrates_s, mm, rm, params.interlocus_rec,
-                    params.make_gvalue(), recorder, params.pself, params.prune_selected)
+                    params.gvalue, recorder, params.pself, params.prune_selected)

--- a/tests/quick_pops.py
+++ b/tests/quick_pops.py
@@ -30,7 +30,7 @@ def quick_neutral_slocus(N=1000, simlen=100):
     from fwdpy11.wright_fisher import evolve
     pop = SlocusPop(N)
     params_dict = mslike(pop, simlen=simlen)
-    params_dict['gvalue'] = (SlocusMult, (2.,))
+    params_dict['gvalue'] = SlocusMult(2.)
     params = ModelParams(**params_dict)
     rng = GSLrng(42)
     evolve(rng, pop, params)
@@ -50,7 +50,7 @@ def quick_nonneutral_slocus(N=1000, simlen=100, dfe=None):
     params_dict = mslike(
         pop, simlen=simlen, dfe=dfe,
         pneutral=0.95)
-    params_dict['gvalue'] = (SlocusMult, (2.0,))
+    params_dict['gvalue'] = SlocusMult(2.0)
     params = ModelParams(**params_dict)
     rng = GSLrng(42)
     evolve(rng, pop, params)
@@ -69,8 +69,7 @@ def quick_slocus_qtrait_pop_params(N=1000, simlen=100):
          'recregions': [Region(0, 1, 1)],
          'rates': (0.0, 2e-3, 1e-3),
          'demography': np.array([N] * simlen, dtype=np.uint32),
-         'gvalue': (SlocusAdditive, (2.0,)),
-         'gv2w': (GSS, {'VS': 1.0, 'opt': 0.0}),
+         'gvalue': SlocusAdditive(2.0, GSS(VS=1.0,opt=0.0)),
          'prune_selected': False
          }
     pop = SlocusPop(N)
@@ -108,8 +107,7 @@ def quick_mlocus_qtrait_pop_params(N=1000, simlen=100):
                   'recregions': recregions,
                   'rates': (mutrates_n, mutrates_s, recrates),
                   'interlocus_rec': interlocus_rec,
-                  'gvalue': (MlocusAdditive, (2.0,)),
-                  'gv2w': (GSS, {'VS': 1, 'opt': 0.0}),
+                  'gvalue': MlocusAdditive(2.0,GSS(VS=1.0,opt=0.0)),
                   'demography': nlist,
                   'prune_selected': False
                   }
@@ -166,8 +164,7 @@ def quick_mlocus_qtrait_change_optimum(N=1000, simlen=100, prune_selected=False)
                   'mutrates_n': [theta / (4. * float(N))] * nloci,
                   'mutrates_s': [mu] * nloci,
                   'recrates': [rho / (4. * float(N))] * nloci,
-                  'gvalue': (MlocusAdditive, (2.0,)),
-                  'trait2w': (GSSmo, ([(0, 0, 1), (simlen / 2, 1, 1)])),
+                  'gvalue': MlocusAdditive(2.0,GSSmo([(0, 0, 1), (simlen / 2, 1, 1)])),
                   'demography': nlist,
                   'prune_selected': prune_selected}
     params = MlocusParamsQ(**param_dict)

--- a/tests/quick_pops.py
+++ b/tests/quick_pops.py
@@ -58,7 +58,6 @@ def quick_nonneutral_slocus(N=1000, simlen=100, dfe=None):
 
 
 def quick_slocus_qtrait_pop_params(N=1000, simlen=100):
-    from fwdpy11.model_params import ModelParams
     from fwdpy11 import SlocusPop
     from fwdpy11.genetic_values import GSS
     from fwdpy11.genetic_values import SlocusAdditive
@@ -69,7 +68,7 @@ def quick_slocus_qtrait_pop_params(N=1000, simlen=100):
          'recregions': [Region(0, 1, 1)],
          'rates': (0.0, 2e-3, 1e-3),
          'demography': np.array([N] * simlen, dtype=np.uint32),
-         'gvalue': SlocusAdditive(2.0, GSS(VS=1.0,opt=0.0)),
+         'gvalue': SlocusAdditive(2.0, GSS(VS=1.0, opt=0.0)),
          'prune_selected': False
          }
     pop = SlocusPop(N)
@@ -107,7 +106,7 @@ def quick_mlocus_qtrait_pop_params(N=1000, simlen=100):
                   'recregions': recregions,
                   'rates': (mutrates_n, mutrates_s, recrates),
                   'interlocus_rec': interlocus_rec,
-                  'gvalue': MlocusAdditive(2.0,GSS(VS=1.0,opt=0.0)),
+                  'gvalue': MlocusAdditive(2.0, GSS(VS=1.0, opt=0.0)),
                   'demography': nlist,
                   'prune_selected': False
                   }
@@ -126,7 +125,9 @@ def quick_mlocus_qtrait(N=1000, simlen=100):
     return pop
 
 
-def quick_mlocus_qtrait_change_optimum(N=1000, simlen=100, prune_selected=False):
+# TODO: fix or remove
+def quick_mlocus_qtrait_change_optimum(N=1000,
+                                       simlen=100, prune_selected=False):
     """
     .. warning:: May result in long-running tests
     """
@@ -153,9 +154,7 @@ def quick_mlocus_qtrait_change_optimum(N=1000, simlen=100, prune_selected=False)
                   for i, j in zip(range(nloci), locus_boundaries)]
     sregions = [[GaussianS(j[0] + 5., j[0] + 6., mu, sigmu, coupled=False)]
                 for i, j in zip(range(nloci), locus_boundaries)]
-    agg = AggAddTrait()
     interlocus_rec = binomial_rec([0.5] * (nloci - 1))
-    mlv = MultiLocusGeneticValue([SlocusAdditiveTrait(2.0)] * nloci)
     nlist = np.array([N] * simlen, dtype=np.uint32)
     param_dict = {'nregions': nregions,
                   'sregions': sregions,
@@ -164,10 +163,11 @@ def quick_mlocus_qtrait_change_optimum(N=1000, simlen=100, prune_selected=False)
                   'mutrates_n': [theta / (4. * float(N))] * nloci,
                   'mutrates_s': [mu] * nloci,
                   'recrates': [rho / (4. * float(N))] * nloci,
-                  'gvalue': MlocusAdditive(2.0,GSSmo([(0, 0, 1), (simlen / 2, 1, 1)])),
+                  'gvalue': MlocusAdditive(2.0, GSSmo([(0, 0, 1),
+                                                       (simlen / 2, 1, 1)])),
                   'demography': nlist,
                   'prune_selected': prune_selected}
-    params = MlocusParamsQ(**param_dict)
+    params = ModelParams(**param_dict)
     pop = MlocusPop(N, locus_boundaries)
     evolve(rng, pop, params)
     return pop

--- a/tests/test_custom_stateless_fitness.py
+++ b/tests/test_custom_stateless_fitness.py
@@ -18,7 +18,7 @@ class testCustomAdditive(unittest.TestCase):
         self.pdict = fwdpy11.ezparams.mslike(self.pop,
                                              dfe=fwdpy11.ExpS(0, 1, 1, -0.05),
                                              pneutral=0.95, simlen=10)
-        self.pdict['gvalue'] = (ca.additive, )
+        self.pdict['gvalue'] = ca.additive()
         self.rng = fwdpy11.GSLrng(42)
         self.params = fwdpy11.model_params.ModelParams(**self.pdict)
 
@@ -26,7 +26,7 @@ class testCustomAdditive(unittest.TestCase):
         fwdpy11.wright_fisher.evolve(self.rng, self.pop, self.params)
 
     def testPickle(self):
-        a = self.params.make_gvalue()
+        a = self.params.gvalue
         p = pickle.dumps(a, -1)
         up = pickle.loads(p)
         self.assertEqual(type(a), type(up))
@@ -47,12 +47,12 @@ class testGeneralModule(unittest.TestCase):
                                              dfe=fwdpy11.ConstantS(
                                                  0, 1, 1, -0.05, 0.05),
                                              pneutral=0.95, simlen=10)
-        self.pdict['gvalue'] = (general.GeneralW, )
+        self.pdict['gvalue'] = general.GeneralW()
         self.rng = fwdpy11.GSLrng(42)
         self.params = fwdpy11.model_params.ModelParams(**self.pdict)
 
     def testPickle(self):
-        a = self.params.make_gvalue()
+        a = self.params.gvalue
         p = pickle.dumps(a, -1)
         up = pickle.loads(p)
         self.assertEqual(type(a), type(up))

--- a/tests/test_opaque.py
+++ b/tests/test_opaque.py
@@ -79,7 +79,7 @@ class testSlocusPopSampler(unittest.TestCase):
         self.sampler = SlocusTypeSampler()
         self.pop = fwdpy11.SlocusPop(1000)
         self.params_dict = mslike(self.pop, simlen=10)
-        self.params_dict['gvalue'] = (SlocusMult, (2.,))
+        self.params_dict['gvalue'] = SlocusMult(2.)
         self.params = ModelParams(**self.params_dict)
         self.rng = fwdpy11.GSLrng(42)
 

--- a/tests/test_simple_parallel.py
+++ b/tests/test_simple_parallel.py
@@ -1,7 +1,5 @@
 import fwdpy11 as fp11
 import fwdpy11.ezparams as fp11ez
-import fwdpy11.model_params
-import fwdpy11.wright_fisher
 # concurrent.futures is Python 3 only
 import concurrent.futures as cf
 import numpy as np
@@ -28,7 +26,7 @@ def evolve_and_return(args):
     rng = fp11.GSLrng(seed)
     p = fp11ez.mslike(pop, simlen=100, rates=(
         theta / float(4 * pop.N), 1e-3, theta / float(4 * pop.N)))
-    p['gvalue'] = (SlocusMult, (2.,))
+    p['gvalue'] = SlocusMult(2.)
     params = fp11.model_params.ModelParams(**p)
     fp11.wright_fisher.evolve(rng, pop, params)
     # The population is picklable, and so

--- a/tests/test_stateful_fitness.py
+++ b/tests/test_stateful_fitness.py
@@ -51,7 +51,7 @@ def evolve_snowdrift(args):
     p = {'sregions': [fp11.ExpS(0, 1, 1, -0.1, 1.0)],
          'recregions': [fp11.Region(0, 1, 1)],
          'nregions': [],
-         'gvalue': (snowdrift.SlocusSnowdrift, (0.2, -0.2, 1, -2)),
+         'gvalue': snowdrift.SlocusSnowdrift(0.2, -0.2, 1, -2),
          # evolve for 100 generations so that unit tests are
          # fast
          'demography': np.array([N] * 100, dtype=np.uint32),

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -30,7 +30,7 @@ class testWFevolve(unittest.TestCase):
         self.p.nregions = [fp11.Region(0, 1, 1)]
         self.p.sregions = [fp11.ExpS(0, 1, 1, -1e-2)]
         self.p.recregions = self.p.nregions
-        self.p.gvalue = (SlocusMult, (2.0,))
+        self.p.gvalue = SlocusMult(2.0)
 
     def testEvolve(self):
         from fwdpy11.wright_fisher import evolve
@@ -57,7 +57,7 @@ class testCythonRecorder(unittest.TestCase):
         self.p.nregions = [fp11.Region(0, 1, 1)]
         self.p.sregions = [fp11.ExpS(0, 1, 1, -1e-2)]
         self.p.recregions = self.p.nregions
-        self.p.gvalue = (SlocusMult, (2.0,))
+        self.p.gvalue = SlocusMult(2.0)
 
     def testEvolve(self):
         from fwdpy11.wright_fisher import evolve

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -1,9 +1,8 @@
 import unittest
 import fwdpy11 as fp11
-import fwdpy11.wright_fisher as wf
 import pyximport
 import numpy as np
-pyximport.install(setup_args={'include_dirs': np.get_include()})
+pyximport.install(setup_args={'include_dirs': np.get_include()})  # noqa
 from MeanFitness import MeanFitness
 
 
@@ -63,6 +62,6 @@ class testCythonRecorder(unittest.TestCase):
         from fwdpy11.wright_fisher import evolve
         evolve(self.rng, self.pop, self.p, self.cython_recorder)
 
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
This PR builds on top of #132 to refactor `ModelParams` to hold instances of genetic value types.  The previous API was to take types used to construct such objects.  Since #132 makes these objects support pickling, we can make `ModelParams` simply store an instance as `gvalue`.

Not to be merged until #132 is merged.

See #129.

cc @vancleve
