### PR TITLE
Better gsl error handling

### DIFF
--- a/fwdpy11/src/_init.cc
+++ b/fwdpy11/src/_init.cc
@@ -19,14 +19,37 @@
 #include <pybind11/pybind11.h>
 #include <gsl/gsl_version.h>
 #include <gsl/gsl_errno.h>
+#include <stdexcept>
+#include <sstream>
 #include <type_traits>
 
 static_assert(GSL_MAJOR_VERSION >= 2, "GSL major version >= 2 required");
 static_assert(GSL_MINOR_VERSION >= 2, "GSL minor version >= 2 required");
+
+namespace py = pybind11;
+
+void
+gsl_error_to_exception(const char* reason, const char* file, int line,
+                       int gsl_errno)
+{
+    std::ostringstream o;
+    o << "GSL error raised: " << reason << ", " << file << ", " << line << ", "
+      << gsl_errno;
+    throw std::runtime_error(o.str());
+}
 
 PYBIND11_MODULE(_init, m)
 {
     m.doc() = "Module executing some setup code when fwdpy11 is imported.";
 
     auto handler = gsl_set_error_handler_off();
+
+    auto custom_handler = gsl_set_error_handler(&gsl_error_to_exception);
+
+    // When the module exits, restore the old handler.
+    // We re-use variables to suppress unused variable warnings.
+    py::module::import("atexit").attr("register")(
+        py::cpp_function{ [&handler, &custom_handler]() {
+            custom_handler = gsl_set_error_handler(handler);
+        } });
 }

--- a/tests/gsl_error.cpp
+++ b/tests/gsl_error.cpp
@@ -22,4 +22,11 @@ PYBIND11_MODULE(gsl_error, m)
             }
         gsl_matrix_free(m);
     });
+
+    // Causes a memory leak!
+    m.def("trigger_error_not_handled", []() {
+        gsl_matrix* m = gsl_matrix_alloc(2, 3); //non-square
+        gsl_matrix_transpose(m);
+        gsl_matrix_free(m);
+    });
 }

--- a/tests/test_GSLerror.py
+++ b/tests/test_GSLerror.py
@@ -4,10 +4,16 @@ cppimport.force_rebuild()
 gsl = cppimport.imp("gsl_error")
 import unittest
 
+
 class testGSLerror(unittest.TestCase):
     def testErrorHandler(self):
         with self.assertRaises(RuntimeError):
             gsl.trigger_error()
+
+    def testUnhandledGSLError(self):
+        with self.assertRaises(RuntimeError):
+            gsl.trigger_error_not_handled()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Registers a custom GSL error handler that will raise `RuntimeError` if a GSL error is not dealt with at the calling point.