### PR TITLE
Refine API/UI for W-F simulations with tree sequences.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,6 +48,7 @@ Welcome to fwdpy11's documentation!
     pages/tsoverview
     pages/tstypes
     pages/ts
+    pages/tsdetails
 
 .. toctree::
     :caption: Examples

--- a/doc/pages/tsdetails.rst
+++ b/doc/pages/tsdetails.rst
@@ -1,0 +1,60 @@
+.. _tsdetails:
+
+Considerations to make when recording tree sequences
+======================================================================
+
+While tree sequence recording can be used to vastly speed up simulations, there are decisions that you can make 
+that will speed things up even further.
+
+The default behavior
+-------------------------------------------------
+
+What is happening behind the scenes of :func:`fwdpy11.wright_fisher_ts.evolve` when simplification occurs?
+The default behavior is the following:
+
+1. The tables are simplified and any node remapping of ancient samples occurs.
+2. The new edge table is *indexed* according to the procedure described in Kelleher *et al.* (2016) PLoS Computational
+   Biology, a.k.a the "msprime paper".
+3. The number of occurrences of each mutation is counted by a tree traversal that follows the description of Algorithm L
+   of the "msprime paper".
+4. The mutation counts from step 3 are used to mark mutations for "recycling".  For example, a mutation with a count of
+   zero has gone extinct.  Internally, fwdpp will re-use the memory of that extinct mutation.  Likewise, if fixations
+   are being "pruned" from a simulation, fixed variants will be similarly recycled.
+
+All of the above steps rely on efficient algorithms.  But not all of the above steps are *necessary*.
+
+An alternative behavior
+-------------------------------------------------
+
+Typically, we will only simplify every 100 generations or so.  Thus, the mutation counts are only up to date with
+respect to the last time simplification happened.  In this case, the mutations counts are simply a data structure being
+used internally for orchestrating mutation recycling.  Related to this is that the table indexing is relatively
+expensive, requiring two :math:`E\times log(E)` operations, where :math:`E` is the length of the edge table.
+
+Steps two through four above may be skipped entirely by passing the value `True` to the `suppress_table_indexing`
+argument of :func:`fwdpy11.wright_fisher_ts.evolve`.  This option triggers a code path that uses the return value from
+simplification to mark mutations for recycling using a method that avoids the tree traversal entirely.
+
+When should you use this option?  When some or all of the following apply:
+
+1. You are simplifying very often but are not doing any time-series analysis during the simulation that relies on the
+   mutation counts [1]_ [2]_.
+2. You are running a simulation where you do not want to prune selected fixtations.  This option suppresses that
+   possibility.
+3. Your analysis of any genotypes will be restricted to the final generation of the simulation plus and ancient samples
+   recorded during the simulation.
+
+.. note::
+    
+    Suppressing table indexing is a huge performance boost when "densely" recording ancient samples. (For example,
+    when taking a time series involving a random sample taken each generation.)  The reason is that ancient samples
+    increase the size of the edge table because we must track the extra edges leading to those extinct lineages.  When
+    tracking large numbers of ancient samples, the edge table grows considerably, meaning that traversal takes much
+    longer, meaning that the default behavior described above is the less efficient option.
+
+
+.. [1] If you insist, you may generate the mutation counts for the current generation by manually traversing all genomes
+    for all diploids.
+
+.. [2] Note that you may still analyze all individual metadata each generation.  Those data are always kept up to date.
+

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -35,7 +35,7 @@ namespace fwdpy11
     // TODO allow for fixation recording
     // and simulation of neutral variants
     template <typename poptype>
-    std::vector<fwdpp::ts::TS_NODE_INT>
+    std::pair<std::vector<fwdpp::ts::TS_NODE_INT>, std::vector<std::size_t>>
     simplify_tables(poptype &pop,
                     std::vector<fwdpp::uint_t> &mcounts_from_preserved_nodes,
                     fwdpp::ts::table_collection &tables,
@@ -43,13 +43,14 @@ namespace fwdpy11
                     const fwdpp::ts::TS_NODE_INT first_sample_node,
                     const std::size_t num_samples,
                     const bool preserve_selected_fixations,
-                    const bool simulating_neutral_variants)
+                    const bool simulating_neutral_variants,
+                    const bool suppress_edge_table_indexing)
     {
         tables.sort_tables(pop.mutations);
         std::vector<std::int32_t> samples(num_samples);
         std::iota(samples.begin(), samples.end(), first_sample_node);
         auto rv = simplifier.simplify(tables, samples, pop.mutations);
-        tables.build_indexes();
+
         for (auto &s : samples)
             {
                 s = rv.first[s];
@@ -57,9 +58,14 @@ namespace fwdpy11
 #ifndef NDEBUG
         for (auto &s : tables.preserved_nodes)
             {
-                assert(rv.first[s] != 1);
+                assert(rv.first[s] != -1);
             }
 #endif
+        if (suppress_edge_table_indexing == true)
+            {
+                return rv;
+            }
+        tables.build_indexes();
         fwdpp::ts::count_mutations(tables, pop.mutations, samples, pop.mcounts,
                                    mcounts_from_preserved_nodes);
         // TODO: update this to allow neutral mutations to be simulated
@@ -78,11 +84,11 @@ namespace fwdpy11
                                           == 0;
                         }),
                     tables.mutation_table.end());
+                fwdpp::ts::remove_fixations_from_gametes(
+                    pop.gametes, pop.mutations, pop.mcounts,
+                    mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
+                    preserve_selected_fixations);
             }
-        fwdpp::ts::remove_fixations_from_gametes(
-            pop.gametes, pop.mutations, pop.mcounts,
-            mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
-            preserve_selected_fixations);
 
         // TODO: the blocks below should be abstracted out into a closure
         // that removes these if statements
@@ -99,8 +105,7 @@ namespace fwdpy11
                     pop.generation, std::true_type(), std::false_type());
             }
         //confirm_mutation_counts(pop, tables);
-        // TODO: return the entire data?
-        return rv.first;
+        return rv;
     }
 } // namespace fwdpy11
 #endif

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -58,7 +58,7 @@ namespace fwdpy11
 #ifndef NDEBUG
         for (auto &s : tables.preserved_nodes)
             {
-                assert(rv.first[s] != -1);
+                assert(s != -1);
             }
 #endif
         if (suppress_edge_table_indexing == true)

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <stdexcept>
 #include <fwdpp/ts/table_collection.hpp>
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
@@ -58,7 +59,11 @@ namespace fwdpy11
 #ifndef NDEBUG
         for (auto &s : tables.preserved_nodes)
             {
-                assert(s != -1);
+                if (s == -1)
+                    {
+                        throw std::runtime_error("ancient sample node is NULL "
+                                                 "after simplification");
+                    }
             }
 #endif
         if (suppress_edge_table_indexing == true)

--- a/fwdpy11/wright_fisher.py
+++ b/fwdpy11/wright_fisher.py
@@ -22,10 +22,14 @@ def evolve(rng, pop, params, recorder=None):
     """
     Evolve a population
 
-    :param rng: An instance of :class:`fwdpy11.GSLrng`
-    :param pop: An instance of :class:`fwdpy11.SlocusPop`
-    :param params: An instance of :class:`fwdpy11.model_params.SlocusParams`
+    :param rng: random number generator
+    :type rng: :class:`fwdpy11.GSLrng`
+    :param pop: A population
+    :type pop: :class:`fwdpy11.SlocusPop`
+    :param params: simulation parameters
+    :type params: :class:`fwdpy11.model_params.ModelParams`
     :param recorder: (None) A temporal sampler/data recorder.
+    :type recorder: callable
 
     .. note::
         If recorder is None,

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -28,7 +28,7 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
     :param pop: A population
     :type pop: :class:`fwdpy11.SlocusPop`
     :param params: simulation parameters
-    :type params: :class:`fwdpy11.model_params.SlocusParams`
+    :type params: :class:`fwdpy11.model_params.ModelParams`
     :param simplification_interval: Number of generations between simplifications.
     :type simplification_interval: int
     :param recorder: (None) A temporal sampler/data recorder.
@@ -38,7 +38,7 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
 
     .. note::
         If recorder is None,
-        then :class:`fwdpy11.temporal_samplers.RecordNothing` will be used.
+        then :class:`fwdpy11.tsrecorders.NoAncientSamples` will be used.
 
     """
     import warnings

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -18,7 +18,8 @@
 #
 
 
-def evolve(rng, pop, params, simplification_interval, recorder=None):
+def evolve(rng, pop, params, simplification_interval, recorder=None,
+           suppress_table_indexing=False):
     """
     Evolve a population
 
@@ -68,7 +69,8 @@ def evolve(rng, pop, params, simplification_interval, recorder=None):
     WFSlocusPop_ts(rng, pop, sr, simplification_interval,
                    params.demography, params.mutrate_s,
                    params.recrate, mm, rm, params.gvalue,
-                   recorder, params.pself, params.prune_selected is True)
+                   recorder, params.pself, params.prune_selected is True,
+                   suppress_table_indexing)
     # else
     #     from .wright_fisher_mlocus import WFMlocusPop
     #     mm = [makeMutationRegions(rng, pop, i, j, n/(n+s)) for

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -23,19 +23,24 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
     """
     Evolve a population
 
-    :param rng: An instance of :class:`fwdpy11.GSLrng`
-    :param pop: An instance of :class:`fwdpy11.SlocusPop`
-    :param params: An instance of :class:`fwdpy11.model_params.SlocusParams`
+    :param rng: random number generator
+    :type rng: :class:`fwdpy11.GSLrng`
+    :param pop: A population
+    :type pop: :class:`fwdpy11.SlocusPop`
+    :param params: simulation parameters
+    :type params: :class:`fwdpy11.model_params.SlocusParams`
     :param simplification_interval: Number of generations between simplifications.
+    :type simplification_interval: int
     :param recorder: (None) A temporal sampler/data recorder.
+    :type recorder: callable
+    :param suppress_table_indexing: (False) Prevents edge table indexing until end of simulation
+    :type suppress_table_indexing: boolean
 
     .. note::
         If recorder is None,
         then :class:`fwdpy11.temporal_samplers.RecordNothing` will be used.
 
     """
-    # import fwdpy11.SlocusPop
-    # import fwdpy11.MlocusPop
     import warnings
 
     # Currently, we do not support simulating neutral mutations
@@ -52,10 +57,9 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
         params.validate()
 
     from .internal import makeMutationRegions, makeRecombinationRegions
-    # if pop.__class__ is fwdpy11.SlocusPop:
     from .wright_fisher_slocus_ts import WFSlocusPop_ts
     # TODO: update to allow neutral mutations
-    pneutral = 0  # params.mutrate_n/(params.mutrate_n+params.mutrate_s)
+    pneutral = 0
     mm = makeMutationRegions(rng, pop, params.nregions,
                              params.sregions, pneutral)
     rm = makeRecombinationRegions(rng, params.recrate, params.recregions)
@@ -71,20 +75,3 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
                    params.recrate, mm, rm, params.gvalue,
                    recorder, params.pself, params.prune_selected is True,
                    suppress_table_indexing)
-    # else
-    #     from .wright_fisher_mlocus import WFMlocusPop
-    #     mm = [makeMutationRegions(rng, pop, i, j, n/(n+s)) for
-    #           i, j, n, s in zip(params.nregions,
-    #                             params.sregions,
-    #                             params.mutrates_n, params.mutrates_s)]
-    #     rm = [makeRecombinationRegions(rng, i, j) for i, j in zip(
-    #         params.recrates, params.recregions)]
-
-    #     if recorder is None:
-    #         from fwdpy11.temporal_samplers import RecordNothing
-    #         recorder = RecordNothing()
-
-    #     WFMlocusPop(rng, pop, params.demography, params.mutrates_n,
-    #                 params.mutrates_s, mm, rm, params.interlocus_rec,
-    #                 params.gvalue, recorder, params.pself,
-    #                 params.prune_selected)


### PR DESCRIPTION
This PR cleans up the Python interface to simulating WF populations with tree sequence recording.

- [x] Allow for alternate method of mutation counting.  See molpopgen/fwdpp#167
- [x] Write documentation in manual
- [x] Clean up the Python file providing the interface.