### PR TITLE
Refactor genetic values to store vectors

### DIFF
--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
@@ -29,6 +29,13 @@ namespace fwdpy11
     /// Concepts we have to deal with:
     /// Noise and aggregation are a bit trickier here?
     {
+        std::size_t total_dim;
+        mutable std::vector<double> gvalues;
+
+        explicit MlocusPopGeneticValue(std::size_t dimensonality)
+            : total_dim(dimensonality), gvalues(total_dim, 0.0)
+        {
+        }
         // Callable from Python
         virtual double
         calculate_gvalue(const std::size_t /*diploid*/,
@@ -53,6 +60,13 @@ namespace fwdpy11
                              const std::size_t /*parent2*/,
                              const MlocusPop& /*pop*/) const = 0;
         virtual void update(const fwdpy11::MlocusPop& /*pop*/) = 0;
+        virtual pybind11::tuple shape() const = 0;
+
+        std::vector<double>
+        genetic_values() const
+        {
+            return gvalues;
+        }
         virtual pybind11::object pickle() const = 0;
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValueWithMapping.hpp
@@ -66,6 +66,10 @@ namespace fwdpy11
         pybind11::tuple
         shape() const
         {
+            if (total_dim != 1 || total_dim != gvalues.size())
+                {
+                    throw std::runtime_error("dimensionality mismatch");
+                }
             return pybind11::tuple(1);
         }
     };

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValueWithMapping.hpp
@@ -34,18 +34,22 @@ namespace fwdpy11
         std::unique_ptr<GeneticValueNoise> noise_fxn;
 
         MlocusPopGeneticValueWithMapping(const GeneticValueToFitnessMap& gv2w_)
-            : gv2w{ gv2w_.clone() }, noise_fxn{ new NoNoise() }
+            : MlocusPopGeneticValue(1), gv2w{ gv2w_.clone() }, noise_fxn{
+                  new NoNoise()
+              }
         {
         }
 
         MlocusPopGeneticValueWithMapping(const GeneticValueToFitnessMap& gv2w_,
                                          const GeneticValueNoise& noise_)
-            : gv2w{ gv2w_.clone() }, noise_fxn{ noise_.clone() }
+            : MlocusPopGeneticValue(1), gv2w{ gv2w_.clone() }, noise_fxn{
+                  noise_.clone()
+              }
         {
         }
 
         inline virtual double
-        genetic_value_to_fitness(const DiploidMetadata & metadata) const
+        genetic_value_to_fitness(const DiploidMetadata& metadata) const
         {
             return gv2w->operator()(metadata);
         }
@@ -57,6 +61,12 @@ namespace fwdpy11
         {
             return noise_fxn->operator()(rng, offspring_metadata, parent1,
                                          parent2, pop);
+        }
+
+        pybind11::tuple
+        shape() const
+        {
+            return pybind11::tuple(1);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusMultivariateEffectsStrictAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusMultivariateEffectsStrictAdditive.hpp
@@ -37,21 +37,19 @@ namespace fwdpy11
         calculate_gvalue(const std::size_t diploid_index,
                          const SlocusPop &pop) const
         {
-            std::fill(begin(multivariate_effects), end(multivariate_effects),
-                      0.0);
+            std::fill(begin(gvalues), end(gvalues), 0.0);
 
             for (auto key :
                  pop.gametes[pop.diploids[diploid_index].first].smutations)
                 {
                     const auto &mut = pop.mutations[key];
-                    if (mut.esizes.size() != multivariate_effects.size())
+                    if (mut.esizes.size() != gvalues.size())
                         {
                             throw std::runtime_error(
                                 "dimensionality mismatch");
                         }
                     std::transform(begin(mut.esizes), end(mut.esizes),
-                                   begin(multivariate_effects),
-                                   begin(multivariate_effects),
+                                   begin(gvalues), begin(gvalues),
                                    std::plus<double>());
                 }
 
@@ -59,24 +57,22 @@ namespace fwdpy11
                  pop.gametes[pop.diploids[diploid_index].second].smutations)
                 {
                     const auto &mut = pop.mutations[key];
-                    if (mut.esizes.size() != multivariate_effects.size())
+                    if (mut.esizes.size() != gvalues.size())
                         {
                             throw std::runtime_error(
                                 "dimensionality mismatch");
                         }
                     std::transform(begin(mut.esizes), end(mut.esizes),
-                                   begin(multivariate_effects),
-                                   begin(multivariate_effects),
+                                   begin(gvalues), begin(gvalues),
                                    std::plus<double>());
                 }
-            return multivariate_effects[focal_trait_index];
+            return gvalues[focal_trait_index];
         }
 
         pybind11::object
         pickle() const
         {
-            return pybind11::make_tuple(multivariate_effects.size(),
-                                        focal_trait_index);
+            return pybind11::make_tuple(gvalues.size(), focal_trait_index);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
@@ -20,6 +20,7 @@
 #define FWDPY11_SLOCUSPOP_GENETIC_VALUE_HPP__
 
 #include <cstdint>
+#include <vector>
 #include <pybind11/pybind11.h>
 #include <fwdpy11/rng.hpp>
 #include <fwdpy11/types/SlocusPop.hpp>
@@ -46,6 +47,14 @@ namespace fwdpy11
     /// Things to note:
     /// Any deme/geography-specific details must be handled by the derived class.
     {
+        std::size_t total_dim;
+        mutable std::vector<double> gvalues;
+
+        explicit SlocusPopGeneticValue(std::size_t dimensonality)
+            : total_dim(dimensonality), gvalues(total_dim, 0.0)
+        {
+        }
+
         // Callable from Python
         virtual double calculate_gvalue(const std::size_t /*diploid_index*/,
                                         const SlocusPop& /*pop*/) const = 0;
@@ -69,6 +78,14 @@ namespace fwdpy11
                              const SlocusPop& /*pop*/) const = 0;
         virtual void update(const SlocusPop& /*pop*/) = 0;
         virtual pybind11::object pickle() const = 0;
+
+        virtual pybind11::tuple shape() const = 0;
+
+        std::vector<double>
+        genetic_values() const
+        {
+            return gvalues;
+        }
     };
 } //namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
@@ -34,18 +34,21 @@ namespace fwdpy11
         std::unique_ptr<GeneticValueNoise> noise_fxn;
 
         SlocusPopGeneticValueWithMapping(const GeneticValueToFitnessMap& gv2w_)
-            : gv2w{ std::move(gv2w_.clone()) }, noise_fxn{ new NoNoise() }
+            : SlocusPopGeneticValue(1), gv2w{ std::move(gv2w_.clone()) },
+              noise_fxn{ new NoNoise() }
         {
         }
 
         SlocusPopGeneticValueWithMapping(const GeneticValueToFitnessMap& gv2w_,
                                          const GeneticValueNoise& noise_)
-            : gv2w{ gv2w_.clone() }, noise_fxn{ noise_.clone() }
+            : SlocusPopGeneticValue(1), gv2w{ gv2w_.clone() }, noise_fxn{
+                  noise_.clone()
+              }
         {
         }
 
         inline virtual double
-        genetic_value_to_fitness(const DiploidMetadata & metadata ) const
+        genetic_value_to_fitness(const DiploidMetadata& metadata) const
         {
             return gv2w->operator()(metadata);
         }
@@ -57,6 +60,12 @@ namespace fwdpy11
         {
             return noise_fxn->operator()(rng, offspring_metadata, parent1,
                                          parent2, pop);
+        }
+
+        pybind11::tuple
+        shape() const
+        {
+            return pybind11::make_tuple(total_dim);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
@@ -65,6 +65,10 @@ namespace fwdpy11
         pybind11::tuple
         shape() const
         {
+            if (total_dim != 1 || total_dim != gvalues.size())
+                {
+                    throw std::runtime_error("dimensionality mismatch");
+                }
             return pybind11::make_tuple(total_dim);
         }
     };

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopMultivariateGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopMultivariateGeneticValueWithMapping.hpp
@@ -29,7 +29,6 @@ namespace fwdpy11
     struct SlocusPopMultivariateGeneticValueWithMapping
         : public SlocusPopGeneticValue
     {
-        mutable std::vector<double> multivariate_effects;
         /// Classes deriving from this must call gv2w->update
         /// from their own update functions.
         std::unique_ptr<MultivariateGeneticValueToFitnessMap> gv2w;
@@ -39,8 +38,9 @@ namespace fwdpy11
         SlocusPopMultivariateGeneticValueWithMapping(
             std::size_t ndim,
             const MultivariateGeneticValueToFitnessMap& gv2w_)
-            : multivariate_effects(ndim, 0.0), gv2w{ gv2w_.clone() },
-              noise_fxn{ new NoNoise() }
+            : SlocusPopGeneticValue(ndim), gv2w{ gv2w_.clone() }, noise_fxn{
+                  new NoNoise()
+              }
         {
         }
 
@@ -48,15 +48,16 @@ namespace fwdpy11
             std::size_t ndim,
             const MultivariateGeneticValueToFitnessMap& gv2w_,
             const GeneticValueNoise& noise_)
-            : multivariate_effects(ndim, 0.0), gv2w{ gv2w_.clone() },
-              noise_fxn{ noise_.clone() }
+            : SlocusPopGeneticValue(ndim), gv2w{ gv2w_.clone() }, noise_fxn{
+                  noise_.clone()
+              }
         {
         }
 
         virtual double
         genetic_value_to_fitness(const DiploidMetadata& metadata) const
         {
-            return gv2w->operator()(metadata, multivariate_effects);
+            return gv2w->operator()(metadata, gvalues);
         }
 
         virtual double
@@ -73,6 +74,12 @@ namespace fwdpy11
         {
             gv2w->update(pop);
             noise_fxn->update(pop);
+        }
+
+        pybind11::tuple
+        shape() const
+        {
+            return pybind11::make_tuple(total_dim);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_mlocus_gvalue.hpp
@@ -69,7 +69,8 @@ namespace fwdpy11
                            [this, &pop](const DiploidGenotype& g) {
                                return gv(g, pop.gametes, pop.mutations);
                            });
-            return agg(per_locus_genetic_values);
+            gvalues[0] = agg(per_locus_genetic_values);
+            return gvalues[0];
         }
 
         inline void
@@ -78,6 +79,7 @@ namespace fwdpy11
             gv2w->update(pop);
             noise_fxn->update(pop);
         }
+
         virtual pybind11::object
         pickle() const
         {

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_slocus_gvalue.hpp
@@ -56,7 +56,9 @@ namespace fwdpy11
         calculate_gvalue(const std::size_t diploid_index,
                          const fwdpy11::SlocusPop& pop) const
         {
-            return gv(pop.diploids[diploid_index], pop.gametes, pop.mutations);
+            gvalues[0]
+                = gv(pop.diploids[diploid_index], pop.gametes, pop.mutations);
+            return gvalues[0];
         }
 
         inline void

--- a/fwdpy11/src/genetic_values.cc
+++ b/fwdpy11/src/genetic_values.cc
@@ -173,7 +173,12 @@ PYBIND11_MODULE(genetic_values, m)
         :return: The fitness of an individual.
         :rtype: float
         )delim",
-             py::arg("diploid_index"), py::arg("pop"));
+             py::arg("diploid_index"), py::arg("pop"))
+        .def("shape", &fwdpy11::SlocusPopGeneticValue::shape,
+             "Return the dimensions of the genetic values.")
+        .def_readonly("genetic_values",
+                      &fwdpy11::SlocusPopGeneticValue::gvalues,
+                      "Return the list of genetic values.");
 
     py::class_<fwdpy11::SlocusPopGeneticValueWithMapping,
                fwdpy11::SlocusPopGeneticValue>(

--- a/fwdpy11/src/genetic_values.cc
+++ b/fwdpy11/src/genetic_values.cc
@@ -415,7 +415,15 @@ PYBIND11_MODULE(genetic_values, m)
              :return: The fitness of an individual.
              :rtype: float
              )delim",
-             py::arg("diploid_index"), py::arg("pop"));
+             py::arg("diploid_index"), py::arg("pop"))
+        .def_property_readonly("shape",
+                               [](const fwdpy11::MlocusPopGeneticValue& self) {
+                                   return self.shape();
+                               },
+                               "Return dimensions of genetic values")
+        .def_readonly("genetic_values",
+                      &fwdpy11::MlocusPopGeneticValue::gvalues,
+                      "Return the list of genetic values.");
 
     py::class_<fwdpy11::MlocusPopGeneticValueWithMapping,
                fwdpy11::MlocusPopGeneticValue>(

--- a/fwdpy11/src/genetic_values.cc
+++ b/fwdpy11/src/genetic_values.cc
@@ -174,8 +174,11 @@ PYBIND11_MODULE(genetic_values, m)
         :rtype: float
         )delim",
              py::arg("diploid_index"), py::arg("pop"))
-        .def("shape", &fwdpy11::SlocusPopGeneticValue::shape,
-             "Return the dimensions of the genetic values.")
+        .def_property_readonly("shape",
+                               [](const fwdpy11::SlocusPopGeneticValue& self) {
+                                   return self.shape();
+                               },
+                               "Return the dimensions of the genetic values.")
         .def_readonly("genetic_values",
                       &fwdpy11::SlocusPopGeneticValue::gvalues,
                       "Return the list of genetic values.");

--- a/fwdpy11/src/genetic_values.cc
+++ b/fwdpy11/src/genetic_values.cc
@@ -178,10 +178,18 @@ PYBIND11_MODULE(genetic_values, m)
                                [](const fwdpy11::SlocusPopGeneticValue& self) {
                                    return self.shape();
                                },
-                               "Return the dimensions of the genetic values.")
+                               R"delim(
+                               Return the dimensions of the genetic values.
+
+                               .. versionadded:: 0.3.0
+                               )delim")
         .def_readonly("genetic_values",
                       &fwdpy11::SlocusPopGeneticValue::gvalues,
-                      "Return the list of genetic values.");
+                      R"delim(
+                      Return the list of genetic values.
+
+                      .. versionadded:: 0.3.0
+                      )delim");
 
     py::class_<fwdpy11::SlocusPopGeneticValueWithMapping,
                fwdpy11::SlocusPopGeneticValue>(
@@ -420,10 +428,18 @@ PYBIND11_MODULE(genetic_values, m)
                                [](const fwdpy11::MlocusPopGeneticValue& self) {
                                    return self.shape();
                                },
-                               "Return dimensions of genetic values")
+                               R"delim(
+                               Return dimensions of genetic values.
+
+                               .. versionadded:: 0.3.0
+                               )delim")
         .def_readonly("genetic_values",
                       &fwdpy11::MlocusPopGeneticValue::gvalues,
-                      "Return the list of genetic values.");
+                      R"delim(
+                      Return the list of genetic values.
+
+                      .. versinadded:: 0.3.0
+                      )delim");
 
     py::class_<fwdpy11::MlocusPopGeneticValueWithMapping,
                fwdpy11::MlocusPopGeneticValue>(

--- a/tests/custom_additive.cpp
+++ b/tests/custom_additive.cpp
@@ -23,6 +23,8 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
 
     struct additive : public fwdpy11::SlocusPopGeneticValue
 {
+    additive() : fwdpy11::SlocusPopGeneticValue(1) {}
+
     inline double
     calculate_gvalue(const std::size_t diploid_index,
                      const fwdpy11::SlocusPop& pop) const
@@ -38,7 +40,8 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
             {
                 sum += pop.mutations[m].s;
             }
-        return std::max(0.0, 1.0 + sum);
+        gvalues[0] = std::max(0.0, 1.0 + sum);
+        return gvalues[0];
     }
 
     double
@@ -62,6 +65,12 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
         return pybind11::bytes("custom_additive");
     }
     DEFAULT_SLOCUSPOP_UPDATE();
+
+    pybind11::tuple
+    shape() const
+    {
+        return pybind11::make_tuple(1);
+    }
 };
 
 //Standard pybind11 stuff goes here

--- a/tests/custom_stateless_genotype.cpp
+++ b/tests/custom_stateless_genotype.cpp
@@ -26,19 +26,20 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
 {
     fwdpp::site_dependent_genetic_value w;
 
-    GeneralW() : fwdpy11::SlocusPopGeneticValue{}, w{} {}
+    GeneralW() : fwdpy11::SlocusPopGeneticValue{1}, w{} {}
 
     inline double
     calculate_gvalue(const std::size_t diploid_index,
                      const fwdpy11::SlocusPop& pop) const
     {
-        return std::max(
+        gvalues[0] = std::max(
             0.0,
             w(pop.diploids[diploid_index], pop.gametes, pop.mutations,
               [](double& g, const fwdpy11::Mutation& m) { g *= (1.0 + m.s); },
               [](double& g, const fwdpy11::Mutation& m) {
                   g *= (1.0 + m.h);
               }));
+        return gvalues[0];
     }
 
     double
@@ -63,6 +64,12 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
     }
 
     DEFAULT_SLOCUSPOP_UPDATE();
+
+    pybind11::tuple
+    shape() const
+    {
+        return pybind11::make_tuple(1);
+    }
 };
 
 //Standard pybind11 stuff goes here

--- a/tests/snowdrift.cpp
+++ b/tests/snowdrift.cpp
@@ -68,8 +68,8 @@ struct snowdrift : public fwdpy11::SlocusPopGeneticValue
 
     // This constructor is exposed to Python
     snowdrift(double b1_, double b2_, double c1_, double c2_)
-        : fwdpy11::SlocusPopGeneticValue{}, b1(b1_), b2(b2_), c1(c1_), c2(c2_),
-          phenotypes()
+        : fwdpy11::SlocusPopGeneticValue{ 1 }, b1(b1_), b2(b2_), c1(c1_),
+          c2(c2_), phenotypes()
     {
     }
 
@@ -80,7 +80,7 @@ struct snowdrift : public fwdpy11::SlocusPopGeneticValue
     //initialize the phenotypes w/o extra copies.
     template <typename T>
     snowdrift(double b1_, double b2_, double c1_, double c2_, T &&p)
-        : fwdpy11::SlocusPopGeneticValue{}, b1(b1_), b2(b2_), c1(c1_), c2(c2_),
+        : fwdpy11::SlocusPopGeneticValue{1}, b1(b1_), b2(b2_), c1(c1_), c2(c2_),
           phenotypes(std::forward<T>(p))
     {
     }
@@ -90,7 +90,8 @@ struct snowdrift : public fwdpy11::SlocusPopGeneticValue
                      const fwdpy11::SlocusPop & /*pop*/) const
     // The call operator must return the genetic value of an individual
     {
-        return phenotypes[diploid_index];
+        gvalues[0] = phenotypes[diploid_index];
+        return gvalues[0];
     }
 
     inline double
@@ -151,6 +152,12 @@ struct snowdrift : public fwdpy11::SlocusPopGeneticValue
     pickle() const
     {
         return py::make_tuple(b1, b2, c1, c2, phenotypes);
+    }
+
+    py::tuple
+    shape() const
+    {
+        return py::make_tuple(1);
     }
 };
 

--- a/tests/test_stateful_fitness.py
+++ b/tests/test_stateful_fitness.py
@@ -70,6 +70,14 @@ class testSnowdrift(unittest.TestCase):
     def setUp(self):
         self.f = snowdrift.SlocusSnowdrift(1, -1, 0.1, 0.2)
 
+    def testShape(self):
+        s = self.f.shape
+        self.assertEqual(len(s), 1)
+        self.assertEqual(s[0], 1)
+
+    def test_genetic_values(self):
+        self.assertEqual(len(self.f.genetic_values), 1)
+
     def testPickle(self):
         self.f.phenotypes = [1, 2, 3, 4]
         p = pickle.dumps(self.f, -1)


### PR DESCRIPTION
#164 introduced support for multivariate mutational effects.  That PR's changes posed a problem in how to obtain them during a simulation, as they do not fit easily into the existing metadata model.  

This PR is one step towards solving that issue by requiring that a genetic value object store its results into a vector.