### PR TITLE
Allow for genetic value tracking in the multivariate case

### DIFF
--- a/doc/pages/types.rst
+++ b/doc/pages/types.rst
@@ -156,6 +156,10 @@ The population base class
 
 .. versionadded:: 0.2.0
 
+.. versionchanged:: 0.3.0
+
+    Added `genetic_values` and `ancient_samaple_genetic_values`.
+
 All populations based around :class:`fwdpy11.Mutation` and :class:`fwdpy11.Gamete` inherit from a common base class,
 :class:`fwdpy11.Population`.  This class in an Abstract Base Class, or ABC. You may not create instances of this class. \
 Rather, you work with the derived classes :class:`fwdpy11.SlocusPop` and :class:`fwdpy11.MlocusPop`.
@@ -171,6 +175,8 @@ Rather, you work with the derived classes :class:`fwdpy11.SlocusPop` and :class:
     "gametes", "A :class:`fwdpy11.VecGamete`.  See :ref:`gametes`."
     "fixations", "A :class:`fwdpy11.VecMutation` storing fixations. See :ref:`popgenmuts`."
     "fixation_times", "A :class:`fwdpy11.VecUint32` storing fixation times."
+    "genetic_values", "A 2d numpy array of genetic values."
+    "ancient_samaple_genetic_values", "A 2d numpy array of genetic values corresponding to ancient samples."
 
 .. note::
 

--- a/fwdpy11/headers/fwdpy11/numpy/array.hpp
+++ b/fwdpy11/headers/fwdpy11/numpy/array.hpp
@@ -1,0 +1,22 @@
+#ifndef FWDPY11_NUMPY_ARRAY_HPP
+#define FWDPY11_NUMPY_ARRAY_HPP
+
+#include <vector>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace fwdpy11
+{
+    template <typename T>
+    inline pybind11::array_t<T>
+    make_1d_ndarray(const std::vector<T>& v)
+    // Returns a 1d numpy array that does not own
+    // its data.
+    {
+        auto rv = pybind11::array_t<T>({ v.size() }, { sizeof(T) }, v.data(),
+                                       pybind11::cast(v));
+        return rv;
+    }
+} // namespace fwdpy11
+
+#endif

--- a/fwdpy11/headers/fwdpy11/numpy/array.hpp
+++ b/fwdpy11/headers/fwdpy11/numpy/array.hpp
@@ -17,6 +17,18 @@ namespace fwdpy11
                                        pybind11::cast(v));
         return rv;
     }
+
+    template <typename T>
+    inline pybind11::array_t<T>
+    make_2d_ndarray(const std::vector<T>& v, std::size_t dim1,
+                    std::size_t dim2)
+    // Returns a 2d numpy array that does not own
+    // its data.
+    {
+        auto rv = pybind11::array_t<T>({ dim1, dim2 }, v.data(),
+                                       pybind11::cast(v));
+        return rv;
+    }
 } // namespace fwdpy11
 
 #endif

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -37,7 +37,9 @@ namespace fwdpy11
         inline constexpr int
         magic()
         {
-            return 2;
+            // Changed to 3 im 0.3.0
+            // to handle genetic value matrices
+            return 3;
         }
 
         template <typename streamtype, typename poptype>
@@ -57,6 +59,20 @@ namespace fwdpy11
                 buffer, pop->ancient_sample_records);
             fwdpp::io::serialize_population(buffer, *pop);
             fwdpp::ts::io::serialize_tables(buffer, pop->tables);
+            std::size_t msize = pop->genetic_value_matrix.size();
+            fwdpp::io::scalar_writer w;
+            w(buffer, &msize);
+            if (msize > 0)
+                {
+                    w(buffer, pop->genetic_value_matrix.data(), msize);
+                }
+            msize = pop->ancient_sample_genetic_value_matrix.size();
+            w(buffer, &msize);
+            if (msize > 0)
+                {
+                    w(buffer, pop->genetic_value_matrix.data(), msize);
+                }
+
             return buffer;
         }
 
@@ -105,6 +121,28 @@ namespace fwdpy11
                         fwdpp::ts::count_mutations(
                             pop.tables, pop.mutations, samples, pop.mcounts,
                             pop.mcounts_from_preserved_nodes);
+                    }
+                if (version > 2)
+                    {
+                        std::size_t msize;
+                        fwdpp::io::scalar_reader r;
+                        r(buffer, &msize);
+                        if (msize > 0)
+                            {
+                                pop.genetic_value_matrix.resize(msize);
+                                r(buffer, pop.genetic_value_matrix.data(),
+                                  msize);
+                            }
+                        r(buffer, &msize);
+                        if (msize > 0)
+                            {
+                                pop.ancient_sample_genetic_value_matrix.resize(
+                                    msize);
+                                r(buffer,
+                                  pop.ancient_sample_genetic_value_matrix
+                                      .data(),
+                                  msize);
+                            }
                     }
                 return buffer;
             }

--- a/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
@@ -51,6 +51,13 @@ namespace fwdpy11
         std::vector<ancient_sample_record> ancient_sample_records;
         fwdpp::ts::table_collection tables;
 
+        // These track genetic values for the individuals differently
+        // from what diploid_metadata/ancient_sample_metadata do.
+        // For the case of a multivariate trait, we imagine this to
+        // represent a matrix of N rows by "dimensions" columns.
+        std::vector<double> genetic_value_matrix,
+            ancient_sample_genetic_value_matrix;
+
         virtual ~PyPopulation() = default;
 
         PyPopulation(PyPopulation &&) = default;
@@ -59,7 +66,8 @@ namespace fwdpy11
         PyPopulation(fwdpp::uint_t N_, const double L)
             : fwdpp_base{ N_ }, N{ N_ }, generation{ 0 }, diploid_metadata(N),
               ancient_sample_metadata{}, ancient_sample_records{},
-              tables(init_tables(N_, L))
+              tables(init_tables(N_, L)), genetic_value_matrix{},
+              ancient_sample_genetic_value_matrix{}
         {
         }
 
@@ -72,7 +80,8 @@ namespace fwdpy11
                           std::forward<mutations_input>(m), reserve_size },
               N{ N_ }, generation{ 0 }, diploid_metadata(N),
               ancient_sample_metadata{}, ancient_sample_records{},
-              tables(std::numeric_limits<double>::max())
+              tables(std::numeric_limits<double>::max()),
+              genetic_value_matrix{}, ancient_sample_genetic_value_matrix{}
         {
         }
 

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -233,15 +233,40 @@ PYBIND11_MODULE(_Population, m)
                 Give access to the population's 
                 :class:`fwdpy11.ts.TableCollection`
                 )delim")
-        .def_property_readonly("genetic_values",
-                               [](const fwdpy11::Population& self) {
-                                   return fwdpy11::make_1d_ndarray(
-                                       self.genetic_value_matrix);
-                               })
+        .def_property_readonly(
+            "genetic_values",
+            [](const fwdpy11::Population& self) {
+                py::print(self.N, self.genetic_value_matrix.size());
+                //return fwdpy11::make_1d_ndarray(self.genetic_value_matrix);
+                return fwdpy11::make_2d_ndarray(
+                    self.genetic_value_matrix, self.N,
+                    self.genetic_value_matrix.size() / self.N);
+            },
+            R"delim(
+        Return the genetic values as a 2d matrix.
+        
+        The array is read-write, so be careful!
+        
+        Rows are individuals.  Columns are genetic values.
+        
+        ..  versionadded 0.3.0
+        )delim")
         .def_property_readonly(
             "ancient_sample_genetic_values",
             [](const fwdpy11::Population& self) {
-                return fwdpy11::make_1d_ndarray(
-                    self.ancient_sample_genetic_value_matrix);
-            });
+                return fwdpy11::make_2d_ndarray(
+                    self.ancient_sample_genetic_value_matrix,
+                    self.ancient_sample_metadata.size(),
+                    self.ancient_sample_genetic_value_matrix.size()
+                        / self.ancient_sample_metadata.size());
+            },
+            R"delim(
+        Return the genetic values for ancient samples as a 2d matrix.
+        
+        The array is read-write, so be careful!
+        
+        Rows are individuals.  Columns are genetic values.
+        
+        ..  versionadded 0.3.0
+        )delim");
 }

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -236,7 +236,6 @@ PYBIND11_MODULE(_Population, m)
         .def_property_readonly(
             "genetic_values",
             [](const fwdpy11::Population& self) {
-                py::print(self.N, self.genetic_value_matrix.size());
                 //return fwdpy11::make_1d_ndarray(self.genetic_value_matrix);
                 return fwdpy11::make_2d_ndarray(
                     self.genetic_value_matrix, self.N,

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -21,6 +21,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 #include <fwdpy11/types/Population.hpp>
+#include <fwdpy11/numpy/array.hpp>
 
 namespace py = pybind11;
 
@@ -231,5 +232,16 @@ PYBIND11_MODULE(_Population, m)
                       R"delim(
                 Give access to the population's 
                 :class:`fwdpy11.ts.TableCollection`
-                )delim");
+                )delim")
+        .def_property_readonly("genetic_values",
+                               [](const fwdpy11::Population& self) {
+                                   return fwdpy11::make_1d_ndarray(
+                                       self.genetic_value_matrix);
+                               })
+        .def_property_readonly(
+            "ancient_sample_genetic_values",
+            [](const fwdpy11::Population& self) {
+                return fwdpy11::make_1d_ndarray(
+                    self.ancient_sample_genetic_value_matrix);
+            });
 }

--- a/fwdpy11/src/ts.cc
+++ b/fwdpy11/src/ts.cc
@@ -18,6 +18,7 @@
 #include <fwdpy11/types/Population.hpp>
 #include <fwdpy11/rng.hpp>
 #include <fwdpy11/policies/mutation.hpp>
+#include <fwdpy11/numpy/array.hpp>
 
 namespace py = pybind11;
 
@@ -79,15 +80,6 @@ generate_neutral_variants(fwdpp::flagged_mutation_queue& recycling_bin,
                                       return_zero, return_zero, 0);
 }
 
-template <typename T>
-inline py::array_t<T>
-make_1d_ndarray(const std::vector<T>& v)
-{
-    auto rv
-        = py::array_t<T>({ v.size() }, { sizeof(T) }, v.data(), py::cast(v));
-    return rv;
-}
-
 struct VariantIterator
 {
     std::vector<fwdpp::ts::mutation_record>::const_iterator mbeg, mend;
@@ -100,7 +92,7 @@ struct VariantIterator
                     const std::vector<fwdpp::ts::TS_NODE_INT>& samples)
         : mbeg(tc.mutation_table.begin()), mend(tc.mutation_table.end()),
           pos(), tv(tc, samples), genotype_data(samples.size(), 0),
-          genotypes(make_1d_ndarray(genotype_data))
+          genotypes(fwdpy11::make_1d_ndarray(genotype_data))
     {
         // Advance to first tree
         auto flag = tv(std::true_type(), std::true_type());
@@ -309,55 +301,55 @@ PYBIND11_MODULE(ts, m)
                       "Right edge of genomic interval (exclusive")
         .def_property_readonly("parents",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.parents);
+                                   return fwdpy11::make_1d_ndarray(m.parents);
                                },
                                "Vector of child -> parent relationships")
         .def_property_readonly("leaf_counts",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.leaf_counts);
+                                   return fwdpy11::make_1d_ndarray(m.leaf_counts);
                                },
                                "Leaf counts for each node")
         .def_property_readonly("preserved_leaf_counts",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(
+                                   return fwdpy11::make_1d_ndarray(
                                        m.preserved_leaf_counts);
                                },
                                "Ancient sample leaf counts for each node")
         .def_property_readonly("left_sib",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.left_sib);
+                                   return fwdpy11::make_1d_ndarray(m.left_sib);
                                },
                                "Return the left sibling of the current node")
         .def_property_readonly("right_sib",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.right_sib);
+                                   return fwdpy11::make_1d_ndarray(m.right_sib);
                                },
                                "Return the right sibling of the current node")
         .def_property_readonly("left_child",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.left_child);
+                                   return fwdpy11::make_1d_ndarray(m.left_child);
                                },
                                "Mapping of current node id to its left child")
         .def_property_readonly("right_child",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.right_child);
+                                   return fwdpy11::make_1d_ndarray(m.right_child);
                                },
                                "Mapping of current node id to its right child")
         .def_property_readonly("left_sample",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.left_sample);
+                                   return fwdpy11::make_1d_ndarray(m.left_sample);
                                })
         .def_property_readonly("right_sample",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.right_sample);
+                                   return fwdpy11::make_1d_ndarray(m.right_sample);
                                })
         .def_property_readonly("next_sample",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.next_sample);
+                                   return fwdpy11::make_1d_ndarray(m.next_sample);
                                })
         .def_property_readonly("sample_index_map",
                                [](const fwdpp::ts::marginal_tree& m) {
-                                   return make_1d_ndarray(m.sample_index_map);
+                                   return fwdpy11::make_1d_ndarray(m.sample_index_map);
                                })
         .def_readonly("sample_size", &fwdpp::ts::marginal_tree::sample_size)
         .def("total_time",

--- a/fwdpy11/src/ts/tree_iterator.cc
+++ b/fwdpy11/src/ts/tree_iterator.cc
@@ -3,17 +3,9 @@
 #include <pybind11/stl.h>
 #include <fwdpp/ts/tree_visitor.hpp>
 #include <fwdpp/ts/marginal_tree.hpp>
+#include <fwdpy11/numpy/array.hpp>
 
 namespace py = pybind11;
-
-template <typename T>
-inline py::array_t<T>
-make_1d_ndarray(const std::vector<T>& v)
-{
-    auto rv
-        = py::array_t<T>({ v.size() }, { sizeof(T) }, v.data(), py::cast(v));
-    return rv;
-}
 
 PYBIND11_MAKE_OPAQUE(fwdpp::ts::edge_vector);
 PYBIND11_MAKE_OPAQUE(fwdpp::ts::node_vector);
@@ -30,18 +22,18 @@ struct tree_visitor_wrapper
                          const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                          bool update_sample_list)
         : visitor(tables, samples),
-          parents(make_1d_ndarray(visitor.tree().parents)),
-          leaf_counts(make_1d_ndarray(visitor.tree().leaf_counts)),
+          parents(fwdpy11::make_1d_ndarray(visitor.tree().parents)),
+          leaf_counts(fwdpy11::make_1d_ndarray(visitor.tree().leaf_counts)),
           preserved_leaf_counts(
-              make_1d_ndarray(visitor.tree().preserved_leaf_counts)),
-          left_sib(make_1d_ndarray(visitor.tree().left_sib)),
-          right_sib(make_1d_ndarray(visitor.tree().right_sib)),
-          left_child(make_1d_ndarray(visitor.tree().left_child)),
-          right_child(make_1d_ndarray(visitor.tree().right_child)),
-          left_sample(make_1d_ndarray(visitor.tree().left_sample)),
-          right_sample(make_1d_ndarray(visitor.tree().right_sample)),
-          next_sample(make_1d_ndarray(visitor.tree().next_sample)),
-          sample_index_map(make_1d_ndarray(visitor.tree().sample_index_map)),
+              fwdpy11::make_1d_ndarray(visitor.tree().preserved_leaf_counts)),
+          left_sib(fwdpy11::make_1d_ndarray(visitor.tree().left_sib)),
+          right_sib(fwdpy11::make_1d_ndarray(visitor.tree().right_sib)),
+          left_child(fwdpy11::make_1d_ndarray(visitor.tree().left_child)),
+          right_child(fwdpy11::make_1d_ndarray(visitor.tree().right_child)),
+          left_sample(fwdpy11::make_1d_ndarray(visitor.tree().left_sample)),
+          right_sample(fwdpy11::make_1d_ndarray(visitor.tree().right_sample)),
+          next_sample(fwdpy11::make_1d_ndarray(visitor.tree().next_sample)),
+          sample_index_map(fwdpy11::make_1d_ndarray(visitor.tree().sample_index_map)),
           update_samples(update_sample_list)
     {
     }
@@ -52,18 +44,18 @@ struct tree_visitor_wrapper
         const std::vector<fwdpp::ts::TS_NODE_INT>& preserved_nodes,
         bool update_sample_list)
         : visitor(tables, samples),
-          parents(make_1d_ndarray(visitor.tree().parents)),
-          leaf_counts(make_1d_ndarray(visitor.tree().leaf_counts)),
+          parents(fwdpy11::make_1d_ndarray(visitor.tree().parents)),
+          leaf_counts(fwdpy11::make_1d_ndarray(visitor.tree().leaf_counts)),
           preserved_leaf_counts(
-              make_1d_ndarray(visitor.tree().preserved_leaf_counts)),
-          left_sib(make_1d_ndarray(visitor.tree().left_sib)),
-          right_sib(make_1d_ndarray(visitor.tree().right_sib)),
-          left_child(make_1d_ndarray(visitor.tree().left_child)),
-          right_child(make_1d_ndarray(visitor.tree().right_child)),
-          left_sample(make_1d_ndarray(visitor.tree().left_sample)),
-          right_sample(make_1d_ndarray(visitor.tree().right_sample)),
-          next_sample(make_1d_ndarray(visitor.tree().next_sample)),
-          sample_index_map(make_1d_ndarray(visitor.tree().sample_index_map)),
+              fwdpy11::make_1d_ndarray(visitor.tree().preserved_leaf_counts)),
+          left_sib(fwdpy11::make_1d_ndarray(visitor.tree().left_sib)),
+          right_sib(fwdpy11::make_1d_ndarray(visitor.tree().right_sib)),
+          left_child(fwdpy11::make_1d_ndarray(visitor.tree().left_child)),
+          right_child(fwdpy11::make_1d_ndarray(visitor.tree().right_child)),
+          left_sample(fwdpy11::make_1d_ndarray(visitor.tree().left_sample)),
+          right_sample(fwdpy11::make_1d_ndarray(visitor.tree().right_sample)),
+          next_sample(fwdpy11::make_1d_ndarray(visitor.tree().next_sample)),
+          sample_index_map(fwdpy11::make_1d_ndarray(visitor.tree().sample_index_map)),
           update_samples(update_sample_list)
     {
     }

--- a/fwdpy11/src/wright_fisher_slocus_ts.cc
+++ b/fwdpy11/src/wright_fisher_slocus_ts.cc
@@ -218,7 +218,6 @@ wfSlocusPop_ts(
             genetic_value_fxn.update(pop);
             lookup = calculate_fitness(rng, pop, genetic_value_fxn,
                                        new_metadata, new_diploid_gvalues);
-            auto d = pop.genetic_value_matrix.data();
             if (gen > 0 && gen % simplification_interval == 0.0)
                 {
                     // TODO: update this to allow neutral mutations to be simulated

--- a/fwdpy11/src/wright_fisher_slocus_ts.cc
+++ b/fwdpy11/src/wright_fisher_slocus_ts.cc
@@ -271,6 +271,16 @@ wfSlocusPop_ts(
                             // Record the metadata for this individual
                             pop.ancient_sample_metadata.push_back(
                                 pop.diploid_metadata[i]);
+                            // Update the genotype matrix w.r.to
+                            // the new ancient samples
+                            if (!pop.genetic_value_matrix.empty())
+                                {
+                                    pop.ancient_sample_genetic_value_matrix.insert(
+                                        end(pop.ancient_sample_genetic_value_matrix),
+                                        begin(pop.genetic_value_matrix) + i,
+                                        begin(pop.genetic_value_matrix) + i
+                                            + genetic_value_fxn.total_dim);
+                                }
                             // Record the time and nodes for this individual
                             pop.ancient_sample_records.emplace_back(
                                 fwdpy11::ancient_sample_record{

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -19,7 +19,7 @@
 
 
 def evolve(rng, pop, params, simplification_interval, recorder=None,
-           suppress_table_indexing=False):
+           suppress_table_indexing=False, record_gvalue_matrix=False):
     """
     Evolve a population
 
@@ -35,6 +35,13 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
     :type recorder: callable
     :param suppress_table_indexing: (False) Prevents edge table indexing until end of simulation
     :type suppress_table_indexing: boolean
+    :param record_gvalue_matrix: (False) Whether to record genetic values into :attr:`fwdpy11.Population.genetic_values`.
+    :type record_gvalue_matrix: boolean
+
+    The recording of genetic values into :attr:`fwdpy11.Population.genetic_values` is supprssed by default.  First, it
+    is redundant with :attr:`fwdpy11.DiploidMetadata.g` for the common case of mutational effects on a single trait.
+    Second, we save some memory by not tracking these matrices.  However, it is useful to track these data for some
+    cases when simulating multivariate mutational effects (pleiotropy).
 
     .. note::
         If recorder is None,
@@ -74,4 +81,4 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
                    params.demography, params.mutrate_s,
                    params.recrate, mm, rm, params.gvalue,
                    recorder, params.pself, params.prune_selected is True,
-                   suppress_table_indexing)
+                   suppress_table_indexing,record_gvalue_matrix)


### PR DESCRIPTION
Builds on #164 and #172 to allow multivariate genetic values to be tracked during simulation for all dimensions.

- [x] Add matrix types to C++ classes
- [x] Add ndarray properties to Python classes
- [x] Add simulation support
- [x] Add tracking for ancient samples
- [x] Serialization of the new data fields in the population class
- [x] Determine if we can maintain backwards compatibility with the previous serialization format.
- [x] Add documentation to manual re: new matrix types