### PR TITLE
Get rid of "ancient sample records"

### DIFF
--- a/doc/pages/ts.rst
+++ b/doc/pages/ts.rst
@@ -320,28 +320,18 @@ have a mapping from their nodes to what individual they were:
 
 .. ipython:: python
 
-    print(pop.ancient_sample_records)
-    for i in pop.ancient_sample_records[:5]:
-        # time, node 1, node 2
-        print(i.time, i.n1, i.n2)
+    print(pop.ancient_sample_metadata)
+    for i in pop.ancient_sample_metadata[:5]:
+        print(i.nodes)
 
-We may view the same data using a numpy array:
+We may view the same data using a numpy array.  These data are the same
+format as for "alive" individuals.
 
 .. ipython:: python
 
-    ar = np.array(pop.ancient_sample_records, copy=False)
+    ar = np.array(pop.metadata, copy=False)
     print(ar.dtype)
     print(ar[:5])
-
-The other form of metadata is the same as for alive individuals:
-
-.. ipython:: python
-
-    print(type(pop.ancient_sample_metadata[0]))
-    md = np.array(pop.ancient_sample_metadata)
-    print(md.dtype)
-    print(md[:5])
-
 
 Obtaining genotype data from tree sequences
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/doc/pages/types.rst
+++ b/doc/pages/types.rst
@@ -141,7 +141,7 @@ The later class contains useful additional data about the individual:
     "deme", "The deme index of this diploid. New in 0.2.0."
     "sex", "The sex index of this diploid. New in 0.2.0."
     "parents", "A list containing the label fields of each parent."
-    "nodes", "The nodes in a tree sequence corresponding to this diploid. (Not used in 0.2.0)"
+    "nodes", "The nodes in a tree sequence corresponding to this diploid."
 
 For a multi-locus simulation, the diploid genotype at each locus is stored in a :class:`fwdpy11.VecDiploid`, which is an opaque list of :class:`fwdpy11.DiploidGenotype` objects.  
 

--- a/fwdpy11/_tables_to_msprime.py
+++ b/fwdpy11/_tables_to_msprime.py
@@ -75,17 +75,17 @@ def _initializeIndividualTable(pop, tc):
 
     # Now, preserved nodes
     num_ind_nodes = pop.N
-    for i in pop.ancient_sample_records:
+    for i in pop.ancient_sample_metadata:
         assert i not in individal_nodes, "indivudal record error"
-        individal_nodes[i.n1] = num_ind_nodes
-        individal_nodes[i.n2] = num_ind_nodes
+        individal_nodes[i.nodes[0]] = num_ind_nodes
+        individal_nodes[i.nodes[1]] = num_ind_nodes
         num_ind_nodes += 1
 
     metadata_strings.extend(_generate_individual_metadata(
         pop.ancient_sample_metadata, tc))
 
     md, mdo = msprime.pack_bytes(metadata_strings)
-    flags = [0 for i in range(pop.N+len(pop.ancient_sample_records))]
+    flags = [0 for i in range(pop.N+len(pop.ancient_sample_metadata))]
     tc.individuals.set_columns(flags=flags, metadata=md, metadata_offset=mdo)
     return individal_nodes
 

--- a/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/MlocusPop.hpp
@@ -74,6 +74,10 @@ namespace fwdpy11
                 {
                     d.label = label++;
                     d.w = 1.0;
+                    if (length == std::numeric_limits<double>::max())
+                        {
+                            d.nodes[0] = d.nodes[1] = -1;
+                        }
                 }
             if(length < locus_boundaries.back().second)
             {

--- a/fwdpy11/headers/fwdpy11/types/SlocusPop.hpp
+++ b/fwdpy11/headers/fwdpy11/types/SlocusPop.hpp
@@ -58,6 +58,10 @@ namespace fwdpy11
                 {
                     d.label = label++;
                     d.w = 1.0;
+                    if (length == std::numeric_limits<double>::max())
+                        {
+                            d.nodes[0] = d.nodes[1] = -1;
+                        }
                 }
         }
 

--- a/fwdpy11/src/_Population.cc
+++ b/fwdpy11/src/_Population.cc
@@ -59,7 +59,6 @@ namespace
 PYBIND11_MAKE_OPAQUE(fwdpy11::Population::gcont_t);
 PYBIND11_MAKE_OPAQUE(fwdpy11::Population::mcont_t);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidMetadata>);
-PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::ancient_sample_record>);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpp::uint_t>);
 
 PYBIND11_MODULE(_Population, m)
@@ -110,9 +109,6 @@ PYBIND11_MODULE(_Population, m)
         .def_readwrite("ancient_sample_metadata",
                        &fwdpy11::Population::ancient_sample_metadata,
                        "Container of metadata for ancient samples.")
-        .def_readwrite("ancient_sample_records",
-                       &fwdpy11::Population::ancient_sample_records,
-                       "Container of time and node data for ancient samples")
         .def_property_readonly(
             "mut_lookup",
             [](const fwdpy11::Population& pop) -> py::object {

--- a/fwdpy11/src/_opaque_diploids.cc
+++ b/fwdpy11/src/_opaque_diploids.cc
@@ -27,13 +27,11 @@ namespace py = pybind11;
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidGenotype>);
 PYBIND11_MAKE_OPAQUE(std::vector<std::vector<fwdpy11::DiploidGenotype>>);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidMetadata>);
-PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::ancient_sample_record>);
 
 PYBIND11_MODULE(_opaque_diploids, m)
 {
     m.doc() = "Expose C++ containers of diploids to Python without copies.";
     PYBIND11_NUMPY_DTYPE(fwdpy11::DiploidGenotype, first, second);
-    PYBIND11_NUMPY_DTYPE(fwdpy11::ancient_sample_record, time, n1, n2);
 
     py::bind_vector<fwdpy11::dipvector_t>(
         m, "VecDiploid", py::buffer_protocol(), py::module_local(false),
@@ -89,11 +87,4 @@ PYBIND11_MODULE(_opaque_diploids, m)
         R"delim(
         Container of diploid metadata.
         )delim");
-
-    py::bind_vector<std::vector<fwdpy11::ancient_sample_record>>(
-        m, "VecAncientSampleRecords", py::module_local(false),
-        py::buffer_protocol(),
-        R"delim(
-            Container of records for ancient samples.
-            )delim");
 }

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -251,10 +251,4 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def_readwrite("deme", &fwdpy11::DiploidMetadata::deme, "Deme.")
         .def_readwrite("label", &fwdpy11::DiploidMetadata::label,
                        "Index of the individual in the population.");
-
-    py::class_<fwdpy11::ancient_sample_record>(m, "AncientSampleRecord",
-            "Additional data relating to ancient samples.")
-        .def_readonly("time", &fwdpy11::ancient_sample_record::time,"Time when individual existed")
-        .def_readonly("n1", &fwdpy11::ancient_sample_record::n1,"First node on tree.")
-        .def_readonly("n2", &fwdpy11::ancient_sample_record::n2,"Second node on tree.");
 }

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -250,5 +250,13 @@ PYBIND11_MODULE(fwdpy11_types, m)
         .def_readwrite("sex", &fwdpy11::DiploidMetadata::sex, "Sex.")
         .def_readwrite("deme", &fwdpy11::DiploidMetadata::deme, "Deme.")
         .def_readwrite("label", &fwdpy11::DiploidMetadata::label,
-                       "Index of the individual in the population.");
+                       "Index of the individual in the population.")
+        .def_property_readonly("nodes",
+                               [](const fwdpy11::DiploidMetadata &md) {
+                                   py::list rv;
+                                   rv.append(md.nodes[0]);
+                                   rv.append(md.nodes[1]);
+                                   return rv;
+                               },
+                               "Node ids for individual");
 }

--- a/fwdpy11/src/tsevolution/mlocuspop.cc
+++ b/fwdpy11/src/tsevolution/mlocuspop.cc
@@ -251,8 +251,6 @@ wfMlocusPop_ts(
                     simplified = true;
                     next_index = pop.tables.num_nodes();
                     first_parental_index = 0;
-                    remap_ancient_samples(pop.ancient_sample_records,
-                                          rv.first);
                     remap_metadata(pop.ancient_sample_metadata, rv.first);
                     remap_metadata(pop.diploid_metadata, rv.first);
                 }
@@ -336,7 +334,6 @@ wfMlocusPop_ts(
                 preserve_selected_fixations, false,
                 suppress_edge_table_indexing);
 
-            remap_ancient_samples(pop.ancient_sample_records, rv.first);
             remap_metadata(pop.ancient_sample_metadata, rv.first);
             remap_metadata(pop.diploid_metadata, rv.first);
         }

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -197,8 +197,6 @@ wfSlocusPop_ts(
                     simplified = true;
                     next_index = pop.tables.num_nodes();
                     first_parental_index = 0;
-                    remap_ancient_samples(pop.ancient_sample_records,
-                                          rv.first);
                     remap_metadata(pop.ancient_sample_metadata, rv.first);
                     remap_metadata(pop.diploid_metadata, rv.first);
                 }
@@ -282,7 +280,6 @@ wfSlocusPop_ts(
                 preserve_selected_fixations, false,
                 suppress_edge_table_indexing);
 
-            remap_ancient_samples(pop.ancient_sample_records, rv.first);
             remap_metadata(pop.ancient_sample_metadata, rv.first);
             remap_metadata(pop.diploid_metadata, rv.first);
         }

--- a/fwdpy11/src/tsevolution/util.cc
+++ b/fwdpy11/src/tsevolution/util.cc
@@ -22,19 +22,3 @@ remap_metadata(std::vector<fwdpy11::DiploidMetadata> &metadata,
         }
 }
 
-void
-remap_ancient_samples(std::vector<fwdpy11::ancient_sample_record> &records,
-                      const std::vector<fwdpp::ts::TS_NODE_INT> &idmap)
-{
-    for (auto &a : records)
-        {
-            a.n1 = idmap[a.n1];
-            a.n2 = idmap[a.n2];
-            if (a.n1 == fwdpp::ts::TS_NULL_NODE
-                || a.n2 == fwdpp::ts::TS_NULL_NODE)
-                {
-                    throw std::runtime_error(
-                        "error simplifying with respect to ancient samples");
-                }
-        }
-}

--- a/fwdpy11/src/tsevolution/util.hpp
+++ b/fwdpy11/src/tsevolution/util.hpp
@@ -10,7 +10,4 @@ void
 remap_metadata(std::vector<fwdpy11::DiploidMetadata> &metadata,
                const std::vector<fwdpp::ts::TS_NODE_INT> &idmap);
 
-void
-remap_ancient_samples(std::vector<fwdpy11::ancient_sample_record> &records,
-                      const std::vector<fwdpp::ts::TS_NODE_INT> &idmap);
 #endif

--- a/fwdpy11/src/wright_fisher_mlocus.cc
+++ b/fwdpy11/src/wright_fisher_mlocus.cc
@@ -225,6 +225,7 @@ wfMlocusPop(const fwdpy11::GSLrng_t &rng, fwdpy11::MlocusPop &pop,
               offspring_metadata.deme = 0;
               offspring_metadata.parents[0] = p1;
               offspring_metadata.parents[1] = p2;
+              offspring_metadata.nodes[0] = offspring_metadata.nodes[1] = -1;
           };
 
     for (std::uint32_t gen = 0; gen < num_generations; ++gen)

--- a/fwdpy11/src/wright_fisher_slocus.cc
+++ b/fwdpy11/src/wright_fisher_slocus.cc
@@ -185,6 +185,7 @@ wfSlocusPop(const fwdpy11::GSLrng_t &rng, fwdpy11::SlocusPop &pop,
               offspring_metadata.deme = 0;
               offspring_metadata.parents[0] = p1;
               offspring_metadata.parents[1] = p2;
+              offspring_metadata.nodes[0] = offspring_metadata.nodes[1] = -1;
           };
 
     for (std::uint32_t gen = 0; gen < num_generations; ++gen)

--- a/tests/test_MlocusPop.py
+++ b/tests/test_MlocusPop.py
@@ -49,6 +49,14 @@ class testMlocusPop(unittest.TestCase):
     def test_e_values(self):
         self.assertEqual(sum([i.e for i in self.pop.diploid_metadata]), 0.0)
 
+    def test_nodes(self):
+        self.assertEqual(len(self.pop.diploids),
+                         len(self.pop.diploid_metadata))
+        import fwdpy11.ts
+        for i in self.pop.diploid_metadata:
+            self.assertEqual(i.nodes[0], fwdpy11.ts.NULL_NODE)
+            self.assertEqual(i.nodes[1], fwdpy11.ts.NULL_NODE)
+
 
 class testMlocusPopExceptions(unittest.TestCase):
     def testNzero(self):
@@ -102,6 +110,12 @@ class testSampling(unittest.TestCase):
             numbers to a list of unsigned types.
             """
             self.pop.sample(individuals=range(-10, 10))
+
+    def test_nodes(self):
+        import fwdpy11.ts
+        for i in self.pop.diploid_metadata:
+            self.assertEqual(i.nodes[0], fwdpy11.ts.NULL_NODE)
+            self.assertEqual(i.nodes[1], fwdpy11.ts.NULL_NODE)
 
 
 class testBadLocusBoundaries(unittest.TestCase):

--- a/tests/test_SlocusPop.py
+++ b/tests/test_SlocusPop.py
@@ -99,6 +99,24 @@ class testPythonObjects(unittest.TestCase):
             self.assertTrue(i[0] < self.pop.N)
             self.assertTrue(i[1] < self.pop.N)
 
+    def test_nodes(self):
+        import fwdpy11.ts
+        self.assertEqual(len(self.pop.diploids),
+                         len(self.pop.diploid_metadata))
+        for i in self.pop.diploid_metadata:
+            self.assertEqual(i.nodes[0], fwdpy11.ts.NULL_NODE)
+            self.assertEqual(i.nodes[1], fwdpy11.ts.NULL_NODE)
+
+    def test_nodes_after_evolution(self):
+        from fwdpy11.model_params import ModelParams
+        from fwdpy11.wright_fisher import evolve
+        import fwdpy11.ts
+        params = ModelParams(**self.pdict)
+        evolve(self.rng, self.pop, params)
+        for i in self.pop.diploid_metadata:
+            self.assertEqual(i.nodes[0], fwdpy11.ts.NULL_NODE)
+            self.assertEqual(i.nodes[1], fwdpy11.ts.NULL_NODE)
+
     def testMutationLookupTable(self):
         from fwdpy11.model_params import ModelParams
         from fwdpy11.wright_fisher import evolve


### PR DESCRIPTION
The finishing touches on closing #184.

* Remove AncientSampleRecord from fwdpy11.
* Add `node` field to DiploidMetadata Python class.
* Sims w/o tree sequence recording set the node fields to -1 in the metadata.