### PR TITLE
Generalize genetic maps

### DIFF
--- a/doc/pages/regions.rst
+++ b/doc/pages/regions.rst
@@ -183,7 +183,7 @@ To model two continuous regions separated by 25 centiMorgans:
                   fwdpy11.BinomialPoint(1, 0.25),
                   fwdpy11.PoissonInterval(1, 2, 1e-3)]
 
-The number of recombination in the intervals :math:`[0,1)` and :math:`[1,2)` will both be Poisson-distributed with means
+The number of recombination breakpoints in the intervals :math:`[0,1)` and :math:`[1,2)` will both be Poisson-distributed with means
 of :math:`10^{-3}`.  A recombination event *between* the two regions will happen in 25% of meioses.
 
 How to set up a model

--- a/doc/pages/regions.rst
+++ b/doc/pages/regions.rst
@@ -185,6 +185,12 @@ To model two continuous regions separated by 25 centiMorgans:
                   fwdpy11.BinomialPoint(1, 0.25),
                   fwdpy11.PoissonInterval(1, 2, 1e-3)]
 
+To model a genomic segment having exactly one crossover on the interval :math:`[0,1)`:
+
+.. ipython:: python
+
+    recRegions = [fwdpy11.FixedCrossovers(0, 1, 1)]
+
 The number of recombination breakpoints in the intervals :math:`[0,1)` and :math:`[1,2)` will both be Poisson-distributed with means
 of :math:`10^{-3}`.  A recombination event *between* the two regions will happen in 25% of meioses.
 

--- a/doc/pages/regions.rst
+++ b/doc/pages/regions.rst
@@ -76,7 +76,9 @@ intervals and point processes.
 The relevant classes are:
 
 * :class:`fwdpy11.PoissonInterval`, which specifies that the number of breakpoints are Poisson-distributed and positions
-  uniform on the interval :math:`[beg, end)`.
+  uniform on the continuous interval :math:`[beg, end)`.
+* :class:`fwdpy11.FixedCrossovers` generates a fixed number of breakpoints whose positions are 
+  uniform on the continuous interval :math:`[beg, end)`.
 * :class:`fwdpy11.BinomialPoint` represents recombination events occurring at a specific position with a specific
   probability.
 * :class:`fwdpy11.PoissonPoint` also represents recombination events occurring at a fixed position.  The number of

--- a/doc/pages/regions.rst
+++ b/doc/pages/regions.rst
@@ -64,6 +64,24 @@ thus an equivalent specification would be this:
     for i in recRegions:
         print (i)
 
+A more general approach to genetic maps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.3.0
+
+An alternative approach to modeling variation in recombination rates involves classes derived from
+:class:`fwdpy11.GeneticMapUnit` (which is an ABC).  These classes allow you to "compose" a genetic map that is a mixture of continuous
+intervals and point processes.
+
+The relevant classes are:
+
+* :class:`fwdpy11.PoissonInterval`, which specifies that the number of breakpoints are Poisson-distributed and positions
+  uniform on the interval :math:`[beg, end)`.
+* :class:`fwdpy11.BinomialPoint` represents recombination events occurring at a specific position with a specific
+  probability.
+* :class:`fwdpy11.PoissonPoint` also represents recombination events occurring at a fixed position.  The number of
+  breakpoints is Poisson-distributed, and a breakpoint is inserted if the total number is odd.
+
 
 Specific examples
 -------------------
@@ -136,7 +154,7 @@ Crossover rate variation
 Just like neutral mutations, intervals with different crossover rates are specified by different :class:`fwdpy11.Region` objects.  Let's set up the following concrete example:
 
 * A region where crossovers occur between positions [0,1)
-* Positions [0,0.45) and [0.55,1) have uniform recombintion rates at the "background" rate.
+* Positions [0,0.45) and [0.55,1) have uniform recombination rates at the "background" rate.
 * Positions [0.45,0.55) are a recombination hotspot with 100x the background intensity (per "base pair").
 
 The above model can be represented as:
@@ -156,6 +174,17 @@ Internally, this is what will happen to the above input:
 * The weight on the hotspot will be :math:`100\times(0.55-0.45) = 10`
 
 This gives us what we want: the hotspot is 100x hotter "per base", and is 10% of the total region in length.  We therefore expect 10x as many crossovers in that region as in the flanking regions.
+
+To model two continuous regions separated by 25 centiMorgans:
+
+.. ipython:: python
+
+    recRegions = [fwdpy11.PoissonInterval(0, 1, 1e-3),
+                  fwdpy11.BinomialPoint(1, 0.25),
+                  fwdpy11.PoissonInterval(1, 2, 1e-3)]
+
+The number of recombination in the intervals :math:`[0,1)` and :math:`[1,2)` will both be Poisson-distributed with means
+of :math:`10^{-3}`.  A recombination event *between* the two regions will happen in 25% of meioses.
 
 How to set up a model
 ---------------------------------

--- a/doc/pages/ts.rst
+++ b/doc/pages/ts.rst
@@ -329,7 +329,7 @@ format as for "alive" individuals.
 
 .. ipython:: python
 
-    ar = np.array(pop.metadata, copy=False)
+    ar = np.array(pop.ancient_sample_metadata, copy=False)
     print(ar.dtype)
     print(ar[:5])
 
@@ -376,10 +376,7 @@ which they belong, the following trick helps:
 
     # Revisit our ancient node data
     print(ar[:5])
-    # Stack and flatten gives us the nodes
-    # for the individuals in the same order
-    # as in ar:
-    anodes = np.stack((ar['n1'],ar['n2']), axis=1).flatten()
+    anodes = ar['nodes'].flatten()
     print(anodes[:10])
 
 You may also iterate over the genotypes on a per-marker basis using :class:`fwdpy11.ts.VariantIterator`:

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -7,7 +7,10 @@ set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
 
 set(REGION_SOURCES src/regions/init.cc src/regions/Region.cc src/regions/Sregion.cc src/regions/GammaS.cc src/regions/ConstantS.cc
     src/regions/ExpS.cc src/regions/UniformS.cc src/regions/GaussianS.cc src/regions/MutationRegions.cc
-    src/regions/RecombinationRegions.cc src/regions/MultivariateGaussianEffects.cc)
+    src/regions/RecombinationRegions.cc src/regions/MultivariateGaussianEffects.cc
+    src/regions/GeneticMapUnit.cc src/regions/PoissonInterval.cc 
+    src/regions/BinomialPoint.cc
+    src/regions/PoissonPoint.cc)
 
 set(GENETIC_VALUE_SOURCES src/genetic_values/init.cc src/genetic_values/SlocusMultivariateEffectsStrictAdditive.cc
     src/genetic_values/MultivariateGeneticValueToFitnessMap.cc

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -10,7 +10,8 @@ set(REGION_SOURCES src/regions/init.cc src/regions/Region.cc src/regions/Sregion
     src/regions/RecombinationRegions.cc src/regions/MultivariateGaussianEffects.cc
     src/regions/GeneticMapUnit.cc src/regions/PoissonInterval.cc 
     src/regions/BinomialPoint.cc
-    src/regions/PoissonPoint.cc)
+    src/regions/PoissonPoint.cc
+    src/regions/FixedCrossovers.cc)
 
 set(GENETIC_VALUE_SOURCES src/genetic_values/init.cc src/genetic_values/SlocusMultivariateEffectsStrictAdditive.cc
     src/genetic_values/MultivariateGeneticValueToFitnessMap.cc

--- a/fwdpy11/headers/fwdpy11/regions/BinomialPoint.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/BinomialPoint.hpp
@@ -1,0 +1,63 @@
+#ifndef FWDPY11_REGIONS_BINOMIALPOINT_HPP
+#define FWDPY11_REGIONS_BINOMIALPOINT_HPP
+
+#include <cmath>
+#include <stdexcept>
+#include <gsl/gsl_randist.h>
+#include "GeneticMapUnit.hpp"
+
+namespace fwdpy11
+{
+    struct BinomialPoint : public GeneticMapUnit
+    {
+        double position, prob;
+        BinomialPoint(const double pos, const double pr)
+            : position(pos), prob(pr)
+        {
+            if (!std::isfinite(pos))
+                {
+                    throw std::invalid_argument("position must be finite");
+                }
+            if (pr < 0 || pr > 1.)
+                {
+                    throw std::invalid_argument(
+                        "probability must be 0 <= x <= 1");
+                }
+        }
+
+        void
+        operator()(const GSLrng_t& rng,
+                   std::vector<double>& breakpoints) const final
+        {
+            if (gsl_rng_uniform(rng.get()) <= prob)
+                {
+                    breakpoints.push_back(position);
+                }
+        }
+
+        pybind11::object
+        pickle() const final
+        {
+            return pybind11::make_tuple(position, prob);
+        }
+
+        static BinomialPoint
+        unpickle(pybind11::object o)
+        {
+            auto t = o.cast<pybind11::tuple>();
+            if (t.size() != 2)
+                {
+                    throw std::runtime_error("invalid tuple size");
+                }
+            return BinomialPoint(t[0].cast<double>(), t[1].cast<double>());
+        }
+
+        std::unique_ptr<GeneticMapUnit>
+        clone() const final
+        {
+            return std::unique_ptr<GeneticMapUnit>(new BinomialPoint(*this));
+        }
+    };
+} // namespace fwdpy11
+
+#endif

--- a/fwdpy11/headers/fwdpy11/regions/FixedCrossovers.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/FixedCrossovers.hpp
@@ -1,0 +1,73 @@
+#ifndef FWDPY11_REGIONS_FIXEDCROSSOVERS_HPP
+#define FWDPY11_REGIONS_FIXEDCROSSOVERS_HPP
+
+#include <cmath>
+#include <stdexcept>
+#include <gsl/gsl_randist.h>
+#include "GeneticMapUnit.hpp"
+
+namespace fwdpy11
+{
+    struct FixedCrossovers : public GeneticMapUnit
+    {
+        double beg, end;
+        int nxovers;
+        FixedCrossovers(double b, double e, int n) : beg(b), end(e), nxovers(n)
+        {
+            if (!std::isfinite(b))
+                {
+                    throw std::invalid_argument("beg must be finite");
+                }
+            if (!std::isfinite(e))
+                {
+                    throw std::invalid_argument("end must be finite");
+                }
+            if (e <= b)
+                {
+                    throw std::invalid_argument(
+                        "end must be greater than beg");
+                }
+            if (nxovers < 0)
+                {
+                    throw std::invalid_argument(
+                        "number of crossovers must be non-negative");
+                }
+        }
+
+        void
+        operator()(const GSLrng_t& rng,
+                   std::vector<double>& breakpoints) const final
+        {
+            for (int i = 0; i < nxovers; ++i)
+                {
+                    breakpoints.push_back(gsl_ran_flat(rng.get(), beg, end));
+                }
+        }
+
+        pybind11::object
+        pickle() const final
+        {
+            return pybind11::make_tuple(beg, end, nxovers);
+        }
+
+        std::unique_ptr<GeneticMapUnit>
+        clone() const final
+        {
+            return std::unique_ptr<GeneticMapUnit>(new FixedCrossovers(*this));
+        }
+
+        static FixedCrossovers
+        unpickle(pybind11::object o)
+        {
+            auto t = o.cast<pybind11::tuple>();
+            if (t.size() != 3)
+                {
+                    throw std::runtime_error("invalid tuple size");
+                }
+            return FixedCrossovers(t[0].cast<double>(), t[1].cast<double>(),
+                                   t[2].cast<int>());
+        }
+    };
+} // namespace fwdpy11
+
+#endif

--- a/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
@@ -1,0 +1,20 @@
+#ifndef FWDPY11_REGIONS_GENETICMAPUNIT_HPP
+#define FWDPY11_REGIONS_GENETICMAPUNIT_HPP
+
+#include <vector>
+#include <memory>
+#include <fwdpy11/rng.hpp>
+#include <pybind11/pybind11.h>
+
+namespace fwdpy11
+{
+    struct GeneticMapUnit
+    {
+        virtual void operator()(const GSLrng_t&, std::vector<double>&) const = 0;
+        virtual pybind11::object pickle()  const= 0;
+        virtual std::unique_ptr<GeneticMapUnit> clone()  const = 0;
+    };
+} // namespace fwdpy11
+
+#endif
+

--- a/fwdpy11/headers/fwdpy11/regions/PoissonInterval.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/PoissonInterval.hpp
@@ -1,0 +1,76 @@
+#ifndef FWDPY11_REGIONS_POISSONINTERVAL_HPP
+#define FWDPY11_REGIONS_POISSONINTERVAL_HPP
+
+#include <cmath>
+#include <stdexcept>
+#include <gsl/gsl_randist.h>
+#include "GeneticMapUnit.hpp"
+
+namespace fwdpy11
+{
+    struct PoissonInterval : public GeneticMapUnit
+    {
+        double beg, end, rate;
+        PoissonInterval(double b, double e, double r) : beg(b), end(e), rate(r)
+        {
+            if (!std::isfinite(b))
+                {
+                    throw std::invalid_argument("beg must be finite");
+                }
+            if (!std::isfinite(e))
+                {
+                    throw std::invalid_argument("end must be finite");
+                }
+            if (!std::isfinite(r))
+                {
+                    throw std::invalid_argument("rate must be finite");
+                }
+            if (e <= b)
+                {
+                    throw std::invalid_argument(
+                        "end must be greater than beg");
+                }
+            if (r < 0)
+                {
+                    throw std::invalid_argument("rate must be non-negative");
+                }
+        }
+
+        void
+        operator()(const GSLrng_t& rng,
+                   std::vector<double>& breakpoints) const final
+        {
+            unsigned n = gsl_ran_poisson(rng.get(), rate);
+            for (unsigned i = 0; i < n; ++i)
+                {
+                    breakpoints.push_back(gsl_ran_flat(rng.get(), beg, end));
+                }
+        }
+
+        pybind11::object
+        pickle() const final
+        {
+            return pybind11::make_tuple(beg, end, rate);
+        }
+
+        std::unique_ptr<GeneticMapUnit>
+        clone() const final
+        {
+            return std::unique_ptr<GeneticMapUnit>(new PoissonInterval(*this));
+        }
+
+        static PoissonInterval
+        unpickle(pybind11::object o)
+        {
+            auto t = o.cast<pybind11::tuple>();
+            if (t.size() != 3)
+                {
+                    throw std::runtime_error("invalid tuple size");
+                }
+            return PoissonInterval(t[0].cast<double>(), t[1].cast<double>(),
+                                   t[2].cast<double>());
+        }
+    };
+} // namespace fwdpy11
+
+#endif

--- a/fwdpy11/headers/fwdpy11/regions/PoissonInterval.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/PoissonInterval.hpp
@@ -10,8 +10,8 @@ namespace fwdpy11
 {
     struct PoissonInterval : public GeneticMapUnit
     {
-        double beg, end, rate;
-        PoissonInterval(double b, double e, double r) : beg(b), end(e), rate(r)
+        double beg, end, mean;
+        PoissonInterval(double b, double e, double m) : beg(b), end(e), mean(m)
         {
             if (!std::isfinite(b))
                 {
@@ -21,18 +21,18 @@ namespace fwdpy11
                 {
                     throw std::invalid_argument("end must be finite");
                 }
-            if (!std::isfinite(r))
+            if (!std::isfinite(mean))
                 {
-                    throw std::invalid_argument("rate must be finite");
+                    throw std::invalid_argument("mean must be finite");
                 }
             if (e <= b)
                 {
                     throw std::invalid_argument(
                         "end must be greater than beg");
                 }
-            if (r < 0)
+            if (mean < 0)
                 {
-                    throw std::invalid_argument("rate must be non-negative");
+                    throw std::invalid_argument("mean must be non-negative");
                 }
         }
 
@@ -40,7 +40,7 @@ namespace fwdpy11
         operator()(const GSLrng_t& rng,
                    std::vector<double>& breakpoints) const final
         {
-            unsigned n = gsl_ran_poisson(rng.get(), rate);
+            unsigned n = gsl_ran_poisson(rng.get(), mean);
             for (unsigned i = 0; i < n; ++i)
                 {
                     breakpoints.push_back(gsl_ran_flat(rng.get(), beg, end));
@@ -50,7 +50,7 @@ namespace fwdpy11
         pybind11::object
         pickle() const final
         {
-            return pybind11::make_tuple(beg, end, rate);
+            return pybind11::make_tuple(beg, end, mean);
         }
 
         std::unique_ptr<GeneticMapUnit>

--- a/fwdpy11/headers/fwdpy11/regions/PoissonPoint.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/PoissonPoint.hpp
@@ -1,0 +1,67 @@
+#ifndef FWDPY11_REGIONS_BINOMIALPOINT_HPP
+#define FWDPY11_REGIONS_BINOMIALPOINT_HPP
+
+#include <cmath>
+#include <stdexcept>
+#include <gsl/gsl_randist.h>
+#include "GeneticMapUnit.hpp"
+
+namespace fwdpy11
+{
+    struct PoissonPoint : public GeneticMapUnit
+    {
+        double position, rate;
+        PoissonPoint(const double pos, const double r) : position(pos), rate(r)
+        {
+            if (!std::isfinite(pos))
+                {
+                    throw std::invalid_argument("position must be finite");
+                }
+            if (!std::isfinite(rate))
+                {
+                    throw std::invalid_argument("rate must be finite");
+                }
+            if (rate < 0)
+                {
+                    throw std::invalid_argument("rate must be non-negative");
+                }
+        }
+
+        void
+        operator()(const GSLrng_t& rng,
+                   std::vector<double>& breakpoints) const final
+        {
+            unsigned n = gsl_ran_poisson(rng.get(), rate);
+            if (n % 2 != 0.0)
+                {
+                    breakpoints.push_back(position);
+                }
+        }
+
+        pybind11::object
+        pickle() const final
+        {
+            return pybind11::make_tuple(position, rate);
+        }
+
+        static PoissonPoint
+        unpickle(pybind11::object o)
+        {
+            auto t = o.cast<pybind11::tuple>();
+            if (t.size() != 2)
+                {
+                    throw std::runtime_error("invalid tuple size");
+                }
+            return PoissonPoint(t[0].cast<double>(), t[1].cast<double>());
+        }
+
+        std::unique_ptr<GeneticMapUnit>
+        clone() const final
+        {
+            return std::unique_ptr<GeneticMapUnit>(new PoissonPoint(*this));
+        }
+    };
+} // namespace fwdpy11
+
+#endif
+

--- a/fwdpy11/headers/fwdpy11/regions/PoissonPoint.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/PoissonPoint.hpp
@@ -10,20 +10,20 @@ namespace fwdpy11
 {
     struct PoissonPoint : public GeneticMapUnit
     {
-        double position, rate;
-        PoissonPoint(const double pos, const double r) : position(pos), rate(r)
+        double position, mean;
+        PoissonPoint(const double pos, const double m) : position(pos), mean(m)
         {
             if (!std::isfinite(pos))
                 {
                     throw std::invalid_argument("position must be finite");
                 }
-            if (!std::isfinite(rate))
+            if (!std::isfinite(mean))
                 {
-                    throw std::invalid_argument("rate must be finite");
+                    throw std::invalid_argument("mean must be finite");
                 }
-            if (rate < 0)
+            if (mean < 0)
                 {
-                    throw std::invalid_argument("rate must be non-negative");
+                    throw std::invalid_argument("mean must be non-negative");
                 }
         }
 
@@ -31,7 +31,7 @@ namespace fwdpy11
         operator()(const GSLrng_t& rng,
                    std::vector<double>& breakpoints) const final
         {
-            unsigned n = gsl_ran_poisson(rng.get(), rate);
+            unsigned n = gsl_ran_poisson(rng.get(), mean);
             if (n % 2 != 0.0)
                 {
                     breakpoints.push_back(position);
@@ -41,7 +41,7 @@ namespace fwdpy11
         pybind11::object
         pickle() const final
         {
-            return pybind11::make_tuple(position, rate);
+            return pybind11::make_tuple(position, mean);
         }
 
         static PoissonPoint

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -4,10 +4,12 @@
 #include <limits>
 #include <vector>
 #include <algorithm>
+#include <functional>
 #include <fwdpp/internal/gsl_discrete.hpp>
 #include <gsl/gsl_randist.h>
 #include <fwdpy11/rng.hpp>
 #include "Region.hpp"
+#include "GeneticMapUnit.hpp"
 
 namespace fwdpy11
 {
@@ -47,6 +49,28 @@ namespace fwdpy11
                 {
                     std::size_t x = gsl_ran_discrete(rng.get(), lookup.get());
                     rv.push_back(regions[x](rng));
+                }
+            std::sort(begin(rv), end(rv));
+            rv.push_back(std::numeric_limits<double>::max());
+            return rv;
+        }
+    };
+
+    struct GeneralizedGeneticMap : public GeneticMap
+    {
+        std::vector<std::unique_ptr<GeneticMapUnit>> callbacks;
+        GeneralizedGeneticMap(std::vector<std::unique_ptr<GeneticMapUnit>> c)
+            : callbacks(std::move(c))
+        {
+        }
+
+        std::vector<double>
+        operator()(const GSLrng_t& rng) const final
+        {
+            std::vector<double> rv;
+            for (auto&& c : callbacks)
+                {
+                    c->operator()(rng, rv);
                 }
             std::sort(begin(rv), end(rv));
             rv.push_back(std::numeric_limits<double>::max());

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -72,8 +72,11 @@ namespace fwdpy11
                 {
                     c->operator()(rng, rv);
                 }
-            std::sort(begin(rv), end(rv));
-            rv.push_back(std::numeric_limits<double>::max());
+            if (!rv.empty())
+                {
+                    std::sort(begin(rv), end(rv));
+                    rv.push_back(std::numeric_limits<double>::max());
+                }
             return rv;
         }
     };

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -11,7 +11,12 @@
 
 namespace fwdpy11
 {
-    struct RecombinationRegions
+    struct GeneticMap
+    {
+        virtual std::vector<double> operator()(const GSLrng_t& rng) const = 0;
+    };
+
+    struct RecombinationRegions : public GeneticMap
     {
         std::vector<Region> regions;
         std::vector<double> weights;
@@ -28,8 +33,8 @@ namespace fwdpy11
                 gsl_ran_discrete_preproc(weights.size(), weights.data()));
         }
 
-        inline std::vector<double>
-        operator()(const GSLrng_t& rng) const
+        std::vector<double>
+        operator()(const GSLrng_t& rng) const final
         {
             unsigned nbreaks = gsl_ran_poisson(rng.get(), recrate);
             if (nbreaks == 0)

--- a/fwdpy11/src/regions/BinomialPoint.cc
+++ b/fwdpy11/src/regions/BinomialPoint.cc
@@ -11,6 +11,8 @@ init_BinomialPoint(py::module& m)
         Generate a crossover breakpoint at a fixed position with a
         fixed probability.  This class represents genetic distance
         as centiMorgans/100.
+
+        .. versionadded:: 0.3.0
         )delim")
         .def(py::init<double, double>(), py::arg("position"),
              py::arg("probability"))

--- a/fwdpy11/src/regions/BinomialPoint.cc
+++ b/fwdpy11/src/regions/BinomialPoint.cc
@@ -1,0 +1,18 @@
+#include <fwdpy11/regions/BinomialPoint.hpp>
+
+namespace py = pybind11;
+
+void
+init_BinomialPoint(py::module& m)
+{
+    py::class_<fwdpy11::BinomialPoint, fwdpy11::GeneticMapUnit>(
+        m, "BinomialPoint")
+        .def(py::init<double, double>(), py::arg("position"),
+             py::arg("probability"))
+        .def_readonly("position", &fwdpy11::BinomialPoint::position)
+        .def_readonly("probability", &fwdpy11::BinomialPoint::prob)
+        .def(py::pickle(
+            [](const fwdpy11::BinomialPoint& b) { return b.pickle(); },
+            [](py::object o) { return fwdpy11::BinomialPoint::unpickle(o); }));
+}
+

--- a/fwdpy11/src/regions/BinomialPoint.cc
+++ b/fwdpy11/src/regions/BinomialPoint.cc
@@ -6,11 +6,18 @@ void
 init_BinomialPoint(py::module& m)
 {
     py::class_<fwdpy11::BinomialPoint, fwdpy11::GeneticMapUnit>(
-        m, "BinomialPoint")
+        m, "BinomialPoint",
+        R"delim(
+        Generate a crossover breakpoint at a fixed position with a
+        fixed probability.  This class represents genetic distance
+        as centiMorgans/100.
+        )delim")
         .def(py::init<double, double>(), py::arg("position"),
              py::arg("probability"))
-        .def_readonly("position", &fwdpy11::BinomialPoint::position)
-        .def_readonly("probability", &fwdpy11::BinomialPoint::prob)
+        .def_readonly("position", &fwdpy11::BinomialPoint::position,
+                      "Position")
+        .def_readonly("probability", &fwdpy11::BinomialPoint::prob,
+                      "Probability")
         .def(py::pickle(
             [](const fwdpy11::BinomialPoint& b) { return b.pickle(); },
             [](py::object o) { return fwdpy11::BinomialPoint::unpickle(o); }));

--- a/fwdpy11/src/regions/FixedCrossovers.cc
+++ b/fwdpy11/src/regions/FixedCrossovers.cc
@@ -1,0 +1,29 @@
+#include <fwdpy11/regions/FixedCrossovers.hpp>
+
+namespace py = pybind11;
+
+void
+init_FixedCrossovers(py::module& m)
+{
+    py::class_<fwdpy11::FixedCrossovers, fwdpy11::GeneticMapUnit>(
+        m, "FixedCrossovers",
+        R"delim(
+        Generate a fixed number of crossover breakpoints.
+        
+        .. versionadded:: 0.3.0
+        )delim")
+        .def(py::init<double, double, int>(), py::arg("beg"), py::arg("end"),
+             py::arg("num_xovers"))
+        .def_readonly("beg", &fwdpy11::FixedCrossovers::beg,
+                      "Beginning of interval")
+        .def_readonly("end", &fwdpy11::FixedCrossovers::end,
+                      "End of interval.")
+        .def_readonly("nxovers", &fwdpy11::FixedCrossovers::nxovers,
+                      "Mean number of breakpoints")
+        .def(py::pickle(
+            [](const fwdpy11::FixedCrossovers& pi) { return pi.pickle(); },
+            [](py::object o) {
+                return fwdpy11::FixedCrossovers::unpickle(o);
+            }));
+}
+

--- a/fwdpy11/src/regions/GeneticMapUnit.cc
+++ b/fwdpy11/src/regions/GeneticMapUnit.cc
@@ -1,0 +1,10 @@
+#include <fwdpy11/regions/GeneticMapUnit.hpp>
+
+namespace py = pybind11;
+
+void
+init_GeneticMapUnit(py::module& m)
+{
+    py::class_<fwdpy11::GeneticMapUnit>(m, "GeneticMapUnit",
+                                        "ABC for components of genetic maps");
+}

--- a/fwdpy11/src/regions/GeneticMapUnit.cc
+++ b/fwdpy11/src/regions/GeneticMapUnit.cc
@@ -6,5 +6,9 @@ void
 init_GeneticMapUnit(py::module& m)
 {
     py::class_<fwdpy11::GeneticMapUnit>(m, "GeneticMapUnit",
-                                        "ABC for components of genetic maps");
+                                        R"delim(
+                                        ABC for components of genetic maps
+
+                                        .. versionadded:: 0.3.0
+                                        )delim");
 }

--- a/fwdpy11/src/regions/PoissonInterval.cc
+++ b/fwdpy11/src/regions/PoissonInterval.cc
@@ -6,12 +6,16 @@ void
 init_PoissonInterval(py::module& m)
 {
     py::class_<fwdpy11::PoissonInterval, fwdpy11::GeneticMapUnit>(
-        m, "PoissonInterval")
+        m, "PoissonInterval",
+        "Generate poisson number of crossover breakpoints.")
         .def(py::init<double, double, double>(), py::arg("beg"),
-             py::arg("end"), py::arg("rate"))
-        .def_readonly("beg", &fwdpy11::PoissonInterval::beg)
-        .def_readonly("end", &fwdpy11::PoissonInterval::end)
-        .def_readonly("rate", &fwdpy11::PoissonInterval::rate)
+             py::arg("end"), py::arg("mean"))
+        .def_readonly("beg", &fwdpy11::PoissonInterval::beg,
+                      "Beginning of interval")
+        .def_readonly("end", &fwdpy11::PoissonInterval::end,
+                      "End of interval.")
+        .def_readonly("mean", &fwdpy11::PoissonInterval::mean,
+                      "Mean number of breakpoints")
         .def(py::pickle(
             [](const fwdpy11::PoissonInterval& pi) { return pi.pickle(); },
             [](py::object o) {

--- a/fwdpy11/src/regions/PoissonInterval.cc
+++ b/fwdpy11/src/regions/PoissonInterval.cc
@@ -7,7 +7,11 @@ init_PoissonInterval(py::module& m)
 {
     py::class_<fwdpy11::PoissonInterval, fwdpy11::GeneticMapUnit>(
         m, "PoissonInterval",
-        "Generate poisson number of crossover breakpoints.")
+        R"delim(
+        Generate poisson number of crossover breakpoints.
+        
+        .. versionadded:: 0.3.0
+        )delim")
         .def(py::init<double, double, double>(), py::arg("beg"),
              py::arg("end"), py::arg("mean"))
         .def_readonly("beg", &fwdpy11::PoissonInterval::beg,

--- a/fwdpy11/src/regions/PoissonInterval.cc
+++ b/fwdpy11/src/regions/PoissonInterval.cc
@@ -1,0 +1,21 @@
+#include <fwdpy11/regions/PoissonInterval.hpp>
+
+namespace py = pybind11;
+
+void
+init_PoissonInterval(py::module& m)
+{
+    py::class_<fwdpy11::PoissonInterval, fwdpy11::GeneticMapUnit>(
+        m, "PoissonInterval")
+        .def(py::init<double, double, double>(), py::arg("beg"),
+             py::arg("end"), py::arg("rate"))
+        .def_readonly("beg", &fwdpy11::PoissonInterval::beg)
+        .def_readonly("end", &fwdpy11::PoissonInterval::end)
+        .def_readonly("rate", &fwdpy11::PoissonInterval::rate)
+        .def(py::pickle(
+            [](const fwdpy11::PoissonInterval& pi) { return pi.pickle(); },
+            [](py::object o) {
+                return fwdpy11::PoissonInterval::unpickle(o);
+            }));
+}
+

--- a/fwdpy11/src/regions/PoissonPoint.cc
+++ b/fwdpy11/src/regions/PoissonPoint.cc
@@ -5,11 +5,14 @@ namespace py = pybind11;
 void
 init_PoissonPoint(py::module& m)
 {
-    py::class_<fwdpy11::PoissonPoint, fwdpy11::GeneticMapUnit>(m,
-                                                               "PoissonPoint")
-        .def(py::init<double, double>(), py::arg("position"), py::arg("rate"))
-        .def_readonly("position", &fwdpy11::PoissonPoint::position)
-        .def_readonly("rate", &fwdpy11::PoissonPoint::rate)
+    py::class_<fwdpy11::PoissonPoint, fwdpy11::GeneticMapUnit>(
+        m, "PoissonPoint",
+        "Generate a recombination breakpoint at a fixed position if the "
+        "number of crossover events is odd")
+        .def(py::init<double, double>(), py::arg("position"), py::arg("mean"))
+        .def_readonly("position", &fwdpy11::PoissonPoint::position, "Position")
+        .def_readonly("mean", &fwdpy11::PoissonPoint::mean,
+                      "Mean of Poisson process")
         .def(py::pickle(
             [](const fwdpy11::PoissonPoint& b) { return b.pickle(); },
             [](py::object o) { return fwdpy11::PoissonPoint::unpickle(o); }));

--- a/fwdpy11/src/regions/PoissonPoint.cc
+++ b/fwdpy11/src/regions/PoissonPoint.cc
@@ -1,0 +1,17 @@
+#include <fwdpy11/regions/PoissonPoint.hpp>
+
+namespace py = pybind11;
+
+void
+init_PoissonPoint(py::module& m)
+{
+    py::class_<fwdpy11::PoissonPoint, fwdpy11::GeneticMapUnit>(m,
+                                                               "PoissonPoint")
+        .def(py::init<double, double>(), py::arg("position"), py::arg("rate"))
+        .def_readonly("position", &fwdpy11::PoissonPoint::position)
+        .def_readonly("rate", &fwdpy11::PoissonPoint::rate)
+        .def(py::pickle(
+            [](const fwdpy11::PoissonPoint& b) { return b.pickle(); },
+            [](py::object o) { return fwdpy11::PoissonPoint::unpickle(o); }));
+}
+

--- a/fwdpy11/src/regions/PoissonPoint.cc
+++ b/fwdpy11/src/regions/PoissonPoint.cc
@@ -5,10 +5,14 @@ namespace py = pybind11;
 void
 init_PoissonPoint(py::module& m)
 {
-    py::class_<fwdpy11::PoissonPoint, fwdpy11::GeneticMapUnit>(
-        m, "PoissonPoint",
-        "Generate a recombination breakpoint at a fixed position if the "
-        "number of crossover events is odd")
+    py::class_<fwdpy11::PoissonPoint, fwdpy11::GeneticMapUnit>(m,
+                                                               "PoissonPoint",
+                                                               R"delim(
+        Generate a recombination breakpoint at a fixed position if the
+        number of crossover events is odd.
+
+        .. versionadded:: 0.3.0
+        )delim")
         .def(py::init<double, double>(), py::arg("position"), py::arg("mean"))
         .def_readonly("position", &fwdpy11::PoissonPoint::position, "Position")
         .def_readonly("mean", &fwdpy11::PoissonPoint::mean,

--- a/fwdpy11/src/regions/RecombinationRegions.cc
+++ b/fwdpy11/src/regions/RecombinationRegions.cc
@@ -7,7 +7,10 @@ namespace py = pybind11;
 void
 init_RecombinationRegions(py::module& m)
 {
-    py::class_<fwdpy11::RecombinationRegions>(m, "RecombinationRegions")
+    py::class_<fwdpy11::GeneticMap>(m, "GeneticMap", "ABC for genetic maps");
+
+    py::class_<fwdpy11::RecombinationRegions, fwdpy11::GeneticMap>(
+        m, "RecombinationRegions")
         .def(py::init<double, std::vector<fwdpy11::Region>>())
         .def_readonly("weights", &fwdpy11::RecombinationRegions::weights);
 

--- a/fwdpy11/src/regions/RecombinationRegions.cc
+++ b/fwdpy11/src/regions/RecombinationRegions.cc
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <fwdpy11/regions/RecombinationRegions.hpp>
+#include <fwdpy11/regions/GeneticMapUnit.hpp>
 
 namespace py = pybind11;
 
@@ -13,6 +14,18 @@ init_RecombinationRegions(py::module& m)
         m, "RecombinationRegions")
         .def(py::init<double, std::vector<fwdpy11::Region>>())
         .def_readonly("weights", &fwdpy11::RecombinationRegions::weights);
+
+    py::class_<fwdpy11::GeneralizedGeneticMap, fwdpy11::GeneticMap>(
+        m, "GeneralizedGeneticMap")
+        .def(py::init([](py::list l) {
+            std::vector<std::unique_ptr<fwdpy11::GeneticMapUnit>> callbacks;
+            for (auto& i : l)
+                {
+                    auto& ref = i.cast<fwdpy11::GeneticMapUnit&>();
+                    callbacks.emplace_back(ref.clone());
+                }
+            return fwdpy11::GeneralizedGeneticMap(std::move(callbacks));
+        }));
 
     py::class_<fwdpy11::MlocusRecombinationRegions>(
         m, "MlocusRecombinationRegions")

--- a/fwdpy11/src/regions/init.cc
+++ b/fwdpy11/src/regions/init.cc
@@ -11,8 +11,11 @@ void init_UniformS(py::module &);
 void init_GaussianS(py::module &);
 void init_MutationRegions(py::module &);
 void init_RecombinationRegions(py::module &);
-void
-init_MultivariateGaussianEffects(py::module& );
+void init_MultivariateGaussianEffects(py::module &);
+void init_GeneticMapUnit(py::module &);
+void init_PoissonInterval(py::module &);
+void init_BinomialPoint(py::module &);
+void init_PoissonPoint(py::module &);
 
 void
 initialize_regions(py::module &m)
@@ -27,4 +30,8 @@ initialize_regions(py::module &m)
     init_MutationRegions(m);
     init_RecombinationRegions(m);
     init_MultivariateGaussianEffects(m);
+    init_GeneticMapUnit(m);
+    init_PoissonInterval(m);
+    init_BinomialPoint(m);
+    init_PoissonPoint(m);
 }

--- a/fwdpy11/src/regions/init.cc
+++ b/fwdpy11/src/regions/init.cc
@@ -16,6 +16,7 @@ void init_GeneticMapUnit(py::module &);
 void init_PoissonInterval(py::module &);
 void init_BinomialPoint(py::module &);
 void init_PoissonPoint(py::module &);
+void init_FixedCrossovers(py::module &);
 
 void
 initialize_regions(py::module &m)
@@ -34,4 +35,5 @@ initialize_regions(py::module &m)
     init_PoissonInterval(m);
     init_BinomialPoint(m);
     init_PoissonPoint(m);
+    init_FixedCrossovers(m);
 }

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -51,7 +51,7 @@ wfSlocusPop_ts(
     py::array_t<std::uint32_t> popsizes, //const double mu_neutral,
     const double mu_selected, const double recrate,
     const fwdpy11::MutationRegions &mmodel,
-    const fwdpy11::RecombinationRegions &rmodel,
+    const fwdpy11::GeneticMap &rmodel,
     fwdpy11::SlocusPopGeneticValue &genetic_value_fxn,
     fwdpy11::SlocusPop_sample_recorder recorder, const double selfing_rate,
     // NOTE: this is the complement of what a user will input, which is "prune_selected"

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -49,7 +49,7 @@ wfSlocusPop_ts(
     const fwdpy11::GSLrng_t &rng, fwdpy11::SlocusPop &pop,
     fwdpy11::samplerecorder &sr, const unsigned simplification_interval,
     py::array_t<std::uint32_t> popsizes, //const double mu_neutral,
-    const double mu_selected, const double recrate,
+    const double mu_selected, 
     const fwdpy11::MutationRegions &mmodel,
     const fwdpy11::GeneticMap &rmodel,
     fwdpy11::SlocusPopGeneticValue &genetic_value_fxn,

--- a/fwdpy11/src/wright_fisher_slocus.cc
+++ b/fwdpy11/src/wright_fisher_slocus.cc
@@ -104,7 +104,7 @@ wfSlocusPop(const fwdpy11::GSLrng_t &rng, fwdpy11::SlocusPop &pop,
             py::array_t<std::uint32_t> popsizes, const double mu_neutral,
             const double mu_selected, const double recrate,
             const fwdpy11::MutationRegions &mmodel,
-            const fwdpy11::RecombinationRegions &rmodel,
+            const fwdpy11::GeneticMap &rmodel,
             fwdpy11::SlocusPopGeneticValue &genetic_value_fxn,
             fwdpy11::SlocusPop_temporal_sampler recorder,
             const double selfing_rate, const bool remove_selected_fixations)

--- a/fwdpy11/wright_fisher.py
+++ b/fwdpy11/wright_fisher.py
@@ -49,9 +49,13 @@ def evolve(rng, pop, params, recorder=None):
     from fwdpy11 import RecombinationRegions
     if pop.__class__ is fwdpy11.SlocusPop:
         from .wright_fisher_slocus import WFSlocusPop
+        from fwdpy11 import GeneralizedGeneticMap
         pneutral = params.mutrate_n/(params.mutrate_n+params.mutrate_s)
         mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
-        rm = RecombinationRegions(params.recrate, params.recregions)
+        if all([i.__class__ is fwdpy11.Region for i in params.recregions]) is True:
+            rm = RecombinationRegions(params.recrate, params.recregions)
+        else:
+            rm = GeneralizedGeneticMap(params.recregions)
 
         if recorder is None:
             from fwdpy11.temporal_samplers import RecordNothing

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -72,11 +72,15 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
     from fwdpy11 import MutationRegions
     from fwdpy11 import RecombinationRegions
     if pop.__class__ is fwdpy11.SlocusPop:
+        from fwdpy11 import GeneralizedGeneticMap
         from ._tsevolution import WFSlocusPop_ts
         # TODO: update to allow neutral mutations
         pneutral = 0
         mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
-        rm = RecombinationRegions(params.recrate, params.recregions)
+        if all([i.__class__ is fwdpy11.Region for i in params.recregions]) is True:
+            rm = RecombinationRegions(params.recrate, params.recregions)
+        else:
+            rm = GeneralizedGeneticMap(params.recregions)
 
         from fwdpy11.tsrecorders import SampleRecorder
         sr = SampleRecorder()

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -86,7 +86,7 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
         sr = SampleRecorder()
         WFSlocusPop_ts(rng, pop, sr, simplification_interval,
                        params.demography, params.mutrate_s,
-                       params.recrate, mm, rm, params.gvalue,
+                       mm, rm, params.gvalue,
                        recorder, params.pself, params.prune_selected is True,
                        suppress_table_indexing, record_gvalue_matrix)
     else:

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -332,6 +332,18 @@ class testPoissonPoint(unittest.TestCase):
         self.assertEqual(up.position, self.pi.position)
         self.assertEqual(up.mean, self.pi.mean)
 
+
+class testBinomialPoint(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.pi = fwdpy11.BinomialPoint(1., 0.5)
+
+    def test_pickling(self):
+        p = pickle.dumps(self.pi)
+        up = pickle.loads(p)
+        self.assertEqual(up.position, self.pi.position)
+        self.assertEqual(up.probability, self.pi.probability)
+
 # class test_Region_repr(unittest.TestCase):
 #     @classmethod
 #     def setUpClass(self):

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -295,6 +295,30 @@ class testRecombinationRegions(unittest.TestCase):
                                           fwdpy11.GaussianS(1, 2, 1, 0.25)])
 
 
+class testPoissonInterval(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.pi = fwdpy11.PoissonInterval(0, 1, 1e-3)
+
+    def test_pickling(self):
+        p = pickle.dumps(self.pi)
+        up = pickle.loads(p)
+        self.assertEqual(up.beg, self.pi.beg)
+        self.assertEqual(up.end, self.pi.end)
+        self.assertEqual(up.rate, self.pi.rate)
+
+
+class testPoissonPoint(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.pi = fwdpy11.PoissonPoint(1., 0.5)
+
+    def test_pickling(self):
+        p = pickle.dumps(self.pi)
+        up = pickle.loads(p)
+        self.assertEqual(up.position, self.pi.position)
+        self.assertEqual(up.rate, self.pi.rate)
+
 # class test_Region_repr(unittest.TestCase):
 #     @classmethod
 #     def setUpClass(self):

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -305,7 +305,7 @@ class testPoissonInterval(unittest.TestCase):
         up = pickle.loads(p)
         self.assertEqual(up.beg, self.pi.beg)
         self.assertEqual(up.end, self.pi.end)
-        self.assertEqual(up.rate, self.pi.rate)
+        self.assertEqual(up.mean, self.pi.mean)
 
 
 class testPoissonPoint(unittest.TestCase):
@@ -317,7 +317,7 @@ class testPoissonPoint(unittest.TestCase):
         p = pickle.dumps(self.pi)
         up = pickle.loads(p)
         self.assertEqual(up.position, self.pi.position)
-        self.assertEqual(up.rate, self.pi.rate)
+        self.assertEqual(up.mean, self.pi.mean)
 
 # class test_Region_repr(unittest.TestCase):
 #     @classmethod

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -308,6 +308,19 @@ class testPoissonInterval(unittest.TestCase):
         self.assertEqual(up.mean, self.pi.mean)
 
 
+class testFixedCrossovers(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.pi = fwdpy11.FixedCrossovers(0, 1, 10)
+
+    def test_pickling(self):
+        p = pickle.dumps(self.pi)
+        up = pickle.loads(p)
+        self.assertEqual(up.beg, self.pi.beg)
+        self.assertEqual(up.end, self.pi.end)
+        self.assertEqual(up.nxovers, self.pi.nxovers)
+
+
 class testPoissonPoint(unittest.TestCase):
     @classmethod
     def setUp(self):


### PR DESCRIPTION
Adds new classes to allow for both continuous and discrete recombination processes along a genomic segment.  

Five new Python classes are added:

* GeneticMapUnit, which is an ABC
* PoissonInterval, which generates a Poisson number of breakpoints uniform on `[start, stop)` 
* FixedCrossovers, which generates a fixed number of breakpoints uniform in `[start, stop)`.
* BinomialPoint, which generates a single breakpoint with a fixed probability.  This represents centiMorgans.
* PoissonPoint, which generates a single breakpoint if the number of crossover events is odd.