### PR TITLE
Pickle populations

### DIFF
--- a/doc/pages/pickling.rst
+++ b/doc/pages/pickling.rst
@@ -32,11 +32,13 @@ Some general notes:
     
     If you wish to serialize a population to file, an alternative to pickling is described in :ref:`binary_pops`.
 
-In fwdpy11 0.3.0, :class:`fwdpy11.SlocusPop` has two new functions that avoid high memory consumption while pickling.
+In fwdpy11 0.3.0, population classes have two new functions that avoid high memory consumption while pickling.
 The cost is that pickling is slower.  The functions are:
 
 * :func:`fwdpy11.SlocusPop.pickle_to_file`, which is an instance method
 * :func:`fwdpy11.SlocusPop.load_from_pickle_file`, which is a static method
+* :func:`fwdpy11.MlocusPop.pickle_to_file`, which is an instance method
+* :func:`fwdpy11.MlocusPop.load_from_pickle_file`, which is a static method
 
 Please notes that these functions must be used in a coordinated manner!  See documentation for details.
 

--- a/doc/pages/pickling.rst
+++ b/doc/pages/pickling.rst
@@ -20,7 +20,8 @@ Some general notes:
 
 .. note::
     If you are pickling populations to a file, you should be aware that you can (and probably should) compress the output.
-    We have found that lzma_ compression is ideal when pickling fwdpy11 population objects.
+    We have found that lzma_ compression results in the smallest files, but takes the longest to compress.  The gzip_
+    module is a good balance between speed and final file size.
 
 .. warning::
     If you are simulating very large populations and/or a very large number of mutations, it is possible to 
@@ -30,6 +31,14 @@ Some general notes:
     last few time points of that model involve very large population sizes.
     
     If you wish to serialize a population to file, an alternative to pickling is described in :ref:`binary_pops`.
+
+In fwdpy11 0.3.0, :class:`fwdpy11.SlocusPop` has two new functions that avoid high memory consumption while pickling.
+The cost is that pickling is slower.  The functions are:
+
+* :func:`fwdpy11.SlocusPop.pickle_to_file`, which is an instance method
+* :func:`fwdpy11.SlocusPop.load_from_pickle_file`, which is a static method
+
+Please notes that these functions must be used in a coordinated manner!  See documentation for details.
 
 .. testcode::
 
@@ -61,4 +70,5 @@ Some general notes:
 .. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html
 .. _concurrent.futures: https://docs.python.org/3/library/concurrent.futures.html
 .. _lzma: https://docs.python.org/3/library/lzma.html
+.. _gzip: https://docs.python.org/3/library/gzip.html
 .. _Tennessen: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3708544/

--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -248,7 +248,134 @@ PYBIND11_MODULE(_Populations, m)
                 fwdpy11::serialization::deserialize_details()(in, pop);
                 return pop;
             },
-            "Load a population from a binary file.");
+            "Load a population from a binary file.")
+        .def("pickle_to_file",
+             [](const fwdpy11::SlocusPop& self, py::object f) {
+                 auto dump = py::module::import("pickle").attr("dump");
+                 dump(py::make_tuple(self.diploids.size(), self.gametes.size(),
+                                     self.mutations.size(), self.generation,
+                                     self.tables.genome_length()),
+                      f);
+                 for (auto& d : self.diploids)
+                     {
+                         dump(d, f);
+                     }
+                 for (auto& g : self.gametes)
+                     {
+                         dump(g, f);
+                     }
+                 for (auto& m : self.mutations)
+                     {
+                         dump(m, f);
+                     }
+                 dump(self.mcounts, f);
+                 dump(self.mcounts_from_preserved_nodes, f);
+                 dump(py::make_tuple(self.diploid_metadata.size(),
+                                     self.ancient_sample_metadata.size()),
+                      f);
+                 for (auto& md : self.diploid_metadata)
+                     {
+                         dump(md, f);
+                     }
+                 for (auto& md : self.ancient_sample_metadata)
+                     {
+                         dump(md, f);
+                     }
+                 dump(py::make_tuple(self.tables.node_table.size(),
+                                     self.tables.edge_table.size(),
+                                     self.tables.mutation_table.size()),
+                      f);
+                 for (auto& n : self.tables.node_table)
+                     {
+                         dump(n, f);
+                     }
+                 for (auto& e : self.tables.edge_table)
+                     {
+                         dump(e, f);
+                     }
+                 for (auto& m : self.tables.mutation_table)
+                     {
+                         dump(m, f);
+                     }
+                 dump(self.tables.preserved_nodes, f);
+             })
+        .def_static("load_from_pickle_file", [](py::object f) {
+            auto load = py::module::import("pickle").attr("load");
+            py::tuple popdata = load(f);
+            fwdpy11::SlocusPop rv(popdata[0].cast<fwdpp::uint_t>(),
+                                  popdata[4].cast<double>());
+            rv.generation
+                = popdata[3].cast<decltype(fwdpy11::SlocusPop::generation)>();
+            auto ndips = popdata[0].cast<std::size_t>();
+            auto ngams = popdata[1].cast<std::size_t>();
+            auto nmuts = popdata[2].cast<std::size_t>();
+            rv.diploids.clear();
+            rv.gametes.clear();
+            rv.mutations.clear();
+            rv.diploids.reserve(ndips);
+            for (std::size_t i = 0; i < ndips; ++i)
+                {
+                    rv.diploids.push_back(
+                        load(f).cast<fwdpy11::DiploidGenotype>());
+                }
+            rv.gametes.reserve(ngams);
+            for (std::size_t i = 0; i < ngams; ++i)
+                {
+                    rv.gametes.push_back(load(f).cast<fwdpp::gamete>());
+                }
+            rv.mutations.reserve(nmuts);
+            for (std::size_t i = 0; i < nmuts; ++i)
+                {
+                    rv.mutations.push_back(load(f).cast<fwdpy11::Mutation>());
+                }
+            rv.mcounts = load(f).cast<decltype(rv.mcounts)>();
+            rv.mcounts_from_preserved_nodes
+                = load(f).cast<decltype(rv.mcounts_from_preserved_nodes)>();
+            py::tuple metadata_data = load(f);
+            rv.diploid_metadata.clear();
+            rv.ancient_sample_metadata.clear();
+            auto lmd = metadata_data[0].cast<std::size_t>();
+            auto lamd = metadata_data[1].cast<std::size_t>();
+            rv.diploid_metadata.reserve(lmd);
+            for (std::size_t i = 0; i < lmd; ++i)
+                {
+                    rv.diploid_metadata.push_back(
+                        load(f).cast<fwdpy11::DiploidMetadata>());
+                }
+            rv.ancient_sample_metadata.reserve(lamd);
+            for (std::size_t i = 0; i < lamd; ++i)
+                {
+                    rv.ancient_sample_metadata.push_back(
+                        load(f).cast<fwdpy11::DiploidMetadata>());
+                }
+            py::tuple table_data = load(f);
+            auto table_len = table_data[0].cast<std::size_t>();
+            rv.tables.clear();
+            rv.tables.node_table.reserve(table_len);
+            for (std::size_t i = 0; i < table_len; ++i)
+                {
+                    rv.tables.node_table.push_back(
+                        load(f).cast<fwdpp::ts::node>());
+                }
+            table_len = table_data[1].cast<std::size_t>();
+            rv.tables.edge_table.reserve(table_len);
+            for (std::size_t i = 0; i < table_len; ++i)
+                {
+                    rv.tables.edge_table.push_back(
+                        load(f).cast<fwdpp::ts::edge>());
+                }
+            table_len = table_data[2].cast<std::size_t>();
+            rv.tables.mutation_table.reserve(table_len);
+            for (std::size_t i = 0; i < table_len; ++i)
+                {
+                    rv.tables.mutation_table.push_back(
+                        load(f).cast<fwdpp::ts::mutation_record>());
+                }
+            rv.tables.preserved_nodes
+                = load(f).cast<decltype(rv.tables.preserved_nodes)>();
+            rv.tables.build_indexes();
+            return rv;
+        });
 
     py::class_<fwdpy11::MlocusPop, fwdpy11::Population>(
         m, "_MlocusPop", "Representation of a multi-locus population")

--- a/fwdpy11/src/_Populations.cc
+++ b/fwdpy11/src/_Populations.cc
@@ -298,84 +298,112 @@ PYBIND11_MODULE(_Populations, m)
                          dump(m, f);
                      }
                  dump(self.tables.preserved_nodes, f);
-             })
-        .def_static("load_from_pickle_file", [](py::object f) {
-            auto load = py::module::import("pickle").attr("load");
-            py::tuple popdata = load(f);
-            fwdpy11::SlocusPop rv(popdata[0].cast<fwdpp::uint_t>(),
-                                  popdata[4].cast<double>());
-            rv.generation
-                = popdata[3].cast<decltype(fwdpy11::SlocusPop::generation)>();
-            auto ndips = popdata[0].cast<std::size_t>();
-            auto ngams = popdata[1].cast<std::size_t>();
-            auto nmuts = popdata[2].cast<std::size_t>();
-            rv.diploids.clear();
-            rv.gametes.clear();
-            rv.mutations.clear();
-            rv.diploids.reserve(ndips);
-            for (std::size_t i = 0; i < ndips; ++i)
-                {
-                    rv.diploids.push_back(
-                        load(f).cast<fwdpy11::DiploidGenotype>());
-                }
-            rv.gametes.reserve(ngams);
-            for (std::size_t i = 0; i < ngams; ++i)
-                {
-                    rv.gametes.push_back(load(f).cast<fwdpp::gamete>());
-                }
-            rv.mutations.reserve(nmuts);
-            for (std::size_t i = 0; i < nmuts; ++i)
-                {
-                    rv.mutations.push_back(load(f).cast<fwdpy11::Mutation>());
-                }
-            rv.mcounts = load(f).cast<decltype(rv.mcounts)>();
-            rv.mcounts_from_preserved_nodes
-                = load(f).cast<decltype(rv.mcounts_from_preserved_nodes)>();
-            py::tuple metadata_data = load(f);
-            rv.diploid_metadata.clear();
-            rv.ancient_sample_metadata.clear();
-            auto lmd = metadata_data[0].cast<std::size_t>();
-            auto lamd = metadata_data[1].cast<std::size_t>();
-            rv.diploid_metadata.reserve(lmd);
-            for (std::size_t i = 0; i < lmd; ++i)
-                {
-                    rv.diploid_metadata.push_back(
-                        load(f).cast<fwdpy11::DiploidMetadata>());
-                }
-            rv.ancient_sample_metadata.reserve(lamd);
-            for (std::size_t i = 0; i < lamd; ++i)
-                {
-                    rv.ancient_sample_metadata.push_back(
-                        load(f).cast<fwdpy11::DiploidMetadata>());
-                }
-            py::tuple table_data = load(f);
-            auto table_len = table_data[0].cast<std::size_t>();
-            rv.tables.clear();
-            rv.tables.node_table.reserve(table_len);
-            for (std::size_t i = 0; i < table_len; ++i)
-                {
-                    rv.tables.node_table.push_back(
-                        load(f).cast<fwdpp::ts::node>());
-                }
-            table_len = table_data[1].cast<std::size_t>();
-            rv.tables.edge_table.reserve(table_len);
-            for (std::size_t i = 0; i < table_len; ++i)
-                {
-                    rv.tables.edge_table.push_back(
-                        load(f).cast<fwdpp::ts::edge>());
-                }
-            table_len = table_data[2].cast<std::size_t>();
-            rv.tables.mutation_table.reserve(table_len);
-            for (std::size_t i = 0; i < table_len; ++i)
-                {
-                    rv.tables.mutation_table.push_back(
-                        load(f).cast<fwdpp::ts::mutation_record>());
-                }
-            rv.tables.preserved_nodes
-                = load(f).cast<decltype(rv.tables.preserved_nodes)>();
-            rv.tables.build_indexes();
-            return rv;
-        });
+             },
+             R"delim(
+             Pickle the population to an open file.
+
+             This function may be preferred over 
+             the direct pickling method because it uses less
+             memory.  It is, however, slower.
+
+             To read the population back in, you must call
+             :func:`fwdpy11.SlocusPop.load_from_pickle_file`.
+
+             :param f: A handle to an open file
+
+             .. versionadded:: 0.3.0
+             )delim")
+        .def_static(
+            "load_from_pickle_file",
+            [](py::object f) {
+                auto load = py::module::import("pickle").attr("load");
+                py::tuple popdata = load(f);
+                fwdpy11::SlocusPop rv(popdata[0].cast<fwdpp::uint_t>(),
+                                      popdata[4].cast<double>());
+                rv.generation
+                    = popdata[3]
+                          .cast<decltype(fwdpy11::SlocusPop::generation)>();
+                auto ndips = popdata[0].cast<std::size_t>();
+                auto ngams = popdata[1].cast<std::size_t>();
+                auto nmuts = popdata[2].cast<std::size_t>();
+                rv.diploids.clear();
+                rv.gametes.clear();
+                rv.mutations.clear();
+                rv.diploids.reserve(ndips);
+                for (std::size_t i = 0; i < ndips; ++i)
+                    {
+                        rv.diploids.push_back(
+                            load(f).cast<fwdpy11::DiploidGenotype>());
+                    }
+                rv.gametes.reserve(ngams);
+                for (std::size_t i = 0; i < ngams; ++i)
+                    {
+                        rv.gametes.push_back(load(f).cast<fwdpp::gamete>());
+                    }
+                rv.mutations.reserve(nmuts);
+                for (std::size_t i = 0; i < nmuts; ++i)
+                    {
+                        rv.mutations.push_back(
+                            load(f).cast<fwdpy11::Mutation>());
+                    }
+                rv.mcounts = load(f).cast<decltype(rv.mcounts)>();
+                rv.mcounts_from_preserved_nodes
+                    = load(f)
+                          .cast<decltype(rv.mcounts_from_preserved_nodes)>();
+                py::tuple metadata_data = load(f);
+                rv.diploid_metadata.clear();
+                rv.ancient_sample_metadata.clear();
+                auto lmd = metadata_data[0].cast<std::size_t>();
+                auto lamd = metadata_data[1].cast<std::size_t>();
+                rv.diploid_metadata.reserve(lmd);
+                for (std::size_t i = 0; i < lmd; ++i)
+                    {
+                        rv.diploid_metadata.push_back(
+                            load(f).cast<fwdpy11::DiploidMetadata>());
+                    }
+                rv.ancient_sample_metadata.reserve(lamd);
+                for (std::size_t i = 0; i < lamd; ++i)
+                    {
+                        rv.ancient_sample_metadata.push_back(
+                            load(f).cast<fwdpy11::DiploidMetadata>());
+                    }
+                py::tuple table_data = load(f);
+                auto table_len = table_data[0].cast<std::size_t>();
+                rv.tables.clear();
+                rv.tables.node_table.reserve(table_len);
+                for (std::size_t i = 0; i < table_len; ++i)
+                    {
+                        rv.tables.node_table.push_back(
+                            load(f).cast<fwdpp::ts::node>());
+                    }
+                table_len = table_data[1].cast<std::size_t>();
+                rv.tables.edge_table.reserve(table_len);
+                for (std::size_t i = 0; i < table_len; ++i)
+                    {
+                        rv.tables.edge_table.push_back(
+                            load(f).cast<fwdpp::ts::edge>());
+                    }
+                table_len = table_data[2].cast<std::size_t>();
+                rv.tables.mutation_table.reserve(table_len);
+                for (std::size_t i = 0; i < table_len; ++i)
+                    {
+                        rv.tables.mutation_table.push_back(
+                            load(f).cast<fwdpp::ts::mutation_record>());
+                    }
+                rv.tables.preserved_nodes
+                    = load(f).cast<decltype(rv.tables.preserved_nodes)>();
+                rv.tables.build_indexes();
+                return rv;
+            },
+            R"delim(
+            Read in a pickled population from a file.
+            The file muse have been generated by
+            a call to :func:`fwdpy11.SlocusPop.pickle_to_file`.
+
+            :param f: A handle to a file opened in 'rb' mode.
+
+            .. versionadded: 0.3.0
+            )delim");
 
     py::class_<fwdpy11::MlocusPop, fwdpy11::Population>(
         m, "_MlocusPop", "Representation of a multi-locus population")

--- a/fwdpy11/src/_opaque_diploids.cc
+++ b/fwdpy11/src/_opaque_diploids.cc
@@ -86,5 +86,23 @@ PYBIND11_MODULE(_opaque_diploids, m)
         py::buffer_protocol(),
         R"delim(
         Container of diploid metadata.
-        )delim");
+        )delim")
+        .def(py::pickle(
+            [](const std::vector<fwdpy11::DiploidMetadata>& md) {
+                py::list rv;
+                for (auto& i : md)
+                    {
+                        rv.append(i);
+                    }
+                return rv;
+            },
+            [](py::list l) {
+                std::vector<fwdpy11::DiploidMetadata> rv;
+                rv.reserve(l.size());
+                for (auto i : l)
+                    {
+                        rv.push_back(i.cast<fwdpy11::DiploidMetadata>());
+                    }
+                return rv;
+            }));
 }

--- a/fwdpy11/src/fwdpy11_types.cc
+++ b/fwdpy11/src/fwdpy11_types.cc
@@ -217,7 +217,6 @@ PYBIND11_MODULE(fwdpy11_types, m)
              [](const fwdpy11::DiploidGenotype &a,
                 const fwdpy11::DiploidGenotype &b) { return a == b; });
 
-    // TODO: pickling support
     py::class_<fwdpy11::DiploidMetadata>(m, "DiploidMetadata",
                                          "Diploid meta data.")
         .def_readwrite("g", &fwdpy11::DiploidMetadata::g, "Genetic value.")
@@ -258,5 +257,34 @@ PYBIND11_MODULE(fwdpy11_types, m)
                                    rv.append(md.nodes[1]);
                                    return rv;
                                },
-                               "Node ids for individual");
+                               "Node ids for individual")
+        .def(py::pickle(
+            [](const fwdpy11::DiploidMetadata &md) {
+                return py::make_tuple(
+                    md.g, md.e, md.w,
+                    py::make_tuple(md.geography[0], md.geography[1],
+                                   md.geography[2]),
+                    md.label, py::make_tuple(md.parents[0], md.parents[1]),
+                    md.deme, md.sex, py::make_tuple(md.nodes[0], md.nodes[1]));
+            },
+            [](py::tuple t) {
+                fwdpy11::DiploidMetadata rv;
+                rv.g = t[0].cast<double>();
+                rv.e = t[1].cast<double>();
+                rv.w = t[2].cast<double>();
+                auto ttuple = t[3].cast<py::tuple>();
+                rv.geography[0] = ttuple[0].cast<double>();
+                rv.geography[1] = ttuple[1].cast<double>();
+                rv.geography[2] = ttuple[2].cast<double>();
+                rv.label = t[4].cast<std::size_t>();
+                ttuple = t[5].cast<py::tuple>();
+                rv.parents[0] = ttuple[0].cast<std::size_t>();
+                rv.parents[1] = ttuple[1].cast<std::size_t>();
+                rv.deme=t[6].cast<std::int32_t>();
+                rv.sex=t[7].cast<std::int32_t>();
+                ttuple = t[8].cast<py::tuple>();
+                rv.nodes[0]=ttuple[0].cast<fwdpp::ts::TS_NODE_INT>();
+                rv.nodes[1]=ttuple[1].cast<fwdpp::ts::TS_NODE_INT>();
+                return rv;
+            }));
 }

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
+import unittest
 import cppimport
 cppimport.force_rebuild()
 cppimport.set_quiet(False)
 pickling_cpp = cppimport.imp("pickling_cpp")
-import unittest
 
 
 class testPickleMutation(unittest.TestCase):
@@ -90,7 +90,7 @@ class testPickleSlocusPop(unittest.TestCase):
 
     def testPicklePopPy(self):
         import pickle
-        p = pickle.dumps(self.pop, -1);
+        p = pickle.dumps(self.pop, -1)
         pp = pickle.loads(p)
         self.assertEqual(pp, self.pop)
 
@@ -99,6 +99,45 @@ class testPickleSlocusPop(unittest.TestCase):
         p = pickling_cpp.general_pickler(self.pop)
         pp = pickle.loads(p)
         self.assertEqual(pp, self.pop)
+
+
+class testPickleSlocusPopTreeSequences(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        import fwdpy11.genetic_values
+        import fwdpy11.wright_fisher_ts
+        import numpy as np
+        self.N = 1000
+        self.demography = np.array([self.N]*self.N, dtype=np.uint32)
+        self.rho = 1.
+        self.theta = 100.
+        self.nreps = 500
+        self.mu = self.theta/(4*self.N)
+        self.r = self.rho/(4*self.N)
+
+        self.GSS = fwdpy11.genetic_values.GSS(VS=1, opt=0)
+        a = fwdpy11.genetic_values.SlocusAdditive(2.0, self.GSS)
+        self.p = {'nregions': [],
+                  'sregions': [fwdpy11.GaussianS(0, 1, 1, 0.25)],
+                  'recregions': [fwdpy11.Region(0, 1, 1)],
+                  'rates': (0.0, 0.025, self.r),
+                  'gvalue': a,
+                  'prune_selected': False,
+                  'demography': self.demography
+                  }
+        self.params = fwdpy11.model_params.ModelParams(**self.p)
+        self.rng = fwdpy11.GSLrng(101*45*110*210)
+        self.pop = fwdpy11.SlocusPop(self.N, 1.0)
+        fwdpy11.wright_fisher_ts.evolve(self.rng, self.pop, self.params, 100)
+
+    def testPickleNodeTable(self):
+        import pickle
+        import numpy as np
+        pn = pickle.dumps(self.pop.tables.nodes)
+        up = pickle.loads(pn)
+        nodes = np.array(self.pop.tables.nodes)
+        nodes2 = np.array(up)
+        self.assertTrue(np.array_equal(nodes, nodes2))
 
 
 class testPickleMlocusPop(unittest.TestCase):
@@ -125,7 +164,6 @@ class testPickleMlocusPop(unittest.TestCase):
         p = pickling_cpp.general_pickler(self.pop)
         pp = pickle.loads(p)
         self.assertEqual(pp, self.pop)
-
 
 
 if __name__ == "__main__":

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -139,6 +139,30 @@ class testPickleSlocusPopTreeSequences(unittest.TestCase):
         nodes2 = np.array(up)
         self.assertTrue(np.array_equal(nodes, nodes2))
 
+    def testPickleEdgeTable(self):
+        import pickle
+        import numpy as np
+        p = pickle.dumps(self.pop.tables.edges)
+        u = pickle.loads(p)
+        edges = np.array(self.pop.tables.edges)
+        edges2 = np.array(u)
+        self.assertTrue(np.array_equal(edges, edges2))
+
+    def testPickleMutationTable(self):
+        import pickle
+        import numpy as np
+        p = pickle.dumps(self.pop.tables.mutations)
+        u = pickle.loads(p)
+        mutations = np.array(self.pop.tables.mutations)
+        mutations2 = np.array(u)
+        self.assertTrue(np.array_equal(mutations, mutations2))
+
+    def testPickleTableCollection(self):
+        import pickle
+        p = pickle.dumps(self.pop.tables)
+        u = pickle.loads(p)
+        self.assertTrue(u == self.pop.tables)
+
 
 class testPickleMlocusPop(unittest.TestCase):
     @classmethod

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -179,6 +179,25 @@ class testPickleSlocusPopTreeSequences(unittest.TestCase):
         md2 = np.array(up)
         self.assertTrue(np.array_equal(md, md2))
 
+    def testPicklingToFile(self):
+        import fwdpy11
+        import lzma
+        import os
+        fname = "pickleFileTesting.pickle"
+        with lzma.open(fname, 'wb') as f:
+            self.pop.pickle_to_file(f)
+        with lzma.open(fname, 'rb') as f:
+            pop = fwdpy11.SlocusPop.load_from_pickle_file(f)
+        self.assertEqual(pop.N, self.pop.N)
+        self.assertEqual(pop.generation, self.pop.generation)
+        self.assertTrue(pop.diploids == self.pop.diploids)
+        self.assertTrue(pop.gametes == self.pop.gametes)
+        self.assertTrue(pop.mutations == self.pop.mutations)
+        self.assertTrue(pop.mcounts == self.pop.mcounts)
+        self.assertTrue(pop.tables == self.pop.tables)
+        self.assertTrue(pop == self.pop)
+        os.remove(fname)
+
 
 class testPickleMlocusPop(unittest.TestCase):
     @classmethod

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -163,6 +163,15 @@ class testPickleSlocusPopTreeSequences(unittest.TestCase):
         u = pickle.loads(p)
         self.assertTrue(u == self.pop.tables)
 
+    def testPickleMetaData(self):
+        import pickle
+        import numpy as np
+        p = pickle.dumps(self.pop.diploid_metadata)
+        up = pickle.loads(p)
+        md = np.array(self.pop.diploid_metadata)
+        md2 = np.array(up)
+        self.assertTrue(np.array_equal(md, md2))
+
 
 class testPickleMlocusPop(unittest.TestCase):
     @classmethod

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -224,6 +224,19 @@ class testPickleMlocusPop(unittest.TestCase):
         pp = pickle.loads(p)
         self.assertEqual(pp, self.pop)
 
+    def testPicklingToFile(self):
+        import fwdpy11
+        import lzma
+        import os
+        fname = "pickleFileTestingMlocus.pickle"
+        with lzma.open(fname, 'wb') as f:
+            self.pop.pickle_to_file(f)
+        with lzma.open(fname, 'rb') as f:
+            pop = fwdpy11.MlocusPop.load_from_pickle_file(f)
+        self.assertTrue(pop == self.pop)
+        self.assertEqual(pop.N, self.pop.N)
+        os.remove(fname)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -100,6 +100,13 @@ class testPickleSlocusPop(unittest.TestCase):
         pp = pickle.loads(p)
         self.assertEqual(pp, self.pop)
 
+    def testPickleTableCollection(self):
+        import pickle
+        import numpy as np
+        p = pickle.dumps(self.pop.tables)
+        up = pickle.loads(p)
+        self.assertEqual(up.genome_length(), np.finfo(np.float).max)
+
 
 class testPickleSlocusPopTreeSequences(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Add member functions to population classes allowing slower, but less RAM-intensive, pickling of populations to files.