### PR TITLE
Remove extinct mutations at the end of tsr sims

### DIFF
--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -33,7 +33,8 @@ set(TSEVOLUTION_SOURCES src/tsevolution/tsevolution.cc
     src/tsevolution/mlocus_fitness.cc
     src/tsevolution/index_and_count_mutations.cc
     src/tsevolution/track_mutation_counts.cc
-    src/tsevolution/no_stopping.cc)
+    src/tsevolution/no_stopping.cc
+    src/tsevolution/remove_extinct_mutations.cc)
 
 # These are the main modules
 pybind11_add_module(_fwdpy11 MODULE src/_fwdpy11.cc ${REGION_SOURCES})

--- a/fwdpy11/src/tsevolution/remove_extinct_mutations.cc
+++ b/fwdpy11/src/tsevolution/remove_extinct_mutations.cc
@@ -13,7 +13,7 @@ namespace
     {
         auto f = std::find(begin(indexes), end(indexes), input_index);
         auto d = std::distance(begin(indexes), f);
-        return indexes[d];
+        return d;
     }
 
     void
@@ -83,6 +83,13 @@ remove_extinct_mutations(fwdpy11::Population& pop)
                     reindex_container(indexes, g.mutations);
                     reindex_container(indexes, g.smutations);
                 }
+        }
+
+    // Easiest way to update the lookup table:
+    pop.mut_lookup.clear();
+    for (std::size_t i = 0; i < pop.mutations.size(); ++i)
+        {
+            pop.mut_lookup.insert(std::make_pair(pop.mutations[i].pos, i));
         }
 }
 

--- a/fwdpy11/src/tsevolution/remove_extinct_mutations.cc
+++ b/fwdpy11/src/tsevolution/remove_extinct_mutations.cc
@@ -1,0 +1,88 @@
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <fwdpy11/types/Population.hpp>
+
+namespace
+{
+    std::size_t
+    reindex(const std::vector<std::size_t>& indexes,
+            const std::size_t input_index)
+    {
+        auto f = std::find(begin(indexes), end(indexes), input_index);
+        auto d = std::distance(begin(indexes), f);
+        return indexes[d];
+    }
+
+    void
+    reindex_container(const std::vector<std::size_t>& indexes,
+                      std::vector<fwdpp::uint_t>& keys)
+    {
+        for (auto& k : keys)
+            {
+                k = reindex(indexes, k);
+            }
+    }
+} // namespace
+
+void
+remove_extinct_mutations(fwdpy11::Population& pop)
+{
+    std::vector<fwdpp::uint_t> summed_counts(pop.mcounts);
+    std::transform(begin(pop.mcounts_from_preserved_nodes),
+                   end(pop.mcounts_from_preserved_nodes), begin(summed_counts),
+                   begin(summed_counts), std::plus<fwdpp::uint_t>());
+    std::vector<std::size_t> indexes(pop.mutations.size());
+    std::iota(begin(indexes), end(indexes), 0);
+
+    //Remove extinct mutations
+    for (auto i : indexes)
+        {
+            if (summed_counts[i] == 0)
+                {
+                    pop.mutations[i].pos = std::numeric_limits<double>::max();
+                    pop.mcounts[i] = std::numeric_limits<fwdpp::uint_t>::max();
+                    pop.mcounts_from_preserved_nodes[i]
+                        = std::numeric_limits<fwdpp::uint_t>::max();
+                }
+        }
+    pop.mutations.erase(
+        std::remove_if(begin(pop.mutations), end(pop.mutations),
+                       [](fwdpy11::Mutation& m) {
+                           return m.pos == std::numeric_limits<double>::max();
+                       }),
+        end(pop.mutations));
+    pop.mcounts.erase(std::remove(begin(pop.mcounts), end(pop.mcounts),
+                                  std::numeric_limits<fwdpp::uint_t>::max()),
+                      end(pop.mcounts));
+    pop.mcounts_from_preserved_nodes.erase(
+        std::remove(begin(pop.mcounts_from_preserved_nodes),
+                    end(pop.mcounts_from_preserved_nodes),
+                    std::numeric_limits<fwdpp::uint_t>::max()),
+        end(pop.mcounts_from_preserved_nodes));
+
+    // Erase indexes associated w/extinct mutations
+    indexes.erase(std::remove_if(begin(indexes), end(indexes),
+                                 [&summed_counts](const std::size_t i) {
+                                     return summed_counts[i] == 0;
+                                 }),
+                  end(indexes));
+
+    // Reindex the containers
+    for (std::size_t i = 0; i < pop.tables.mutation_table.size(); ++i)
+        {
+            pop.tables.mutation_table[i].key
+                = reindex(indexes, pop.tables.mutation_table[i].key);
+        }
+    for (auto& g : pop.gametes)
+        {
+            if (g.n)
+                {
+                    reindex_container(indexes, g.mutations);
+                    reindex_container(indexes, g.smutations);
+                }
+        }
+}
+

--- a/fwdpy11/src/tsevolution/remove_extinct_mutations.hpp
+++ b/fwdpy11/src/tsevolution/remove_extinct_mutations.hpp
@@ -1,0 +1,10 @@
+#ifndef FWDPY11_TSEVOLUTION_REMOVE_EXTINCT_MUTATIONS_HPP
+#define FWDPY11_TSEVOLUTION_REMOVE_EXTINCT_MUTATIONS_HPP
+
+#include <fwdpy11/types/Population.hpp>
+
+void
+remove_extinct_mutations(fwdpy11::Population& pop);
+
+#endif
+

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -41,6 +41,7 @@
 #include "index_and_count_mutations.hpp"
 #include "cleanup_metadata.hpp"
 #include "track_mutation_counts.hpp"
+#include "remove_extinct_mutations.hpp"
 
 namespace py = pybind11;
 
@@ -287,6 +288,7 @@ wfSlocusPop_ts(
                               pop.mutations, pop.tables, pop.mcounts,
                               pop.mcounts_from_preserved_nodes);
     cleanup_metadata(pop.tables, pop.generation, pop.ancient_sample_metadata);
+    remove_extinct_mutations(pop);
 }
 
 void

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -61,7 +61,8 @@ wfSlocusPop_ts(
     // NOTE: this is the complement of what a user will input, which is "prune_selected"
     const bool preserve_selected_fixations,
     const bool suppress_edge_table_indexing, bool record_genotype_matrix,
-    const bool track_mutation_counts_during_sim)
+    const bool track_mutation_counts_during_sim,
+    const bool remove_extinct_mutations_at_finish)
 {
     //validate the input params
     if (pop.tables.genome_length() == std::numeric_limits<double>::max())
@@ -155,6 +156,14 @@ wfSlocusPop_ts(
           };
     fwdpp::flagged_mutation_queue mutation_recycling_bin
         = fwdpp::empty_mutation_queue();
+    if (!pop.mutations.empty())
+        {
+            // Then we assume pop exists in an "already simulated"
+            // state and is properly-book-kept
+            mutation_recycling_bin = fwdpp::ts::make_mut_queue(
+                pop.mcounts, pop.mcounts_from_preserved_nodes);
+        }
+
     fwdpp::ts::TS_NODE_INT first_parental_index = 0,
                            next_index = pop.tables.node_table.size();
     bool simplified = false;
@@ -288,7 +297,10 @@ wfSlocusPop_ts(
                               pop.mutations, pop.tables, pop.mcounts,
                               pop.mcounts_from_preserved_nodes);
     cleanup_metadata(pop.tables, pop.generation, pop.ancient_sample_metadata);
-    remove_extinct_mutations(pop);
+    if (remove_extinct_mutations_at_finish)
+        {
+            remove_extinct_mutations(pop);
+        }
 }
 
 void

--- a/fwdpy11/wright_fisher_ts.py
+++ b/fwdpy11/wright_fisher_ts.py
@@ -21,7 +21,8 @@
 def evolve(rng, pop, params, simplification_interval, recorder=None,
            suppress_table_indexing=False, record_gvalue_matrix=False,
            stopping_criterion=None,
-           track_mutation_counts=False):
+           track_mutation_counts=False,
+           remove_extinct_variants=True):
     """
     Evolve a population
 
@@ -96,7 +97,8 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
                        recorder, stopping_criterion,
                        params.pself, params.prune_selected is False,
                        suppress_table_indexing, record_gvalue_matrix,
-                       track_mutation_counts)
+                       track_mutation_counts,
+                       remove_extinct_variants)
     else:
         from ._tsevolution import WFMlocusPop_ts
         from fwdpy11 import MlocusMutationRegions
@@ -134,4 +136,5 @@ def evolve(rng, pop, params, simplification_interval, recorder=None,
                        recorder, stopping_criterion,
                        params.pself, params.prune_selected is False,
                        suppress_table_indexing, record_gvalue_matrix,
-                       track_mutation_counts)
+                       track_mutation_counts,
+                       remove_extinct_variants)


### PR DESCRIPTION
Simulations using tree sequence recording end up with a lot of extinct variants in memory when the simplification algorithm is applied 'infrequently".

This PR adds an option to remove all those variants before returning from an evolve function.  A plus of this change is that output file sizes can be a good amount smaller.