### PR TITLE
Virtual destructors

### DIFF
--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -1,9 +1,13 @@
 find_package(GSL REQUIRED)
+option(USE_WEFFCPP "Use -Weffc++ during compilation" ON)
 include_directories(BEFORE ${fwdpy11_SOURCE_DIR}/fwdpy11/headers ${fwdpy11_SOURCE_DIR}/fwdpy11/headers/fwdpp)
 message(STATUS "GSL headers in ${GSL_INCLUDE_DIRS}")
 include_directories(BEFORE ${GSL_INCLUDE_DIRS})
 
-add_compile_options(-Weffc++)
+if (USE_WEFFCPP)
+    add_compile_options(-Weffc++)
+endif()
+
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
 
 set(REGION_SOURCES src/regions/init.cc src/regions/Region.cc src/regions/Sregion.cc src/regions/GammaS.cc src/regions/ConstantS.cc

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(BEFORE ${fwdpy11_SOURCE_DIR}/fwdpy11/headers ${fwdpy11_SOURC
 message(STATUS "GSL headers in ${GSL_INCLUDE_DIRS}")
 include_directories(BEFORE ${GSL_INCLUDE_DIRS})
 
+add_compile_options(-Weffc++)
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
 
 set(REGION_SOURCES src/regions/init.cc src/regions/Region.cc src/regions/Sregion.cc src/regions/GammaS.cc src/regions/ConstantS.cc

--- a/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/GeneticValueToFitness.hpp
@@ -36,6 +36,7 @@ namespace fwdpy11
 {
     struct GeneticValueToFitnessMap
     {
+        virtual ~GeneticValueToFitnessMap() = default;
         virtual double
         operator()(const DiploidMetadata & /*metadata*/) const = 0;
         virtual void update(const SlocusPop & /*pop*/) = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MlocusPopGeneticValue.hpp
@@ -37,6 +37,9 @@ namespace fwdpy11
             : total_dim(dimensonality), gvalues(total_dim, 0.0)
         {
         }
+
+        virtual ~MlocusPopGeneticValue() = default;
+
         // Callable from Python
         virtual double
         calculate_gvalue(const std::size_t /*diploid*/,

--- a/fwdpy11/headers/fwdpy11/genetic_values/MultivariateGeneticValueToFitnessMap.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/MultivariateGeneticValueToFitnessMap.hpp
@@ -35,6 +35,7 @@ namespace fwdpy11
 {
     struct MultivariateGeneticValueToFitnessMap
     {
+        virtual ~MultivariateGeneticValueToFitnessMap() = default;
         virtual double
         operator()(const DiploidMetadata& /*metadata*/,
                    const std::vector<double>& /*values*/) const = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValue.hpp
@@ -55,6 +55,8 @@ namespace fwdpy11
         {
         }
 
+        virtual ~SlocusPopGeneticValue() = default;
+
         // Callable from Python
         virtual double calculate_gvalue(const std::size_t /*diploid_index*/,
                                         const SlocusPop& /*pop*/) const = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopGeneticValueWithMapping.hpp
@@ -34,7 +34,7 @@ namespace fwdpy11
         std::unique_ptr<GeneticValueNoise> noise_fxn;
 
         SlocusPopGeneticValueWithMapping(const GeneticValueToFitnessMap& gv2w_)
-            : SlocusPopGeneticValue(1), gv2w{ std::move(gv2w_.clone()) },
+            : SlocusPopGeneticValue(1), gv2w{ gv2w_.clone() },
               noise_fxn{ new NoNoise() }
         {
         }

--- a/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopMultivariateGeneticValueWithMapping.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/SlocusPopMultivariateGeneticValueWithMapping.hpp
@@ -54,6 +54,15 @@ namespace fwdpy11
         {
         }
 
+        SlocusPopMultivariateGeneticValueWithMapping(
+            const SlocusPopMultivariateGeneticValueWithMapping& other)
+            : SlocusPopGeneticValue(other.total_dim), gv2w{ other.gv2w->clone() },
+              noise_fxn{ other.noise_fxn->clone() }
+        {
+        }
+
+        virtual ~SlocusPopMultivariateGeneticValueWithMapping() = default;
+
         virtual double
         genetic_value_to_fitness(const DiploidMetadata& metadata) const
         {

--- a/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/noise.hpp
@@ -32,6 +32,7 @@ namespace fwdpy11
     struct GeneticValueNoise
     ///ABC for random effects on trait values
     {
+        virtual ~GeneticValueNoise() = default;
         virtual double
         operator()(const GSLrng_t& /* rng */,
                    const DiploidMetadata& /*offspring_metadata*/,

--- a/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
@@ -10,6 +10,7 @@ namespace fwdpy11
 {
     struct GeneticMapUnit
     {
+        virtual ~GeneticMapUnit() = default;
         virtual void operator()(const GSLrng_t&, std::vector<double>&) const = 0;
         virtual pybind11::object pickle()  const= 0;
         virtual std::unique_ptr<GeneticMapUnit> clone()  const = 0;

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -15,6 +15,7 @@ namespace fwdpy11
 {
     struct GeneticMap
     {
+        virtual ~GeneticMap() = default;
         virtual std::vector<double> operator()(const GSLrng_t& rng) const = 0;
     };
 

--- a/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
@@ -18,6 +18,8 @@ namespace fwdpy11
         Region region; // For returning positions
         double scaling;
 
+        virtual ~Sregion() = default;
+
         Sregion(const Region& r, double s) : region(r), scaling(s)
         {
             if (!std::isfinite(scaling))

--- a/fwdpy11/src/ts.cc
+++ b/fwdpy11/src/ts.cc
@@ -422,13 +422,12 @@ PYBIND11_MODULE(ts, m)
                                         pop.mcounts_from_preserved_nodes);
         std::vector<fwdpp::ts::TS_NODE_INT> samples(2 * pop.N);
         std::iota(samples.begin(), samples.end(), 0);
-        const auto apply_mutations
-            = [&recycling_bin, &rng, &pop, &samples,
-               mu](const double left, const double right,
-                   const fwdpp::uint_t generation) {
-                  return generate_neutral_variants(recycling_bin, pop, rng,
-                                                   left, right, generation);
-              };
+        const auto apply_mutations =
+            [&recycling_bin, &rng, &pop](const double left, const double right,
+                                         const fwdpp::uint_t generation) {
+                return generate_neutral_variants(recycling_bin, pop, rng, left,
+                                                 right, generation);
+            };
         auto nmuts = fwdpp::ts::mutate_tables(rng, apply_mutations, pop.tables,
                                               samples, mu);
         std::sort(

--- a/fwdpy11/src/tsevolution/mlocuspop.cc
+++ b/fwdpy11/src/tsevolution/mlocuspop.cc
@@ -169,7 +169,7 @@ wfMlocusPop_ts(
     //const auto bound_rmodel = [&rng, &rmodel]() { return rmodel(rng); };
 
     auto genetics = fwdpp::make_genetic_parameters(
-        &genetic_value_fxn, std::move(bound_mmodels),
+        std::ref(genetic_value_fxn), std::move(bound_mmodels),
         std::move(intralocus_recombination), std::move(interlocus_rec));
     // A stateful fitness model will need its data up-to-date,
     // so we must call update(...) prior to calculating fitness,

--- a/fwdpy11/src/tsevolution/mlocuspop.cc
+++ b/fwdpy11/src/tsevolution/mlocuspop.cc
@@ -201,10 +201,10 @@ wfMlocusPop_ts(
               return gsl_ran_discrete(rng.get(), lookup.get());
           };
     const auto generate_offspring_metadata
-        = [&rng](fwdpy11::DiploidMetadata &offspring_metadata,
-                 const std::size_t p1, const std::size_t p2,
-                 const std::vector<fwdpy11::DiploidMetadata>
-                     & /*parental_metadata*/) {
+        = [](fwdpy11::DiploidMetadata &offspring_metadata,
+             const std::size_t p1, const std::size_t p2,
+             const std::vector<fwdpy11::DiploidMetadata>
+                 & /*parental_metadata*/) {
               offspring_metadata.deme = 0;
               offspring_metadata.parents[0] = p1;
               offspring_metadata.parents[1] = p2;

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -115,7 +115,7 @@ wfSlocusPop_ts(
     const auto bound_rmodel = [&rng, &rmodel]() { return rmodel(rng); };
 
     auto genetics = fwdpp::make_genetic_parameters(
-        &genetic_value_fxn, std::move(bound_mmodel), std::move(bound_rmodel));
+        std::ref(genetic_value_fxn), std::move(bound_mmodel), std::move(bound_rmodel));
     // A stateful fitness model will need its data up-to-date,
     // so we must call update(...) prior to calculating fitness,
     // else bad stuff like segfaults could happen.

--- a/fwdpy11/src/tsevolution/slocuspop.cc
+++ b/fwdpy11/src/tsevolution/slocuspop.cc
@@ -146,10 +146,10 @@ wfSlocusPop_ts(
               return gsl_ran_discrete(rng.get(), lookup.get());
           };
     const auto generate_offspring_metadata
-        = [&rng](fwdpy11::DiploidMetadata &offspring_metadata,
-                 const std::size_t p1, const std::size_t p2,
-                 const std::vector<fwdpy11::DiploidMetadata>
-                     & /*parental_metadata*/) {
+        = [](fwdpy11::DiploidMetadata &offspring_metadata,
+             const std::size_t p1, const std::size_t p2,
+             const std::vector<fwdpy11::DiploidMetadata>
+                 & /*parental_metadata*/) {
               offspring_metadata.deme = 0;
               offspring_metadata.parents[0] = p1;
               offspring_metadata.parents[1] = p2;

--- a/fwdpy11/src/wright_fisher_mlocus.cc
+++ b/fwdpy11/src/wright_fisher_mlocus.cc
@@ -218,7 +218,7 @@ wfMlocusPop(const fwdpy11::GSLrng_t &rng, fwdpy11::MlocusPop &pop,
           };
 
     const auto generate_offspring_metadata
-        = [&rng](fwdpy11::DiploidMetadata &offspring_metadata,
+        = [](fwdpy11::DiploidMetadata &offspring_metadata,
                  const std::size_t p1, const std::size_t p2,
                  const std::vector<fwdpy11::DiploidMetadata>
                      & /*parental_metadata*/) {

--- a/fwdpy11/src/wright_fisher_slocus.cc
+++ b/fwdpy11/src/wright_fisher_slocus.cc
@@ -178,10 +178,10 @@ wfSlocusPop(const fwdpy11::GSLrng_t &rng, fwdpy11::SlocusPop &pop,
           };
 
     const auto generate_offspring_metadata
-        = [&rng](fwdpy11::DiploidMetadata &offspring_metadata,
-                 const std::size_t p1, const std::size_t p2,
-                 const std::vector<fwdpy11::DiploidMetadata>
-                     & /*parental_metadata*/) {
+        = [](fwdpy11::DiploidMetadata &offspring_metadata,
+             const std::size_t p1, const std::size_t p2,
+             const std::vector<fwdpy11::DiploidMetadata>
+                 & /*parental_metadata*/) {
               offspring_metadata.deme = 0;
               offspring_metadata.parents[0] = p1;
               offspring_metadata.parents[1] = p2;

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,12 @@ if '--gcc' in sys.argv:
 else:
     USE_GCC = False
 
+if '--no-weffcpp' in sys.argv:
+    USE_WEFFCPP = False
+    sys.argv.remove('--no-weffcpp')
+else:
+    USE_WEFFCPP = True
+
 if '--debug' in sys.argv:
     DEBUG_MODE = True
 else:
@@ -97,6 +103,8 @@ class CMakeBuild(build_ext):
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
 
+        if USE_WEFFCPP is False:
+            cmake_args.append('-DUSE_WEFFCPP=OFF')
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(['cmake', ext.sourcedir] +

--- a/setup.py.in
+++ b/setup.py.in
@@ -38,6 +38,12 @@ if '--gcc' in sys.argv:
 else:
     USE_GCC = False
 
+if '--no-weffcpp' in sys.argv:
+    USE_WEFFCPP = False
+    sys.argv.remove('--no-weffcpp')
+else:
+    USE_WEFFCPP = True
+
 if '--debug' in sys.argv:
     DEBUG_MODE = True
 else:
@@ -97,6 +103,8 @@ class CMakeBuild(build_ext):
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
 
+        if USE_WEFFCPP is False:
+            cmake_args.append('-DUSE_WEFFCPP=OFF')
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(['cmake', ext.sourcedir] +

--- a/tests/pickling_composed_classes.cpp
+++ b/tests/pickling_composed_classes.cpp
@@ -19,6 +19,7 @@ cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
 
 struct Base
 {
+    virtual ~Base() = default;
     virtual py::object repr() const = 0;
     virtual std::unique_ptr<Base> clone() const = 0;
 };

--- a/travis_scripts/build_script.sh
+++ b/travis_scripts/build_script.sh
@@ -19,7 +19,7 @@ then
     # if [ "$TRAVIS_OS_NAME" == "osx" -a "$OSXGCC" == "1" ]; then CC=gcc CXX=g++ python setup.py build_ext -i --gcc; fi
     # if [ "$TRAVIS_OS_NAME" == "osx" -a "$OSXGCC" == "0" ]; then LDFLAGS='-stdlib=libc++ -mmacosx-version-min=10.7' CPPFLAGS="-stdlib=libc++ -mmacosx-version-min=10.7" python -m unittest discover -v tests; fi
     # if [ "$TRAVIS_OS_NAME" == "osx" -a "$OSXGCC" == "1" ]; then CC=gcc CXX=g++ python -m unittest discover -v tests; fi
-    CC=$CC CXX=$CXX python setup.py build_ext -i
+    CC=$CC CXX=$CXX python setup.py build_ext -i --no-weffcpp
     if [ "$?" != "0" ];
     then
         exit 1


### PR DESCRIPTION
Fix several compiler warnings found by clang.  The big one was that many classes were missing virtual destructors!

-Weffc++ has been added to compiler flags.