### PR TITLE
Common mako for tests

### DIFF
--- a/tests/common_mako.py
+++ b/tests/common_mako.py
@@ -1,0 +1,25 @@
+def setup_mako(cfg):
+    # import fwdpy11 so we can find its C++ headers
+    import fwdpy11 as fp11
+    import subprocess
+    import sys
+    gsl_prefix = subprocess.check_output(
+        ['gsl-config', '--prefix']).strip().decode('utf-8')
+    # add fwdpy11 header locations to the include path
+    cfg['include_dirs'].extend(
+        [fp11.get_includes(), fp11.get_fwdpp_includes(),
+         gsl_prefix + str('/include')])
+    gsl_libs = subprocess.check_output(
+        ['gsl-config', '--libs']).strip().decode('utf-8')
+    gsl_libs = gsl_libs.split(' ')
+    gsl_runtime_libs = [i.replace('-l', '') for i in gsl_libs[1:]]
+    cfg['libraries'].extend(gsl_runtime_libs)
+    cfg['extra_link_args'].extend([gsl_libs[0]])
+    # On OS X using clang, there is more work to do.  Using gcc on OS X
+    # gets rid of these requirements. The specifics sadly depend on how
+    # you initially built fwdpy11, and what is below assumes you used
+    # the provided setup.py + OS X + clang:
+    if sys.platform == 'darwin':
+        cfg['compiler_args'].extend(
+            ['-stdlib=libc++', '-mmacosx-version-min=10.7'])
+        cfg['linker_args'] = ['-stdlib=libc++', '-mmacosx-version-min=10.7']

--- a/tests/custom_additive.cpp
+++ b/tests/custom_additive.cpp
@@ -1,18 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
-#On OS X using clang, there is more work to do.  Using gcc on OS X
-#gets rid of these requirements. The specifics sadly depend on how
-#you initially built fwdpy11, and what is below assumes you used
-#the provided setup.py + OS X + clang:
-#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
-#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
-#An alternative to the above is to add the first line to CPPFLAGS
-#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/custom_stateless_genotype.cpp
+++ b/tests/custom_stateless_genotype.cpp
@@ -1,18 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
-#On OS X using clang, there is more work to do.  Using gcc on OS X
-#gets rid of these requirements. The specifics sadly depend on how
-#you initially built fwdpy11, and what is below assumes you used
-#the provided setup.py + OS X + clang:
-#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
-#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
-#An alternative to the above is to add the first line to CPPFLAGS
-#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/fixation_properties.cpp
+++ b/tests/fixation_properties.cpp
@@ -1,18 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes() ])
-#On OS X using clang, there is more work to do.  Using gcc on OS X
-#gets rid of these requirements. The specifics sadly depend on how
-#you initially built fwdpy11, and what is below assumes you used
-#the provided setup.py + OS X + clang:
-#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
-#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
-#An alternative to the above is to add the first line to CPPFLAGS
-#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/gsl_error.cpp
+++ b/tests/gsl_error.cpp
@@ -1,10 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
-cfg['libraries'].extend(['gsl','gslcblas'])
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/pickling_composed_classes.cpp
+++ b/tests/pickling_composed_classes.cpp
@@ -1,10 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/pickling_cpp.cpp
+++ b/tests/pickling_cpp.cpp
@@ -1,18 +1,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
-#On OS X using clang, there is more work to do.  Using gcc on OS X
-#gets rid of these requirements. The specifics sadly depend on how
-#you initially built fwdpy11, and what is below assumes you used
-#the provided setup.py + OS X + clang:
-#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
-#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
-#An alternative to the above is to add the first line to CPPFLAGS
-#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/tests/snowdrift.cpp
+++ b/tests/snowdrift.cpp
@@ -18,18 +18,8 @@
 // clang-format off
 <% 
 setup_pybind11(cfg) 
-#import fwdpy11 so we can find its C++ headers
-import fwdpy11 as fp11 
-#add fwdpy11 header locations to the include path
-cfg['include_dirs'].extend([ fp11.get_includes(), fp11.get_fwdpp_includes()])
-#On OS X using clang, there is more work to do.  Using gcc on OS X
-#gets rid of these requirements. The specifics sadly depend on how
-#you initially built fwdpy11, and what is below assumes you used
-#the provided setup.py + OS X + clang:
-#cfg['compiler_args'].extend(['-stdlib=libc++','-mmacosx-version-min=10.7'])
-#cfg['linker_args']=['-stdlib=libc++','-mmacosx-version-min=10.7']
-#An alternative to the above is to add the first line to CPPFLAGS
-#and the second to LDFLAGS when compiling a plugin on OS X using clang.
+import common_mako
+common_mako.setup_mako(cfg)
 %>
 // clang-format on
 

--- a/travis_scripts/installation_script.sh
+++ b/travis_scripts/installation_script.sh
@@ -28,6 +28,8 @@ then
     fi
     conda install cython numpy python==3.6 gsl
     conda install -c conda-forge pybind11==2.2.4 numpy==1.16.2 msprime openblas cmake
+    # Weird stuff is happening right now, so we force numpy and numpy base:
+    const install -c conda-forge numpy==1.16.2 numpy_base==1.16.2
     # conda install -c conda-forge sphinx nbsphinx ipython matplotlib msprime
     pip install cppimport
     echo `which python`

--- a/travis_scripts/installation_script.sh
+++ b/travis_scripts/installation_script.sh
@@ -29,7 +29,7 @@ then
     conda install cython numpy python==3.6 gsl
     conda install -c conda-forge pybind11==2.2.4 numpy==1.16.2 msprime openblas cmake
     # Weird stuff is happening right now, so we force numpy and numpy base:
-    const install -c conda-forge numpy==1.16.2 numpy_base==1.16.2
+    conda install -c conda-forge numpy==1.16.2 numpy_base==1.16.2
     # conda install -c conda-forge sphinx nbsphinx ipython matplotlib msprime
     pip install cppimport
     echo `which python`

--- a/travis_scripts/installation_script.sh
+++ b/travis_scripts/installation_script.sh
@@ -29,7 +29,7 @@ then
     conda install cython numpy python==3.6 gsl
     conda install -c conda-forge pybind11==2.2.4 numpy==1.16.2 msprime openblas cmake
     # Weird stuff is happening right now, so we force numpy and numpy base:
-    conda install -c conda-forge numpy==1.16.2 numpy_base==1.16.2
+    conda install -c conda-forge numpy==1.16.2 numpy-base==1.16.2
     # conda install -c conda-forge sphinx nbsphinx ipython matplotlib msprime
     pip install cppimport
     echo `which python`

--- a/travis_scripts/installation_script.sh
+++ b/travis_scripts/installation_script.sh
@@ -27,9 +27,9 @@ then
         conda install gcc;
     fi
     conda install cython numpy python==3.6 gsl
-    conda install -c conda-forge pybind11==2.2.4 numpy==1.16.2 msprime openblas cmake
+    conda install -c conda-forge pybind11==2.2.4 numpy==1.16.2 msprime==0.7.0 openblas cmake
     # Weird stuff is happening right now, so we force numpy and numpy base:
-    conda install -c conda-forge numpy==1.16.2 numpy-base==1.16.2
+    # conda install -c conda-forge numpy==1.16.2 numpy-base==1.16.2
     # conda install -c conda-forge sphinx nbsphinx ipython matplotlib msprime
     pip install cppimport
     echo `which python`


### PR DESCRIPTION
Implement a single Python function doing the `cppimport` setup for all unit tests.

Also update the Travis CI setup for Linux + conda.