### PR TITLE
Fix "special" function implementations

### DIFF
--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -40,11 +40,6 @@ namespace fwdpy11
 
         dipvector_t diploids;
 
-        DiploidPopulation(DiploidPopulation &&) = default;
-        DiploidPopulation(const DiploidPopulation &) = default;
-        DiploidPopulation &operator=(DiploidPopulation &&) = default;
-        DiploidPopulation &operator=(const DiploidPopulation &) = default;
-
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
             : Population{ N, length }, diploids(N, { 0, 0 })
@@ -77,6 +72,12 @@ namespace fwdpy11
         {
             this->process_individual_input();
         }
+
+        ~DiploidPopulation() = default;
+        DiploidPopulation(DiploidPopulation&&)=default;
+        DiploidPopulation(const DiploidPopulation&)=default;
+        DiploidPopulation&operator=(const DiploidPopulation&)=default;
+        DiploidPopulation&operator=(DiploidPopulation&&)=default;
 
         bool
         operator==(const DiploidPopulation &rhs) const

--- a/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
@@ -58,10 +58,6 @@ namespace fwdpy11
         std::vector<double> genetic_value_matrix,
             ancient_sample_genetic_value_matrix;
 
-        virtual ~PyPopulation() = default;
-
-        PyPopulation(PyPopulation &&) = default;
-        PyPopulation(const PyPopulation &) = default;
 
         PyPopulation(fwdpp::uint_t N_, const double L)
             : fwdpp_base{ N_ }, N{ N_ }, generation{ 0 }, diploid_metadata(N),
@@ -84,6 +80,12 @@ namespace fwdpy11
               genetic_value_matrix{}, ancient_sample_genetic_value_matrix{}
         {
         }
+
+        virtual ~PyPopulation() = default;
+        PyPopulation(PyPopulation&&) = default;
+        PyPopulation(const PyPopulation&) = default;
+        PyPopulation&operator=(const PyPopulation&) = default;
+        PyPopulation&operator=(PyPopulation&&) = default;
 
         virtual std::vector<std::size_t>
         add_mutations(typename fwdpp_base::mcont_t &mutations,


### PR DESCRIPTION
PyPopulation had declared some, but not all of the 5 special functions, triggering a warning with clang-8.  This PR fixes that.