### PR TITLE
Fix #238

### DIFF
--- a/fwdpy11/_evolve_genomes.py
+++ b/fwdpy11/_evolve_genomes.py
@@ -59,5 +59,5 @@ def evolve_genomes(rng, pop, params, recorder=None):
 
     evolve_without_tree_sequences(rng, pop, params.demography,
                                   params.mutrate_n, params.mutrate_s,
-                                  params.recrate, mm, rm, params.gvalue,
+                                  mm, rm, params.gvalue,
                                   recorder, params.pself, params.prune_selected)

--- a/fwdpy11/_evolve_genomes.py
+++ b/fwdpy11/_evolve_genomes.py
@@ -47,7 +47,9 @@ def evolve_genomes(rng, pop, params, recorder=None):
     from ._fwdpy11 import MutationRegions
     from ._fwdpy11 import evolve_without_tree_sequences
     from ._fwdpy11 import dispatch_create_GeneticMap
-    pneutral = params.mutrate_n/(params.mutrate_n+params.mutrate_s)
+    pneutral = 0.0
+    if params.mutrate_n + params.mutrate_s > 0.0:
+        pneutral = params.mutrate_n/(params.mutrate_n+params.mutrate_s)
     mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
     rm = dispatch_create_GeneticMap(params.recrate, params.recregions)
 

--- a/fwdpy11/_model_params.py
+++ b/fwdpy11/_model_params.py
@@ -189,3 +189,11 @@ class ModelParams(object):
             raise TypeError("gvalue cannot be None")
         if self.rates is None:
             raise TypeError("rates cannot be None")
+        if self.rates[1] > 0 and len(self.sregions) == 0:
+            raise TypeError(
+                "mutation rate to selected variants is > 0 but no Sregions are defined")
+        if self.rates[0] > 0 and len(self.nregions) == 0:
+            raise TypeError(
+                "mutation rate to neutral variants is > 0 but no Regions are defined")
+                
+

--- a/fwdpy11/_model_params.py
+++ b/fwdpy11/_model_params.py
@@ -190,10 +190,10 @@ class ModelParams(object):
         if self.rates is None:
             raise TypeError("rates cannot be None")
         if self.rates[1] > 0 and len(self.sregions) == 0:
-            raise TypeError(
+            raise ValueError(
                 "mutation rate to selected variants is > 0 but no Sregions are defined")
         if self.rates[0] > 0 and len(self.nregions) == 0:
-            raise TypeError(
+            raise ValueError(
                 "mutation rate to neutral variants is > 0 but no Regions are defined")
-                
-
+        # if self.rates[2] > 0 and len(self.recregions) == 0:
+        #     raise ValueError("recombination rate is > 0 but no Regions are defined")

--- a/fwdpy11/headers/fwdpy11/regions/MutationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/MutationRegions.hpp
@@ -18,7 +18,9 @@ namespace fwdpy11
         MutationRegions(std::vector<std::unique_ptr<Sregion>>&& r,
                         std::vector<double>&& w)
             : regions(std::move(r)), weights(std::move(w)),
-              lookup(gsl_ran_discrete_preproc(weights.size(), weights.data()))
+              lookup(weights.empty() ? nullptr
+                                     : gsl_ran_discrete_preproc(
+                                         weights.size(), weights.data()))
         {
         }
 

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -32,8 +32,17 @@ namespace fwdpy11
                 {
                     weights.push_back(reg.weight);
                 }
-            lookup.reset(
-                gsl_ran_discrete_preproc(weights.size(), weights.data()));
+            if (!weights.empty())
+                {
+                    lookup.reset(gsl_ran_discrete_preproc(weights.size(),
+                                                          weights.data()));
+                }
+            else if (rate > 0.0)
+                {
+                    throw std::invalid_argument(
+                        "recombination rate > 0 incompatible with empty "
+                        "regions");
+                }
         }
 
         std::vector<double>

--- a/fwdpy11/src/evolve_population/no_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/no_tree_sequences.cc
@@ -92,6 +92,11 @@ evolve_without_tree_sequences(
             throw std::invalid_argument(
                 "selected mutation rate must be non-negative");
         }
+    if (mu_neutral + mu_selected > 0.0 && mmodel.weights.empty())
+        {
+            throw std::invalid_argument(
+                "nonzero mutation rate incompatible with empty regions");
+        }
     const std::uint32_t num_generations
         = static_cast<std::uint32_t>(popsizes.size());
     if (!num_generations)

--- a/fwdpy11/src/evolve_population/no_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/no_tree_sequences.cc
@@ -66,7 +66,7 @@ void
 evolve_without_tree_sequences(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
     py::array_t<std::uint32_t> popsizes, const double mu_neutral,
-    const double mu_selected, const double recrate,
+    const double mu_selected, 
     const fwdpy11::MutationRegions &mmodel, const fwdpy11::GeneticMap &rmodel,
     fwdpy11::DiploidPopulationGeneticValue &genetic_value_fxn,
     fwdpy11::DiploidPopulation_temporal_sampler recorder,

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -80,6 +80,11 @@ evolve_with_tree_sequences(
             throw std::invalid_argument(
                 "selected mutation rate must be non-negative");
         }
+    if (mu_selected > 0.0 && mmodel.weights.empty())
+        {
+            throw std::invalid_argument(
+                "nonzero mutation rate incompatible with empty regions");
+        }
     const std::uint32_t num_generations
         = static_cast<std::uint32_t>(popsizes.size());
     if (!num_generations)
@@ -114,8 +119,9 @@ evolve_with_tree_sequences(
 
     const auto bound_rmodel = [&rng, &rmodel]() { return rmodel(rng); };
 
-    auto genetics = fwdpp::make_genetic_parameters(
-        std::ref(genetic_value_fxn), std::move(bound_mmodel), std::move(bound_rmodel));
+    auto genetics = fwdpp::make_genetic_parameters(std::ref(genetic_value_fxn),
+                                                   std::move(bound_mmodel),
+                                                   std::move(bound_rmodel));
     // A stateful fitness model will need its data up-to-date,
     // so we must call update(...) prior to calculating fitness,
     // else bad stuff like segfaults could happen.

--- a/fwdpy11/src/regions/RecombinationRegions.cc
+++ b/fwdpy11/src/regions/RecombinationRegions.cc
@@ -34,6 +34,10 @@ init_RecombinationRegions(py::module& m)
 
     m.def("dispatch_create_GeneticMap",
           [](py::object o, std::vector<fwdpy11::Region>& regions) {
+              if (regions.empty() && o.is_none())
+                  {
+                      return fwdpy11::RecombinationRegions(0.0, regions);
+                  }
               return fwdpy11::RecombinationRegions(o.cast<double>(), regions);
           });
 


### PR DESCRIPTION
1. Allows MutationRegions to be constructed with no regions.
2. ModelParams.validate now checks if there is a mismatch between
nonzero mutation rates and empty region lists.
3. The C++ evolve functions also check this requirement.

Fixes #238