### PR TITLE
Add fwdpy11.gsl_version.

### DIFF
--- a/fwdpy11/src/gsl/init.cc
+++ b/fwdpy11/src/gsl/init.cc
@@ -1,10 +1,30 @@
+#include <sstream>
+#include <gsl/gsl_version.h>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 void init_gsl_random(py::module&);
 
-void init_GSL(py::module & m)
+void
+init_GSL(py::module& m)
 {
     init_gsl_random(m);
+
+    m.def(
+        "gsl_version",
+        []() {
+            py::dict rv;
+            std::ostringstream o;
+            o << GSL_MAJOR_VERSION << '.' << GSL_MINOR_VERSION;
+            rv["gsl_version"] = o.str();
+            return rv;
+        },
+        R"delim(
+    Returns the version of the GSL used to compile fwdpy11.
+
+    :rtype: dict
+    
+    .. versionadded:: 0.5.0
+    )delim");
 }


### PR DESCRIPTION
Add a function to return a dict describing the version of GSL used to compile fwdpy11.