### PR TITLE
Update to changes in molpopgen/fwdpp#211

### DIFF
--- a/doc/pages/introexample.rst
+++ b/doc/pages/introexample.rst
@@ -254,7 +254,7 @@ optimum.
         samples_at_t = np.where(mdtimes == t)[0]
         rsamples = np.random.choice(samples_at_t, 25, replace=False)
         rsamples_nodes = all_md['nodes'][rsamples,:].flatten()
-        vi = fwdpy11.VariantIterator(pop.tables, pop.mutations, rsamples_nodes)
+        vi = fwdpy11.VariantIterator(pop.tables, rsamples_nodes)
         ssh = 0.0
         for v in vi:
             g = v.genotypes
@@ -292,7 +292,7 @@ of :class:`fwdpy11.VariantIterator`:
 
     current_generation = np.array([i for i in range(2*pop.N)], dtype=np.int32)
     nmuts_ts = np.zeros(2*pop.N, dtype=np.int32)
-    vi = fwdpy11.VariantIterator(pop.tables, pop.mutations,
+    vi = fwdpy11.VariantIterator(pop.tables,
                                  current_generation,
                                  include_neutral_variants=False)
     for v in vi:
@@ -321,7 +321,6 @@ tree sequence:
     remapped_samples = idmap[current_generation]
     nmuts_simplified_ts = np.zeros(len(remapped_samples), dtype=np.int32)
     vi = fwdpy11.VariantIterator(tables,
-                                 pop.mutations,
                                  remapped_samples,
                                  include_neutral_variants=False)
     for v in vi:

--- a/doc/pages/introexample.rst
+++ b/doc/pages/introexample.rst
@@ -317,7 +317,7 @@ tree sequence:
 
 .. ipython:: python
 
-    tables, idmap = fwdpy11.simplify_tables(pop.tables, pop.mutations, current_generation)
+    tables, idmap = fwdpy11.simplify_tables(pop.tables, current_generation)
     remapped_samples = idmap[current_generation]
     nmuts_simplified_ts = np.zeros(len(remapped_samples), dtype=np.int32)
     vi = fwdpy11.VariantIterator(tables,

--- a/doc/pages/introexample.rst
+++ b/doc/pages/introexample.rst
@@ -258,7 +258,7 @@ optimum.
         ssh = 0.0
         for v in vi:
             g = v.genotypes
-            r = v.record
+            r = v.records[0]
             if pop.mutations[r.key].neutral is True:
                 daf = float(g.sum())
                 het = 2*daf*(len(g)-daf)/float(len(g)*(len(g)-1))
@@ -297,7 +297,7 @@ of :class:`fwdpy11.VariantIterator`:
                                  include_neutral_variants=False)
     for v in vi:
         g = v.genotypes
-        r = v.record
+        r = v.records[0]
         if pop.mutations[r.key].neutral is False:
             who = np.where(g == 1)[0]
             nmuts_ts[who] += 1
@@ -325,7 +325,7 @@ tree sequence:
                                  include_neutral_variants=False)
     for v in vi:
         g = v.genotypes
-        r = v.record
+        r = v.records[0]
         if pop.mutations[r.key].neutral is False:
             who = np.where(g == 1)[0]
             nmuts_simplified_ts[who] += 1

--- a/doc/pages/objectoverview.rst
+++ b/doc/pages/objectoverview.rst
@@ -176,11 +176,10 @@ to filter on neutral-vs-selected because neutral mutations have been added to th
 
     keys = []
     vi = fwdpy11.VariantIterator(pop.tables,
-                                 pop.mutations,
                                  pop.diploid_metadata[0].nodes,
                                  include_neutral_variants=False)
     for v in vi:
-        r = v.record
+        r = v.records[0]
         keys.append(r.key)
     print(keys)
 
@@ -196,11 +195,10 @@ Let's create the full genotype matrix for this individual at selected variants:
 
     genotypes = np.array([], dtype=np.int8)
     vi = fwdpy11.VariantIterator(pop.tables,
-                                 pop.mutations,
                                  pop.diploid_metadata[0].nodes,
                                  include_neutral_variants=False)
     for v in vi:
-        r = v.record
+        r = v.records[0]
         genotypes = np.concatenate((genotypes, v.genotypes))
     genotypes = genotypes.reshape(len(keys), 2)
     print(genotypes)

--- a/doc/pages/working_with_genotypes_trees.rst
+++ b/doc/pages/working_with_genotypes_trees.rst
@@ -58,7 +58,7 @@ We may obtain the genotypes for the samples all at once using the following func
 
 .. ipython:: python
 
-   dm = fwdpy11.data_matrix_from_tables(pop.tables, pop.mutations, [i for i in range(50)],
+   dm = fwdpy11.data_matrix_from_tables(pop.tables, [i for i in range(50)],
                                         record_neutral=False,
                                         record_selected=True,
                                         include_fixations=True)

--- a/doc/pages/working_with_genotypes_trees.rst
+++ b/doc/pages/working_with_genotypes_trees.rst
@@ -15,7 +15,7 @@ To do so, we use :class:`fwdpy11.VariantIterator` to traverse each mutation:
 
    neutral_sfs = np.zeros(50)
    selected_sfs = np.zeros(50)
-   vi = fwdpy11.VariantIterator(pop.tables, pop.mutations, [i for i in range(50)])
+   vi = fwdpy11.VariantIterator(pop.tables, [i for i in range(50)])
    for v in vi:
        n = pop.mutations[v.record.key].neutral
        g = v.genotypes

--- a/doc/pages/working_with_genotypes_trees.rst
+++ b/doc/pages/working_with_genotypes_trees.rst
@@ -17,7 +17,7 @@ To do so, we use :class:`fwdpy11.VariantIterator` to traverse each mutation:
    selected_sfs = np.zeros(50)
    vi = fwdpy11.VariantIterator(pop.tables, [i for i in range(50)])
    for v in vi:
-       n = pop.mutations[v.record.key].neutral
+       n = pop.mutations[v.records[0].key].neutral
        g = v.genotypes
        daf = g.sum()
        if n is True:

--- a/doc/pages/working_with_genotypes_trees.rst
+++ b/doc/pages/working_with_genotypes_trees.rst
@@ -91,7 +91,7 @@ the previous example, and tests that the data are identical:
     windows = [(0, 0.25), (0.75, 1.0)]
     selected_genotypes = np.array(dm.selected)
     p = np.array(dm.selected.positions)
-    dmi = fwdpy11.DataMatrixIterator(pop.tables, pop.mutations,
+    dmi = fwdpy11.DataMatrixIterator(pop.tables,
                                     [i for i in range(50)], windows,
                                     neutral=False, selected=True, fixations=True)
     for i,j in zip(dmi, windows):

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -6,10 +6,12 @@ set(FWDPP_TYPES_SOURCES src/fwdpp_types/init.cc
     src/fwdpp_types/Node.cc
     src/fwdpp_types/Edge.cc
     src/fwdpp_types/MutationRecord.cc
+    src/fwdpp_types/Site.cc
     src/fwdpp_types/IndexedEdge.cc
     src/fwdpp_types/NodeTable.cc
     src/fwdpp_types/EdgeTable.cc
     src/fwdpp_types/MutationTable.cc
+    src/fwdpp_types/SiteTable.cc
     src/fwdpp_types/TableCollection.cc)
 
 set(FWDPP_FUNCTIONS_SOURCES src/fwdpp_functions/init.cc

--- a/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
@@ -118,9 +118,9 @@ namespace fwdpy11
                                  pop.diploid_metadata);
                 // Update nodes of for offspring
                 offspring_metadata[next_offspring].nodes[0]
-                    = next_index_local - 2;
-                offspring_metadata[next_offspring].nodes[1]
                     = next_index_local - 1;
+                offspring_metadata[next_offspring].nodes[1]
+                    = next_index_local;
             }
         assert(next_index_local
                == next_index + 2 * static_cast<std::int32_t>(N_next) - 1);

--- a/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
@@ -77,7 +77,8 @@ namespace fwdpy11
     {
         fwdpp::debug::all_haploid_genomes_extant(pop);
 
-        genetics.haploid_genome_recycling_bin = fwdpp::make_haploid_genome_queue(pop.haploid_genomes);
+        genetics.haploid_genome_recycling_bin
+            = fwdpp::make_haploid_genome_queue(pop.haploid_genomes);
 
         fwdpp::zero_out_haploid_genomes(pop);
 
@@ -98,12 +99,16 @@ namespace fwdpy11
                     first_parental_index, p1, offspring_data.first.swapped);
                 auto p2id = fwdpp::ts::get_parent_ids(
                     first_parental_index, p2, offspring_data.second.swapped);
-                tables.add_offspring_data(
-                    next_index_local++, offspring_data.first.breakpoints,
-                    offspring_data.first.mutation_keys, p1id, 0, generation);
-                tables.add_offspring_data(
-                    next_index_local++, offspring_data.second.breakpoints,
-                    offspring_data.second.mutation_keys, p2id, 0, generation);
+                next_index_local = tables.register_diploid_offspring(
+                    offspring_data.first.breakpoints, p1id, 0, generation);
+                fwdpp::ts::record_mutations_infinite_sites(
+                    next_index_local, pop.mutations,
+                    offspring_data.first.mutation_keys, tables);
+                next_index_local = tables.register_diploid_offspring(
+                    offspring_data.second.breakpoints, p2id, 0, generation);
+                fwdpp::ts::record_mutations_infinite_sites(
+                    next_index_local, pop.mutations,
+                    offspring_data.second.mutation_keys, tables);
 
                 // Give the caller a chance to generate
                 // any metadata for the offspring that
@@ -118,7 +123,7 @@ namespace fwdpy11
                     = next_index_local - 1;
             }
         assert(next_index_local
-               == next_index + 2 * static_cast<std::int32_t>(N_next));
+               == next_index + 2 * static_cast<std::int32_t>(N_next) - 1);
         // This is constant-time
         pop.diploids.swap(offspring);
         pop.diploid_metadata.swap(offspring_metadata);

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -47,10 +47,10 @@ namespace fwdpy11
                     const bool simulating_neutral_variants,
                     const bool suppress_edge_table_indexing)
     {
-        tables.sort_tables(pop.mutations);
+        tables.sort_tables_for_simplification();
         std::vector<std::int32_t> samples(num_samples);
         std::iota(samples.begin(), samples.end(), first_sample_node);
-        auto rv = simplifier.simplify(tables, samples, pop.mutations);
+        auto rv = simplifier.simplify(tables, samples);
 
         for (auto &s : samples)
             {

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -77,18 +77,19 @@ namespace fwdpy11
         // TODO: better fixation handling via accounting for number of ancient samples
         if (!preserve_selected_fixations && !simulating_neutral_variants)
             {
-                tables.mutation_table.erase(
-                    std::remove_if(
-                        tables.mutation_table.begin(),
-                        tables.mutation_table.end(),
-                        [&pop, &mcounts_from_preserved_nodes](
-                            const fwdpp::ts::mutation_record &mr) {
-                            return pop.mcounts[mr.key]
-                                       == 2 * pop.diploids.size()
-                                   && mcounts_from_preserved_nodes[mr.key]
-                                          == 0;
-                        }),
-                    tables.mutation_table.end());
+                auto itr = std::remove_if(
+                    tables.mutation_table.begin(), tables.mutation_table.end(),
+                    [&pop, &mcounts_from_preserved_nodes](
+                        const fwdpp::ts::mutation_record &mr) {
+                        return pop.mcounts[mr.key] == 2 * pop.diploids.size()
+                               && mcounts_from_preserved_nodes[mr.key] == 0;
+                    });
+                auto d = std::distance(itr, end(tables.mutation_table));
+                tables.mutation_table.erase(itr, end(tables.mutation_table));
+                if (d)
+                    {
+                        tables.rebuild_site_table();
+                    }
                 fwdpp::ts::remove_fixations_from_haploid_genomes(
                     pop.haploid_genomes, pop.mutations, pop.mcounts,
                     mcounts_from_preserved_nodes, 2 * pop.diploids.size(),

--- a/fwdpy11/src/fwdpp_types/MutationRecord.cc
+++ b/fwdpy11/src/fwdpp_types/MutationRecord.cc
@@ -35,7 +35,8 @@ init_ts_MutationRecord(py::module& m)
                  std::ostringstream out;
                  out << "MutationRecord(node=" << self.node
                      << ", key=" << self.key << ", site=" << self.site
-                     << ", derived_state = " << self.derived_state
+                     << ", derived_state = "
+                     << static_cast<int>(self.derived_state)
                      << ", neutral = " << self.neutral << ')';
                  return out.str();
              })

--- a/fwdpy11/src/fwdpp_types/MutationRecord.cc
+++ b/fwdpy11/src/fwdpp_types/MutationRecord.cc
@@ -8,7 +8,8 @@ namespace py = pybind11;
 void
 init_ts_MutationRecord(py::module& m)
 {
-    PYBIND11_NUMPY_DTYPE(fwdpp::ts::mutation_record, node, key);
+    PYBIND11_NUMPY_DTYPE(fwdpp::ts::mutation_record, node, key, site,
+                         derived_state, neutral);
     py::class_<fwdpp::ts::mutation_record>(m, "MutationRecord",
                                            R"delim(
             A mutation entry in a tree sequence. A MutationRecord
@@ -21,21 +22,36 @@ init_ts_MutationRecord(py::module& m)
                       "Node id of the mutation")
         .def_readonly("key", &fwdpp::ts::mutation_record::key,
                       "Index of the mutation in the population")
+        .def_readonly("site", &fwdpp::ts::mutation_record::key,
+                      "Index of the mutation's site in the population")
+        .def_readonly("derived_state",
+                      &fwdpp::ts::mutation_record::derived_state,
+                      "The derived state of the mutation")
+        .def_readonly("neutral", &fwdpp::ts::mutation_record::neutral,
+                      "Boolean descriptor of whether or not the mutation "
+                      "affects fitness.")
         .def("__repr__",
              [](const fwdpp::ts::mutation_record& self) {
                  std::ostringstream out;
                  out << "MutationRecord(node=" << self.node
-                     << ", key=" << self.key << ")";
+                     << ", key=" << self.key << ", site=" << self.site
+                     << ", derived_state = " << self.derived_state
+                     << ", neutral = " << self.neutral << ')';
                  return out.str();
              })
         .def(py::pickle(
             [](const fwdpp::ts::mutation_record& m) {
-                return py::make_tuple(m.node, m.key);
+                return py::make_tuple(m.node, m.key, m.site, m.derived_state,
+                                      m.neutral);
             },
             [](py::tuple t) {
                 return fwdpp::ts::mutation_record{
                     t[0].cast<decltype(fwdpp::ts::mutation_record::node)>(),
-                    t[1].cast<decltype(fwdpp::ts::mutation_record::key)>()
+                    t[1].cast<decltype(fwdpp::ts::mutation_record::key)>(),
+                    t[2].cast<decltype(fwdpp::ts::mutation_record::site)>(),
+                    t[3].cast<decltype(
+                        fwdpp::ts::mutation_record::derived_state)>(),
+                    t[4].cast<decltype(fwdpp::ts::mutation_record::neutral)>()
                 };
             }));
 }

--- a/fwdpy11/src/fwdpp_types/Site.cc
+++ b/fwdpy11/src/fwdpp_types/Site.cc
@@ -1,0 +1,40 @@
+#include <fwdpp/ts/site.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <sstream>
+
+namespace py = pybind11;
+
+void
+init_ts_Site(py::module& m)
+{
+    PYBIND11_NUMPY_DTYPE(fwdpp::ts::site, position, ancestral_state);
+
+    py::class_<fwdpp::ts::site>(m, "Site",
+                                R"delim(
+        A site in a genome
+
+        .. versionadded:: 0.5.0
+        )delim")
+        .def_readonly("position", &fwdpp::ts::site::position,
+                      "The position of the site in the genome")
+        .def_readonly("ancestral_state", &fwdpp::ts::site::ancestral_state,
+                      "The ancestral state of the site")
+        .def("__repr__",
+             [](const fwdpp::ts::site& self) {
+                 std::ostringstream out;
+                 out << "Site(position = " << self.position
+                     << ", ancestral_state = "
+                     << static_cast<int>(self.ancestral_state) << ')';
+                 return out.str();
+             })
+        .def(py::pickle(
+            [](const fwdpp::ts::site& self) {
+                return py::make_tuple(self.position, self.ancestral_state);
+            },
+            [](py::tuple t) {
+                return fwdpp::ts::site{ t[0].cast<double>(),
+                                        t[1].cast<std::int8_t>() };
+            }));
+}
+

--- a/fwdpy11/src/fwdpp_types/SiteTable.cc
+++ b/fwdpy11/src/fwdpp_types/SiteTable.cc
@@ -1,0 +1,36 @@
+#include <fwdpp/ts/site.hpp>
+#include <fwdpy11/util/convert_lists.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+namespace py = pybind11;
+
+PYBIND11_MAKE_OPAQUE(std::vector<fwdpp::ts::site>);
+
+void
+init_ts_SiteTable(py::module& m)
+{
+    py::bind_vector<std::vector<fwdpp::ts::site>>(
+        m, "SiteTable", py::buffer_protocol(), py::module_local(false),
+        R"delim(
+        An SiteTable is a container of :class:`fwdpy11.Site`.
+
+        An SiteTable supports the Python buffer protocol, allowing data
+        to be viewed in Python as a numpy record array.  No copy is made
+        when generating such views.
+
+        .. versionadded:: 0.5.0
+        )delim")
+        .def(py::pickle(
+            [](const std::vector<fwdpp::ts::site>& self) {
+                return fwdpy11::vector_to_list(self);
+            },
+            [](py::list l) {
+                return fwdpy11::list_to_vector<
+                    std::vector<fwdpp::ts::site>>(l);
+            }));
+}
+
+

--- a/fwdpy11/src/fwdpp_types/TableCollection.cc
+++ b/fwdpy11/src/fwdpp_types/TableCollection.cc
@@ -32,6 +32,9 @@ init_ts_TableCollection(py::module& m)
         .def_readonly("mutations",
                       &fwdpp::ts::table_collection::mutation_table,
                       "The :class:`fwdpy11.MutationTable`.")
+        .def_readonly("sites",
+                      &fwdpp::ts::table_collection::site_table,
+                      "The :class:`fwdpy11.SiteTable`.")
         .def_readonly("input_left", &fwdpp::ts::table_collection::input_left)
         .def_readonly("output_right",
                       &fwdpp::ts::table_collection::output_right)

--- a/fwdpy11/src/fwdpp_types/TableCollection.cc
+++ b/fwdpy11/src/fwdpp_types/TableCollection.cc
@@ -10,6 +10,7 @@ namespace py = pybind11;
 PYBIND11_MAKE_OPAQUE(fwdpp::ts::edge_vector);
 PYBIND11_MAKE_OPAQUE(fwdpp::ts::node_vector);
 PYBIND11_MAKE_OPAQUE(fwdpp::ts::mutation_key_vector);
+PYBIND11_MAKE_OPAQUE(fwdpp::ts::site_vector);
 
 void
 init_ts_TableCollection(py::module& m)
@@ -50,6 +51,7 @@ init_ts_TableCollection(py::module& m)
                     fwdpy11::vector_to_list(tables.node_table),
                     fwdpy11::vector_to_list(tables.edge_table),
                     fwdpy11::vector_to_list(tables.mutation_table),
+                    fwdpy11::vector_to_list(tables.site_table),
                     fwdpy11::vector_to_list(tables.preserved_nodes));
             },
             [](py::tuple t) {
@@ -64,9 +66,12 @@ init_ts_TableCollection(py::module& m)
                 tables.mutation_table
                     = fwdpy11::list_to_vector<fwdpp::ts::mutation_key_vector>(
                         t[3].cast<py::list>());
+                tables.site_table
+                    = fwdpy11::list_to_vector<fwdpp::ts::site_vector>(
+                        t[4].cast<py::list>());
                 tables.preserved_nodes = fwdpy11::list_to_vector<decltype(
                     fwdpp::ts::table_collection::preserved_nodes)>(
-                    t[4].cast<py::list>());
+                    t[5].cast<py::list>());
                 tables.build_indexes();
                 return tables;
             }));

--- a/fwdpy11/src/fwdpp_types/init.cc
+++ b/fwdpy11/src/fwdpp_types/init.cc
@@ -8,10 +8,12 @@ void init_data_matrix(py::module &);
 void init_ts_Node(py::module &);
 void init_ts_Edge(py::module &);
 void init_ts_MutationRecord(py::module &);
+void init_ts_Site(py::module &m);
 void init_NULL_NODE(py::module &);
 void init_ts_NodeTable(py::module &m);
 void init_ts_EdgeTable(py::module &m);
 void init_ts_MutationTable(py::module &);
+void init_ts_SiteTable(py::module &);
 void init_ts_TableCollection(py::module &);
 
 void
@@ -26,8 +28,10 @@ initialize_fwdpp_types(py::module &m)
     init_ts_Node(m);
     init_ts_Edge(m);
     init_ts_MutationRecord(m);
+    init_ts_Site(m);
     init_ts_NodeTable(m);
     init_ts_EdgeTable(m);
     init_ts_MutationTable(m);
+    init_ts_SiteTable(m);
     init_ts_TableCollection(m);
 }

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -12,8 +12,6 @@
 
 namespace py = pybind11;
 
-PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Mutation>);
-
 class DataMatrixIterator
 // Encapsulate fwdpp::ts::tree_visitor and fwdpp::data_matrix
 // to provide very fast interation over multiple genomic intervals.
@@ -417,7 +415,6 @@ class DataMatrixIterator
 
   public:
     DataMatrixIterator(const fwdpp::ts::table_collection& tables,
-                       const std::vector<fwdpy11::Mutation>& mutations,
                        const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                        const std::vector<std::pair<double, double>>& intervals,
                        bool neutral, bool selected, bool fixations)
@@ -556,18 +553,15 @@ init_DataMatrixIterator(py::module& m)
         .. versionadded:: 0.4.4
         )delim")
         .def(py::init<const fwdpp::ts::table_collection&,
-                      const std::vector<fwdpy11::Mutation>&,
                       const std::vector<fwdpp::ts::TS_NODE_INT>&,
                       const std::vector<std::pair<double, double>>&, bool,
                       bool, bool>(),
-             py::arg("tables"), py::arg("mutations"), py::arg("samples"),
+             py::arg("tables"), py::arg("samples"),
              py::arg("intervals"), py::arg("neutral"), py::arg("selected"),
              py::arg("fixations") = false,
              R"delim(
         :param tables: A table collection
         :type tables: :class:`fwdpy11.TableCollection`
-        :param mutations: The mutations from the simulation
-        :type mutations: :class:`fwdpy11.MutationVector`
         :param samples: A list of samples
         :type samples: List-like
         :param intervals: The :math:`[start, stop)` positions of each interval
@@ -578,6 +572,10 @@ init_DataMatrixIterator(py::module& m)
         :type selected: boolean
         :param fixations: (False) If True, include fixations in the sample
         :type fixations: boolean
+
+        .. versionchanged:: 0.5.0
+            
+            No longer requires :class:`fwdpy11.MutationVector`
         )delim")
         .def("__iter__",
              [](DataMatrixIterator& v) -> DataMatrixIterator& { return v; })

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -26,7 +26,7 @@ class DataMatrixIterator
     using mut_table_itr = fwdpp::ts::mutation_key_vector::const_iterator;
     std::unique_ptr<fwdpp::ts::tree_visitor> current_tree, next_tree;
     const std::vector<std::pair<double, double>> position_ranges;
-    std::vector<std::int8_t> genotypes, is_neutral;
+    std::vector<std::int8_t> genotypes;
     std::vector<double> mutation_positions;
     std::unique_ptr<fwdpp::data_matrix> dmatrix;
     const site_table_itr sbeg, send;
@@ -413,7 +413,7 @@ class DataMatrixIterator
                        bool neutral, bool selected, bool fixations)
         : current_tree(initialize_current_tree(tables, samples)),
           next_tree(nullptr), position_ranges(init_intervals(intervals)),
-          genotypes(samples.size(), 0), is_neutral(set_neutral(mutations)),
+          genotypes(samples.size(), 0), 
           mutation_positions(set_positions(mutations)),
           dmatrix(new fwdpp::data_matrix(samples.size())),
           sbeg(begin(tables.site_table)), send(end(tables.site_table)),

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -41,8 +41,8 @@ class DataMatrixIterator
                             const std::vector<fwdpp::ts::TS_NODE_INT>& samples)
     {
         std::unique_ptr<fwdpp::ts::tree_visitor> rv(
-            new fwdpp::ts::tree_visitor(tables, samples));
-        auto flag = rv->operator()(std::true_type(), std::true_type());
+            new fwdpp::ts::tree_visitor(tables, samples, fwdpp::ts::update_samples_list(true)));
+        auto flag = rv->operator()();
         if (flag == false)
             {
                 throw std::invalid_argument(
@@ -137,7 +137,7 @@ class DataMatrixIterator
 
         while (current_right < first_left)
             {
-                current_tree->operator()(std::true_type(), std::true_type());
+                current_tree->operator()();
                 current_right = current_tree->tree().right;
             }
         double current_tree_left = current_tree->tree().left;
@@ -198,8 +198,7 @@ class DataMatrixIterator
         auto l = position_ranges[current_range].first;
         while (current_tree->tree().right < l)
             {
-                auto flag = current_tree->operator()(std::true_type(),
-                                                     std::true_type());
+                auto flag = current_tree->operator()();
                 if (!flag)
                     {
                         break;
@@ -384,7 +383,7 @@ class DataMatrixIterator
                 return;
             }
         auto lc = tree.leaf_counts[mitr->node];
-        bool fixed = (lc == tree.sample_size);
+        std::size_t fixed = (lc == tree.sample_size());
         if (lc > 0 && (!fixed || (fixed && include_fixations)))
             {
                 bool mut_is_neutral = is_neutral[mitr->key];
@@ -473,8 +472,7 @@ class DataMatrixIterator
                     {
                         process_current_mutation(tree, mcurrent);
                     }
-                iteration_flag = current_tree->operator()(std::true_type(),
-                                                          std::true_type());
+                iteration_flag = current_tree->operator()();
                 tree_in_current_range
                     = (current_tree->tree().left
                        < position_ranges[current_range].second);

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -22,15 +22,14 @@ class DataMatrixIterator
 // next interval without having to initiate a new tree_visitor.
 {
   private:
-    using mut_table_itr
-        = std::vector<fwdpp::ts::mutation_record>::const_iterator;
+    using site_table_itr = fwdpp::ts::site_vector::const_iterator;
     std::unique_ptr<fwdpp::ts::tree_visitor> current_tree, next_tree;
     const std::vector<std::pair<double, double>> position_ranges;
     std::vector<std::int8_t> genotypes, is_neutral;
     std::vector<double> mutation_positions;
     std::unique_ptr<fwdpp::data_matrix> dmatrix;
-    const mut_table_itr mbeg, mend;
-    mut_table_itr mcurrent;
+    const site_table_itr sbeg, send;
+    site_table_itr scurrent;
     std::size_t current_range;
     const bool include_neutral_variants, include_selected_variants,
         include_fixations;
@@ -41,7 +40,8 @@ class DataMatrixIterator
                             const std::vector<fwdpp::ts::TS_NODE_INT>& samples)
     {
         std::unique_ptr<fwdpp::ts::tree_visitor> rv(
-            new fwdpp::ts::tree_visitor(tables, samples, fwdpp::ts::update_samples_list(true)));
+            new fwdpp::ts::tree_visitor(tables, samples,
+                                        fwdpp::ts::update_samples_list(true)));
         auto flag = rv->operator()();
         if (flag == false)
             {
@@ -113,18 +113,17 @@ class DataMatrixIterator
         return p;
     }
 
-    mut_table_itr
-    find_first_mutation_record(mut_table_itr b, mut_table_itr e,
+    site_table_itr
+    find_first_mutation_record(site_table_itr b, site_table_itr e,
                                const double start)
     {
         return std::lower_bound(
-            b, e, start,
-            [this](const fwdpp::ts::mutation_record& mr, const double v) {
-                return mutation_positions[mr.key] < v;
+            b, e, start, [this](const fwdpp::ts::site& s, const double v) {
+                return s.position < v;
             });
     }
 
-    mut_table_itr
+    site_table_itr
     init_trees_and_mutations()
     {
         if (current_tree == nullptr || position_ranges.empty())
@@ -141,18 +140,17 @@ class DataMatrixIterator
                 current_right = current_tree->tree().right;
             }
         double current_tree_left = current_tree->tree().left;
-        mut_table_itr firstmut = mbeg;
-        while (firstmut < mend
-               && mutation_positions[firstmut->key] < current_tree_left)
+        site_table_itr s = sbeg;
+        while (s < send && s->position < current_tree_left)
             {
-                ++firstmut;
+                ++s;
             }
-        return firstmut;
+        return s;
     }
 
-    mut_table_itr
+    site_table_itr
     find_first_mutation_record_after_current_max()
-    // After a call to cleanup_matrix, we may need to reset mcurrent
+    // After a call to cleanup_matrix, we may need to reset scurrent
     // to the first mutation AFTER dmatrix's current data.  We do so
     // here.
     {
@@ -178,13 +176,12 @@ class DataMatrixIterator
             }
         if (m == std::numeric_limits<double>::max())
             {
-                return mcurrent;
+                return scurrent;
             }
-        return std::upper_bound(
-            mcurrent, mend, m,
-            [this](double v, const fwdpp::ts::mutation_record& mr) {
-                return v < mutation_positions[mr.key];
-            });
+        return std::upper_bound(scurrent, send, m,
+                                [this](double v, const fwdpp::ts::site& s) {
+                                    return v < s.position;
+                                });
     }
 
     void
@@ -206,7 +203,7 @@ class DataMatrixIterator
             }
     }
 
-    mut_table_itr
+    site_table_itr
     advance_mutations()
     {
         matrix_requires_clearing = false;
@@ -216,21 +213,20 @@ class DataMatrixIterator
                 next_tree.reset(nullptr);
                 double left = position_ranges[current_range].first;
                 double right = position_ranges[current_range].second;
-                mcurrent = find_first_mutation_record(mbeg, mend, left);
+                scurrent = find_first_mutation_record(sbeg, send, left);
                 cleanup_matrix(left, right);
-                mcurrent = find_first_mutation_record_after_current_max();
+                scurrent = find_first_mutation_record_after_current_max();
             }
         else
             {
                 matrix_requires_clearing = true;
                 const auto& m = current_tree->tree();
-                while (mcurrent < mend
-                       && mutation_positions[mcurrent->key] < m.left)
+                while (scurrent < send && scurrent->position < m.left)
                     {
-                        ++mcurrent;
+                        ++scurrent;
                     }
             }
-        return mcurrent;
+        return scurrent;
     }
 
     void
@@ -335,7 +331,7 @@ class DataMatrixIterator
     void
     check_if_still_iterating()
     {
-        if (!(mcurrent < mend) || current_range >= position_ranges.size())
+        if (!(scurrent < send) || current_range >= position_ranges.size())
             {
                 release_memory();
                 throw py::stop_iteration();
@@ -356,9 +352,9 @@ class DataMatrixIterator
     }
 
     bool
-    mutation_in_current_range(const mut_table_itr mitr)
+    site_in_current_range(const site_table_itr itr)
     {
-        if (!(mitr < mend))
+        if (!(itr < send))
             {
                 return false;
             }
@@ -366,41 +362,21 @@ class DataMatrixIterator
             {
                 throw std::runtime_error("DataMatrixIterator fatal error");
             }
-        auto pos = mutation_positions[mitr->key];
+        auto pos = itr->position;
         return pos >= position_ranges[current_range].first
                && pos < position_ranges[current_range].second;
     }
 
     void
-    process_current_mutation(const fwdpp::ts::marginal_tree& tree,
-                             const mut_table_itr mitr)
+    process_current_site(const fwdpp::ts::marginal_tree& tree,
+                             const site_table_itr itr)
     {
         // Make sure we skip mutants on the
         // current tree but not in the current
         // genomic interval.
-        if (!mutation_in_current_range(mitr))
+        if (!site_in_current_range(itr))
             {
                 return;
-            }
-        auto lc = tree.leaf_counts[mitr->node];
-        std::size_t fixed = (lc == tree.sample_size());
-        if (lc > 0 && (!fixed || (fixed && include_fixations)))
-            {
-                bool mut_is_neutral = is_neutral[mitr->key];
-                bool tracking_n = (mut_is_neutral && include_neutral_variants);
-                bool tracking_s
-                    = (!mut_is_neutral && include_selected_variants);
-                if (tracking_n || tracking_s)
-                    {
-                        auto index = tree.left_sample[mitr->node];
-                        if (index != fwdpp::ts::TS_NULL_NODE)
-                            {
-                                fwdpp::ts::detail::process_samples(
-                                    tree, mitr->node, index, genotypes);
-                                update_data_matrix(mut_is_neutral,
-                                                   mcurrent->key);
-                            }
-                    }
             }
     }
 
@@ -428,9 +404,8 @@ class DataMatrixIterator
           genotypes(samples.size(), 0), is_neutral(set_neutral(mutations)),
           mutation_positions(set_positions(mutations)),
           dmatrix(new fwdpp::data_matrix(samples.size())),
-          mbeg(tables.mutation_table.begin()),
-          mend(tables.mutation_table.end()),
-          mcurrent(init_trees_and_mutations()), current_range(0),
+          sbeg(begin(tables.site_table)), send(begin(tables.site_table)),
+          scurrent(init_trees_and_mutations()), current_range(0),
           include_neutral_variants(neutral),
           include_selected_variants(selected), include_fixations(fixations),
           matrix_requires_clearing(false)
@@ -444,7 +419,7 @@ class DataMatrixIterator
     {
         check_if_still_iterating();
         advance_trees();
-        mcurrent = advance_mutations();
+        scurrent = advance_mutations();
         next_tree.reset(nullptr);
         if (matrix_requires_clearing)
             {
@@ -466,11 +441,10 @@ class DataMatrixIterator
                                     *current_tree));
                             }
                     }
-                for (; mcurrent < mend
-                       && mutation_positions[mcurrent->key] < tree.right;
-                     ++mcurrent)
+                for (; scurrent < send && scurrent->position < tree.right;
+                     ++scurrent)
                     {
-                        process_current_mutation(tree, mcurrent);
+                        process_current_site(tree, scurrent);
                     }
                 iteration_flag = current_tree->operator()();
                 tree_in_current_range

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -465,7 +465,8 @@ class DataMatrixIterator
                             {
                                 ++mcurrent;
                             }
-                        auto m = mcurrent++;
+                        auto m = mcurrent;
+                        m++;
                         while (m < mend
                                && (sbeg + m->site)->position
                                       == scurrent->position)

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -136,7 +136,7 @@ class DataMatrixIterator
     }
 
     site_table_itr
-    init_trees_and_mutations()
+    init_trees_and_sites()
     {
         if (current_tree == nullptr || position_ranges.empty())
             {
@@ -151,9 +151,8 @@ class DataMatrixIterator
                 current_tree->operator()();
                 current_right = current_tree->tree().right;
             }
-        double current_tree_left = current_tree->tree().left;
         site_table_itr s = sbeg;
-        while (s < send && s->position < current_tree_left)
+        while (s < send && s->position < first_left)
             {
                 ++s;
             }
@@ -417,8 +416,8 @@ class DataMatrixIterator
           genotypes(samples.size(), 0), is_neutral(set_neutral(mutations)),
           mutation_positions(set_positions(mutations)),
           dmatrix(new fwdpp::data_matrix(samples.size())),
-          sbeg(begin(tables.site_table)), send(begin(tables.site_table)),
-          scurrent(init_trees_and_mutations()),
+          sbeg(begin(tables.site_table)), send(end(tables.site_table)),
+          scurrent(init_trees_and_sites()),
           mbeg(begin(tables.mutation_table)), mend(end(tables.mutation_table)),
           mcurrent(begin(tables.mutation_table)), current_range(0),
           include_neutral_variants(neutral),

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -231,8 +231,8 @@ class DataMatrixIterator
         else
             {
                 matrix_requires_clearing = true;
-                const auto& m = current_tree->tree();
-                while (scurrent < send && scurrent->position < m.left)
+                double left = position_ranges[current_range].first;
+                while (scurrent < send && scurrent->position < left)
                     {
                         ++scurrent;
                     }

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -475,7 +475,7 @@ class DataMatrixIterator
                             }
                         fwdpp::ts::detail::process_site_range(
                             tree, scurrent, std::make_pair(mcurrent, m),
-                            include_neutral_variants, include_neutral_variants,
+                            include_neutral_variants, include_selected_variants,
                             !include_fixations, genotypes, *dmatrix);
                         mcurrent = m;
                     }

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -45,7 +45,9 @@ class tree_visitor_wrapper
                          const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                          bool update_sample_list, double start, double stop)
         : update_samples(update_sample_list), from(start), until(stop),
-          visitor(tables, samples), sample_list_buffer()
+          visitor(tables, samples,
+                  fwdpp::ts::update_samples_list(update_sample_list)),
+          sample_list_buffer()
     {
         validate_from_until(tables.genome_length());
     }
@@ -56,7 +58,9 @@ class tree_visitor_wrapper
         const std::vector<fwdpp::ts::TS_NODE_INT>& preserved_nodes,
         bool update_sample_list, double start, double stop)
         : update_samples(update_sample_list), from(start), until(stop),
-          visitor(tables, samples), sample_list_buffer()
+          visitor(tables, samples,
+                  fwdpp::ts::update_samples_list(update_sample_list)),
+          sample_list_buffer()
     {
         validate_from_until(tables.genome_length());
     }
@@ -65,21 +69,10 @@ class tree_visitor_wrapper
     operator()()
     {
         bool rv = false;
-        if (update_samples)
+        rv = visitor();
+        while (visitor.tree().right < from)
             {
-                rv = visitor(std::true_type(), std::true_type());
-                while (visitor.tree().right < from)
-                    {
-                        rv = visitor(std::true_type(), std::true_type());
-                    }
-            }
-        else
-            {
-                rv = visitor(std::true_type(), std::false_type());
-                while (visitor.tree().right < from)
-                    {
-                        rv = visitor(std::true_type(), std::false_type());
-                    }
+                rv = visitor();
             }
         if (visitor.tree().left >= until)
             {
@@ -91,7 +84,7 @@ class tree_visitor_wrapper
     fwdpp::ts::TS_NODE_INT
     sample_size() const
     {
-        return visitor.tree().sample_size;
+        return visitor.tree().sample_size();
     }
 
     py::array

--- a/fwdpy11/src/ts/VariantIterator.cc
+++ b/fwdpy11/src/ts/VariantIterator.cc
@@ -3,180 +3,115 @@
 #include <pybind11/stl.h>
 #include <fwdpy11/types/Population.hpp>
 #include <fwdpy11/numpy/array.hpp>
-#include <fwdpp/ts/tree_visitor.hpp>
+#include <fwdpp/ts/site_visitor.hpp>
+#include <fwdpp/ts/marginal_tree_functions/samples.hpp>
 
 namespace py = pybind11;
-
-PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Mutation>);
 
 class VariantIterator
 {
   private:
-    using mut_table_itr
-        = std::vector<fwdpp::ts::mutation_record>::const_iterator;
-
-    mut_table_itr
-    advance_trees_and_mutations()
-    {
-        while (mbeg < mend)
-            {
-                const auto& m = tv.tree();
-                while (pos[mbeg->key] < m.left || pos[mbeg->key] >= m.right)
-                    {
-                        auto flag = tv();
-                        if (flag == false)
-                            {
-                                throw std::runtime_error(
-                                    "VariantIterator: tree traversal "
-                                    "error");
-                            }
-                    }
-                if (m.leaf_counts[mbeg->node]
-                        + m.preserved_leaf_counts[mbeg->node]
-                    != 0)
-                    {
-                        if ((neutral[mbeg->key] && include_neutral)
-                            || (!neutral[mbeg->key] && include_selected))
-                            {
-                                return mbeg;
-                            }
-                    }
-                ++mbeg;
-            }
-        return mbeg;
-    }
-
-    mut_table_itr
-    set_mbeg(mut_table_itr mtbeg, mut_table_itr mtend, const double start,
-             const std::vector<fwdpy11::Mutation>& mutations)
-    {
-        if (std::isnan(start))
-            {
-                return mtbeg;
-            }
-        return std::lower_bound(
-            mtbeg, mtend, start,
-            [&mutations](const fwdpp::ts::mutation_record& mr,
-                         const double v) {
-                return mutations[mr.key].pos < v;
-            });
-    }
-
-    mut_table_itr
-    set_mend(mut_table_itr mtbeg, mut_table_itr mtend, const double end,
-             const std::vector<fwdpy11::Mutation>& mutations)
-    {
-        if (std::isnan(end))
-            {
-                return mtend;
-            }
-        return std::upper_bound(
-            mtbeg, mtend, end,
-            [&mutations](const double v,
-                         const fwdpp::ts::mutation_record& mr) {
-                return v < mutations[mr.key].pos;
-            });
-    }
-    std::vector<double> pos;
-    std::vector<std::int8_t> neutral;
-    const bool include_neutral, include_selected;
+    using site_table_itr = fwdpp::ts::site_vector::const_iterator;
+    fwdpp::ts::site_visitor sv;
+    site_table_itr scurrent, send;
+    std::vector<std::int8_t> genotype_data;
+    bool include_neutral, include_selected;
+    double from, to;
+    fwdpp::ts::convert_sample_index_to_nodes convert;
+    py::list mutation_records;
 
   public:
-    std::vector<fwdpp::ts::mutation_record>::const_iterator mbeg, mend;
-    fwdpp::ts::tree_visitor tv;
-    std::vector<std::int8_t> genotype_data;
     py::array_t<std::int8_t> genotypes;
     double current_position;
-    fwdpp::ts::mutation_record current_record;
     VariantIterator(const fwdpp::ts::table_collection& tc,
-                    const std::vector<fwdpy11::Mutation>& mutations,
                     const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                     const double beg, const double end,
                     const bool include_neutral_variant,
                     const bool include_selected_variants)
-        : pos(), neutral(), include_neutral(include_neutral_variant),
-          include_selected(include_selected_variants),
-          mbeg(set_mbeg(tc.mutation_table.begin(), tc.mutation_table.end(),
-                        beg, mutations)),
-          mend(set_mend(mbeg, tc.mutation_table.end(), end, mutations)),
-          tv(tc, samples, fwdpp::ts::update_samples_list(true)),
-          genotype_data(samples.size(), 0),
+        : sv(tc, samples), scurrent(begin(tc.site_table)),
+          send(std::end(tc.site_table)), genotype_data(samples.size(), 0),
+          include_neutral(include_neutral_variant),
+          include_selected(include_selected_variants), from(beg), to(end),
+          convert(false), mutation_records{},
           genotypes(fwdpy11::make_1d_ndarray(genotype_data)),
-          current_position(std::numeric_limits<double>::quiet_NaN()),
-          current_record{ fwdpp::ts::TS_NULL_NODE,
-                          std::numeric_limits<std::size_t>::max() }
+          current_position(std::numeric_limits<double>::quiet_NaN())
     {
         if (!include_selected && !include_neutral)
             {
                 throw std::invalid_argument(
                     "excluding neutral and selected variants is invalid");
             }
-        if (!std::isnan(beg) && !std::isnan(end))
+        if (!std::isnan(from) && !std::isnan(to))
             {
-                if (!(end > beg))
+                if (!(to > from))
                     {
                         throw std::invalid_argument(
                             "invalid position interval");
                     }
             }
-        // Advance to first tree
-        auto flag = tv();
-        if (flag == false)
-            {
-                throw std::invalid_argument(
-                    "TableCollection contains no trees");
-            }
-        for (auto& m : mutations)
-            {
-                pos.push_back(m.pos);
-                neutral.push_back(m.neutral);
-            }
-        mbeg = advance_trees_and_mutations();
     }
 
     VariantIterator&
     next_variant()
     {
-        if (!(mbeg < mend))
+        if (!(scurrent < send) || scurrent->position >= to)
             {
                 throw py::stop_iteration();
             }
-        const auto& m = tv.tree();
-        std::fill(genotype_data.begin(), genotype_data.end(), 0);
-        auto ls = m.left_sample[mbeg->node];
-        current_position = std::numeric_limits<double>::quiet_NaN();
-        current_record.key = std::numeric_limits<std::size_t>::max();
-        current_record.node = fwdpp::ts::TS_NULL_NODE;
-        if (ls != fwdpp::ts::TS_NULL_NODE)
+        while ((scurrent = sv()) != end(sv) && scurrent->position < to)
             {
-                current_position = pos[mbeg->key];
-                current_record = *mbeg;
-                auto rs = m.right_sample[mbeg->node];
-                int nsteps = 1;
-                while (true)
+                if (scurrent->position >= from && scurrent->position < to)
                     {
-                        if (genotype_data[ls] == 1)
+                        mutation_records.attr("clear")();
+                        current_position = scurrent->position;
+                        std::fill(begin(genotype_data), end(genotype_data),
+                                  scurrent->ancestral_state);
+                        auto m = sv.get_mutations();
+                        unsigned n = 0;
+                        for (auto i = m.first; i < m.second; ++i)
                             {
-                                throw std::runtime_error(
-                                    "VariantIterator error");
+                                int ni = 0;
+                                fwdpp::ts::process_samples(
+                                    sv.current_tree(), convert, i->node,
+                                    [this, i, &ni](fwdpp::ts::TS_NODE_INT u) {
+                                        ++ni;
+                                        genotype_data[u] = i->derived_state;
+                                    });
+                                if (ni)
+                                    {
+                                        fwdpp::ts::mutation_record temp(*i);
+                                        auto o = py::cast(std::move(temp));
+                                        mutation_records.append(std::move(o));
+                                    }
+                                n += ni;
                             }
-                        genotype_data[ls] = 1;
-                        if (ls == rs)
+                        if (n)
                             {
-                                break;
+                                return *this;
                             }
-                        ls = m.next_sample[ls];
-                        ++nsteps;
-                    }
-                if (nsteps != m.leaf_counts[mbeg->node])
-                    {
-                        throw std::runtime_error(
-                            "VariantIterator: sample traversal error");
                     }
             }
-        mbeg++;
-        mbeg = advance_trees_and_mutations();
+        if (!(scurrent < send) || scurrent->position >= to)
+            {
+                throw py::stop_iteration();
+            }
         return *this;
+    }
+
+    fwdpp::ts::site
+    current_site() const
+    {
+        if (!(scurrent < send))
+            {
+                throw std::runtime_error("end of sites");
+            }
+        return *scurrent;
+    }
+
+    py::list
+    records() const
+    {
+        return mutation_records;
     }
 };
 
@@ -187,25 +122,21 @@ init_variant_iterator(py::module& m)
         m, "VariantIterator",
         "An iterable class for traversing genotypes in a tree sequence.")
         .def(py::init([](const fwdpp::ts::table_collection& tables,
-                         const std::vector<fwdpy11::Mutation>& mutations,
                          const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                          double begin, double end,
                          bool include_neutral_variants,
                          bool include_selected_variants) {
-                 return VariantIterator(tables, mutations, samples, begin, end,
+                 return VariantIterator(tables, samples, begin, end,
                                         include_neutral_variants,
                                         include_selected_variants);
              }),
-             py::arg("tables"), py::arg("mutations"), py::arg("samples"),
-             py::arg("begin") = 0.0,
+             py::arg("tables"), py::arg("samples"), py::arg("begin") = 0.0,
              py::arg("end") = std::numeric_limits<double>::max(),
              py::arg("include_neutral_variants") = true,
              py::arg("include_selected_variants") = true,
              R"delim(
              :param tables: The table collection
              :type tables: :class:`fwdpy11.TableCollection`
-             :param mutations: Mutation container
-             :type mutations: :class:`fwdpy11.MutationVector`
              :param samples: Samples list
              :type samples: list
              :param begin: (0.0) First position, inclusive.
@@ -235,8 +166,8 @@ init_variant_iterator(py::module& m)
                                         pop.tables.preserved_nodes.begin(),
                                         pop.tables.preserved_nodes.end());
                      }
-                 return VariantIterator(pop.tables, pop.mutations, samples,
-                                        begin, end, include_neutral_variants,
+                 return VariantIterator(pop.tables, samples, begin, end,
+                                        include_neutral_variants,
                                         include_selected_variants);
              }),
              py::arg("pop"), py::arg("include_preserved_nodes") = false,
@@ -269,8 +200,9 @@ init_variant_iterator(py::module& m)
         .def("__next__", &VariantIterator::next_variant)
         .def_readonly("genotypes", &VariantIterator::genotypes,
                       "Genotype array.  Index order is same as sample input")
-        .def_readonly("record", &VariantIterator::current_record,
-                      "Current mutation record")
+        .def_property_readonly("site", &VariantIterator::current_site,
+                               "Current :class:`fwdpy11.Site`")
+        .def_property_readonly("records", &VariantIterator::records)
         .def_readonly("position", &VariantIterator::current_position,
                       "Current mutation position");
 }

--- a/fwdpy11/src/ts/VariantIterator.cc
+++ b/fwdpy11/src/ts/VariantIterator.cc
@@ -23,7 +23,7 @@ class VariantIterator
                 const auto& m = tv.tree();
                 while (pos[mbeg->key] < m.left || pos[mbeg->key] >= m.right)
                     {
-                        auto flag = tv(std::true_type(), std::true_type());
+                        auto flag = tv();
                         if (flag == false)
                             {
                                 throw std::runtime_error(
@@ -99,7 +99,8 @@ class VariantIterator
           mbeg(set_mbeg(tc.mutation_table.begin(), tc.mutation_table.end(),
                         beg, mutations)),
           mend(set_mend(mbeg, tc.mutation_table.end(), end, mutations)),
-          tv(tc, samples), genotype_data(samples.size(), 0),
+          tv(tc, samples, fwdpp::ts::update_samples_list(true)),
+          genotype_data(samples.size(), 0),
           genotypes(fwdpy11::make_1d_ndarray(genotype_data)),
           current_position(std::numeric_limits<double>::quiet_NaN()),
           current_record{ fwdpp::ts::TS_NULL_NODE,
@@ -119,7 +120,7 @@ class VariantIterator
                     }
             }
         // Advance to first tree
-        auto flag = tv(std::true_type(), std::true_type());
+        auto flag = tv();
         if (flag == false)
             {
                 throw std::invalid_argument(

--- a/fwdpy11/src/ts/data_matrix_from_tables.cc
+++ b/fwdpy11/src/ts/data_matrix_from_tables.cc
@@ -9,12 +9,11 @@ PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Mutation>);
 
 fwdpp::data_matrix
 generate_data_matrix(const fwdpp::ts::table_collection& tables,
-                     const std::vector<fwdpy11::Mutation>& mutations,
                      const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                      bool record_neutral, bool record_selected, bool include_fixations, double start,
                      double stop)
 {
-    return fwdpp::ts::generate_data_matrix(tables, samples, mutations,
+    return fwdpp::ts::generate_data_matrix(tables, samples,
                                            record_neutral, record_selected, !include_fixations,
                                            start, stop);
 }
@@ -28,7 +27,7 @@ init_data_matrix_from_tables(py::module& m)
            const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
            const bool record_neutral, const bool record_selected) {
             return fwdpp::ts::generate_data_matrix(
-                pop.tables, samples, pop.mutations, record_neutral,
+                pop.tables, samples, record_neutral,
                 record_selected, true);
         },
         py::arg("pop"), py::arg("samples"), py::arg("record_neutral"),
@@ -51,7 +50,7 @@ init_data_matrix_from_tables(py::module& m)
      )delim");
 
     m.def("data_matrix_from_tables", &generate_data_matrix, py::arg("tables"),
-          py::arg("mutations"), py::arg("samples"), py::arg("record_neutral"),
+          py::arg("samples"), py::arg("record_neutral"),
           py::arg("record_selected"),
           py::arg("include_fixations") = false, py::arg("begin") = 0.0,
           py::arg("end") = std::numeric_limits<double>::max(),
@@ -60,8 +59,6 @@ init_data_matrix_from_tables(py::module& m)
      
      :param tables: A TableCollection
      :type tables: :class:`fwdpy11.ts.TableCollection`
-     :param mutations: Container of mutations
-     :type mutations: :class:`fwdpy11.VecMutation`
      :param samples: A list of sample nodes
      :type samples: list or array
      :param record_neutral: If True, generate data for neutral variants

--- a/fwdpy11/src/ts/data_matrix_from_tables.cc
+++ b/fwdpy11/src/ts/data_matrix_from_tables.cc
@@ -77,5 +77,9 @@ init_data_matrix_from_tables(py::module& m)
      .. versionchanged:: 0.4.1
         
             Add begin, end options as floats
+
+     .. versionchanged:: 0.5.0
+
+            No longer requires :class:`fwdpy11.MutationVector` argument
      )delim");
 }

--- a/fwdpy11/src/ts/infinite_sites.cc
+++ b/fwdpy11/src/ts/infinite_sites.cc
@@ -2,6 +2,7 @@
 #include <fwdpp/ts/recycling.hpp>
 #include <fwdpp/ts/mutate_tables.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
+#include <fwdpp/ts/mutation_tools.hpp>
 #include <fwdpy11/rng.hpp>
 #include <fwdpy11/types/Population.hpp>
 #include <fwdpy11/policies/mutation.hpp>
@@ -11,7 +12,7 @@ namespace py = pybind11;
 
 namespace
 {
-    inline std::size_t
+    inline fwdpp::ts::new_variant_record
     generate_neutral_variants(fwdpp::flagged_mutation_queue& recycling_bin,
                               fwdpy11::Population& pop,
                               const fwdpy11::GSLrng_t& rng, const double left,
@@ -22,51 +23,60 @@ namespace
             return gsl_ran_flat(rng.get(), left, right);
         };
         const auto return_zero = []() { return 0.0; };
-        return fwdpy11::infsites_Mutation(recycling_bin, pop.mutations,
-                                          pop.mut_lookup, generation, uniform,
-                                          return_zero, return_zero, 0);
+        auto key = fwdpy11::infsites_Mutation(
+            recycling_bin, pop.mutations, pop.mut_lookup, generation, uniform,
+            return_zero, return_zero, 0);
+        return fwdpp::ts::new_variant_record(
+            pop.mutations[key].pos, fwdpp::ts::default_ancestral_state, key,
+            pop.mutations[key].neutral, fwdpp::ts::default_derived_state);
     }
 } // namespace
 
 void
 init_infinite_sites(py::module& m)
 {
-    m.def("infinite_sites", [](const fwdpy11::GSLrng_t& rng,
-                               fwdpy11::Population& pop, const double mu) {
-        fwdpp::flagged_mutation_queue recycling_bin
-            = fwdpp::ts::make_mut_queue(pop.mcounts,
-                                        pop.mcounts_from_preserved_nodes);
+    m.def(
+        "infinite_sites",
+        [](const fwdpy11::GSLrng_t& rng, fwdpy11::Population& pop,
+           const double mu) {
+            fwdpp::flagged_mutation_queue recycling_bin
+                = fwdpp::ts::make_mut_queue(pop.mcounts,
+                                            pop.mcounts_from_preserved_nodes);
 
-        std::vector<fwdpp::ts::TS_NODE_INT> samples;
-        samples.reserve(pop.N);
-        // Assume the pop is simplified
-        auto nb = pop.tables.node_table.cbegin();
-        auto past_sample = std::find_if(
-            nb, pop.tables.node_table.cend(), [&pop](const fwdpp::ts::node& n) {
-                return n.time != static_cast<double>(pop.generation);
-            });
-        for (auto i = nb; i < past_sample; ++i)
-            {
-                samples.push_back(std::distance(nb, i));
-            }
+            std::vector<fwdpp::ts::TS_NODE_INT> samples;
+            samples.reserve(pop.N);
+            // Assume the pop is simplified
+            auto nb = pop.tables.node_table.cbegin();
+            auto past_sample = std::find_if(
+                nb, pop.tables.node_table.cend(),
+                [&pop](const fwdpp::ts::node& n) {
+                    return n.time != static_cast<double>(pop.generation);
+                });
+            for (auto i = nb; i < past_sample; ++i)
+                {
+                    samples.push_back(std::distance(nb, i));
+                }
 
-        const auto apply_mutations =
-            [&recycling_bin, &rng, &pop](const double left, const double right,
-                                         const fwdpp::uint_t generation) {
-                return generate_neutral_variants(recycling_bin, pop, rng, left,
-                                                 right, generation);
-            };
-        auto nmuts = fwdpp::ts::mutate_tables(rng, apply_mutations, pop.tables,
-                                              samples, mu);
-        std::sort(
-            pop.tables.mutation_table.begin(), pop.tables.mutation_table.end(),
-            [&pop](const fwdpp::ts::mutation_record& a,
-                   const fwdpp::ts::mutation_record& b) {
-                return pop.mutations[a.key].pos < pop.mutations[b.key].pos;
-            });
-        fwdpp::ts::count_mutations(pop.tables, pop.mutations, samples,
-                                   pop.mcounts,
-                                   pop.mcounts_from_preserved_nodes);
-        return nmuts;
-    },py::arg("rng"),py::arg("pop"),py::arg("mu"));
+            const auto apply_mutations
+                = [&recycling_bin, &rng,
+                   &pop](const double left, const double right,
+                         const fwdpp::uint_t generation) {
+                      return generate_neutral_variants(
+                          recycling_bin, pop, rng, left, right, generation);
+                  };
+            auto nmuts = fwdpp::ts::mutate_tables(rng, apply_mutations,
+                                                  pop.tables, samples, mu);
+            std::sort(pop.tables.mutation_table.begin(),
+                      pop.tables.mutation_table.end(),
+                      [&pop](const fwdpp::ts::mutation_record& a,
+                             const fwdpp::ts::mutation_record& b) {
+                          return pop.mutations[a.key].pos
+                                 < pop.mutations[b.key].pos;
+                      });
+            fwdpp::ts::count_mutations(pop.tables, pop.mutations, samples,
+                                       pop.mcounts,
+                                       pop.mcounts_from_preserved_nodes);
+            return nmuts;
+        },
+        py::arg("rng"), py::arg("pop"), py::arg("mu"));
 }

--- a/fwdpy11/src/ts/simplify.cc
+++ b/fwdpy11/src/ts/simplify.cc
@@ -87,6 +87,10 @@ init_simplify_functions(py::module& m)
 
                 Ancient samples are no longer kept by default
 
+            .. versionchanged:: 0.5.0
+
+                No longer requires a :class:`MutationVector` argument.
+
             )delim");
 
     m.def(

--- a/fwdpy11/src/ts/simplify.cc
+++ b/fwdpy11/src/ts/simplify.cc
@@ -40,7 +40,7 @@ simplify(const fwdpy11::Population& pop,
     // they must pass them in to the samples list
     t.preserved_nodes.clear();
     fwdpp::ts::table_simplifier simplifier(pop.tables.genome_length());
-    auto rv = simplifier.simplify(t, samples, pop.mutations);
+    auto rv = simplifier.simplify(t, samples);
     t.build_indexes();
     decltype(rv.first)* idmap = new decltype(rv.first)(std::move(rv.first));
     py::capsule cap(idmap, [](void* v) {
@@ -89,30 +89,28 @@ init_simplify_functions(py::module& m)
 
             )delim");
 
-    m.def("simplify_tables",
-          [](const fwdpp::ts::table_collection& tables,
-             const std::vector<fwdpy11::Mutation>& mutations,
-             const std::vector<fwdpp::ts::TS_NODE_INT>& samples) -> py::tuple {
-              auto t(tables);
-              fwdpp::ts::table_simplifier simplifier(tables.genome_length());
-              auto rv = simplifier.simplify(t, samples, mutations);
-              t.build_indexes();
-              decltype(rv.first)* idmap
-                  = new decltype(rv.first)(std::move(rv.first));
-              py::capsule cap(idmap, [](void* v) {
-                  delete reinterpret_cast<decltype(rv.first)*>(v);
-              });
-              return py::make_tuple(
-                  std::move(t), py::array(idmap->size(), idmap->data(), cap));
-          },
-          py::arg("tables"), py::arg("mutations"), py::arg("samples"),
-          R"delim(
+    m.def(
+        "simplify_tables",
+        [](const fwdpp::ts::table_collection& tables,
+           const std::vector<fwdpp::ts::TS_NODE_INT>& samples) -> py::tuple {
+            auto t(tables);
+            fwdpp::ts::table_simplifier simplifier(tables.genome_length());
+            auto rv = simplifier.simplify(t, samples);
+            t.build_indexes();
+            decltype(rv.first)* idmap
+                = new decltype(rv.first)(std::move(rv.first));
+            py::capsule cap(idmap, [](void* v) {
+                delete reinterpret_cast<decltype(rv.first)*>(v);
+            });
+            return py::make_tuple(
+                std::move(t), py::array(idmap->size(), idmap->data(), cap));
+        },
+        py::arg("tables"), py::arg("samples"),
+        R"delim(
           Simplify a TableCollection.
           
           :param pop: A table collection.
           :type pop: :class:`fwdpy11.TableCollection`
-          :param mutations: Container of mutations
-          :type mutations: :class:`fwdpy11.MutationVector`
           :param samples: list of samples
           :type list: list-like or array-like
 

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -603,7 +603,7 @@ class testDataMatrixIterator(unittest.TestCase):
         self.spos = np.array(self.dm.selected.positions)
 
     def test_entire_matrix(self):
-        dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+        dmi = fwdpy11.DataMatrixIterator(self.pop.tables,
                                          self.all_samples,
                                          [(0, 1)], True, True)
         niterations = 0
@@ -618,7 +618,7 @@ class testDataMatrixIterator(unittest.TestCase):
         self.assertEqual(niterations, 1)
 
     def test_single_slice(self):
-        dm = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+        dm = fwdpy11.DataMatrixIterator(self.pop.tables,
                                         self.all_samples,
                                         [(0.1, 0.2)], True, True)
         dm = next(dm)
@@ -630,7 +630,7 @@ class testDataMatrixIterator(unittest.TestCase):
 
     def test_nonoverlapping_slices(self):
         slices = [(0.1, 0.2), (0.21, 0.37), (0.5, 0.55)]
-        dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+        dmi = fwdpy11.DataMatrixIterator(self.pop.tables,
                                          self.all_samples,
                                          slices, True, True)
         niterations = 0
@@ -646,7 +646,7 @@ class testDataMatrixIterator(unittest.TestCase):
     def test_complex_slices(self):
         slices = [(0.1, 0.2), (0.15, 0.23), (0.21, 0.37),
                   (0.38, 0.5337), (0.5, 0.55)]
-        dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+        dmi = fwdpy11.DataMatrixIterator(self.pop.tables,
                                          self.all_samples,
                                          slices, True, True)
         niterations = 0
@@ -662,7 +662,7 @@ class testDataMatrixIterator(unittest.TestCase):
     def test_nested_slices(self):
         slices = [(0.1, 0.2), (0.15, 0.19), (0.21, 0.37),
                   (0.38, 0.5337), (0.39, 0.432), (0.5, 0.55)]
-        dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+        dmi = fwdpy11.DataMatrixIterator(self.pop.tables,
                                          self.all_samples,
                                          slices, True, True)
         for r, dm in zip(slices, dmi):

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -274,7 +274,6 @@ class testTreeSequences(unittest.TestCase):
         cs = np.sum(sa, axis=1)
         i = 0
         vi = fwdpy11.VariantIterator(self.pop.tables,
-                                     self.pop.mutations,
                                      [i for i in range(2*self.pop.N)])
         for v in vi:
             c = self.pop.mcounts[self.pop.tables.mutations[i].key]
@@ -306,14 +305,13 @@ class testTreeSequences(unittest.TestCase):
     def test_VariantIteratorBeginEnd(self):
         for i in np.arange(0, self.pop.tables.genome_length, 0.1):
             vi = fwdpy11.VariantIterator(self.pop.tables,
-                                         self.pop.mutations,
                                          [i for i in range(2*self.pop.N)], i,
                                          i+0.1)
             nm = len([j for j in self.pop.tables.mutations if self.pop.mutations[j.key].pos >= i and
                       self.pop.mutations[j.key].pos < i+0.1])
             nseen = 0
             for v in vi:
-                r = v.record
+                r = v.records[0]
                 self.assertTrue(self.pop.mutations[r.key].pos >= i)
                 self.assertTrue(self.pop.mutations[r.key].pos < i+0.1)
                 nseen += 1
@@ -321,7 +319,7 @@ class testTreeSequences(unittest.TestCase):
 
         # test bad start/stop
         with self.assertRaises(ValueError):
-            vi = fwdpy11.VariantIterator(self.pop.tables, self.pop.mutations,
+            vi = fwdpy11.VariantIterator(self.pop.tables,
                                          [i for i in range(2*self.pop.N)], begin=0.5, end=0.25)
 
     def test_count_mutations(self):
@@ -375,10 +373,9 @@ class testSamplePreservation(unittest.TestCase):
         at = n['time'][pn]
         for u in np.unique(at):
             n = pn[np.where(at == u)[0]]
-            vi = fwdpy11.VariantIterator(self.pop.tables,
-                                         self.pop.mutations, n)
+            vi = fwdpy11.VariantIterator(self.pop.tables, n)
             for variant in vi:
-                k = variant.record
+                k = variant.records[0]
                 self.assertNotEqual(k.node, fwdpy11.NULL_NODE)
                 self.assertNotEqual(k.key, np.iinfo(np.uint64).max)
 
@@ -548,11 +545,11 @@ class testMetaData(unittest.TestCase):
             samples_at_time_u = metadata_nodes[np.where(
                 metadata_node_times == u)]
             vi = fwdpy11.VariantIterator(
-                pop.tables, pop.mutations, samples_at_time_u)
+                pop.tables, samples_at_time_u)
             sum_esizes = np.zeros(len(samples_at_time_u))
             for variant in vi:
                 g = variant.genotypes
-                r = variant.record
+                r = variant.records[0]
                 mutant = np.where(g == 1)[0]
                 sum_esizes[mutant] += pop.mutations[r.key].s
             ind = int(len(samples_at_time_u)/2)

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -621,6 +621,7 @@ class testDataMatrixIterator(unittest.TestCase):
         dm = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
                                         self.all_samples,
                                         [(0.1, 0.2)], True, True)
+        dm = next(dm)
         rows = np.where((self.spos >= 0.1) & (self.spos < 0.2))[0]
         pos_slice = self.spos[rows]
         selected_slice = self.selected[rows, ]

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -606,13 +606,16 @@ class testDataMatrixIterator(unittest.TestCase):
         dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
                                          self.all_samples,
                                          [(0, 1)], True, True)
+        niterations = 0
         for dm in dmi:
+            niterations += 1
             for i in dm.selected_keys:
                 self.assertFalse(self.pop.mutations[i].neutral)
             self.assertTrue(np.array_equal(
                 np.array(self.dm.selected_keys), dm.selected_keys))
             self.assertTrue(np.array_equal(dm.neutral, self.neutral))
             self.assertTrue(np.array_equal(dm.selected, self.selected))
+        self.assertEqual(niterations, 1)
 
     def test_single_slice(self):
         dm = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
@@ -629,12 +632,15 @@ class testDataMatrixIterator(unittest.TestCase):
         dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
                                          self.all_samples,
                                          slices, True, True)
+        niterations = 0
         for r, dm in zip(slices, dmi):
+            niterations += 1
             rows = np.where((self.spos >= r[0]) & (self.spos < r[1]))[0]
             pos_slice = self.spos[rows]
             selected_slice = self.selected[rows, ]
             self.assertTrue(np.array_equal(dm.selected_positions, pos_slice))
             self.assertTrue(np.array_equal(dm.selected, selected_slice))
+        self.assertEqual(niterations, len(slices))
 
     def test_complex_slices(self):
         slices = [(0.1, 0.2), (0.15, 0.23), (0.21, 0.37),
@@ -642,12 +648,15 @@ class testDataMatrixIterator(unittest.TestCase):
         dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
                                          self.all_samples,
                                          slices, True, True)
+        niterations = 0
         for r, dm in zip(slices, dmi):
+            niterations += 1
             rows = np.where((self.spos >= r[0]) & (self.spos < r[1]))[0]
             pos_slice = self.spos[rows]
             selected_slice = self.selected[rows, ]
             self.assertTrue(np.array_equal(dm.selected_positions, pos_slice))
             self.assertTrue(np.array_equal(dm.selected, selected_slice))
+        self.assertEqual(niterations, len(slices))
 
     def test_nested_slices(self):
         slices = [(0.1, 0.2), (0.15, 0.19), (0.21, 0.37),

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -37,7 +37,7 @@ class testTreeSequences(unittest.TestCase):
 
     def test_simplify_tables(self):
         tables, idmap = fwdpy11.simplify_tables(
-            self.pop.tables, self.pop.mutations, [i for i in range(10)])
+            self.pop.tables, [i for i in range(10)])
         for i in range(10):
             self.assertTrue(idmap[i] != fwdpy11.NULL_NODE)
 
@@ -49,8 +49,7 @@ class testTreeSequences(unittest.TestCase):
 
     def test_simplify_tables_numpy_array(self):
         tables, idmap = fwdpy11.simplify_tables(
-            self.pop.tables, self.pop.mutations,
-            np.array([i for i in range(10)]))
+            self.pop.tables, np.array([i for i in range(10)]))
         for i in range(10):
             self.assertTrue(idmap[i] != fwdpy11.NULL_NODE)
 
@@ -245,14 +244,12 @@ class testTreeSequences(unittest.TestCase):
 
     def test_genotype_matrix_ranges(self):
         dm = fwdpy11.data_matrix_from_tables(self.pop.tables,
-                                             self.pop.mutations,
                                              [i for i in range(
                                                  2*self.pop.N)],
                                              False, True)
         spos = np.array(dm.selected.positions)
         for i in np.arange(0, self.pop.tables.genome_length, 0.1):
             dmi = fwdpy11.data_matrix_from_tables(self.pop.tables,
-                                                  self.pop.mutations,
                                                   [i for i in range(
                                                       2*self.pop.N)],
                                                   record_neutral=False,
@@ -270,7 +267,6 @@ class testTreeSequences(unittest.TestCase):
         those in pop.mcounts
         """
         dm = fwdpy11.data_matrix_from_tables(self.pop.tables,
-                                             self.pop.mutations,
                                              [i for i in range(
                                                  2*self.pop.N)],
                                              False, True)
@@ -291,7 +287,6 @@ class testTreeSequences(unittest.TestCase):
 
     def test_VariantIteratorFromPopulation(self):
         dm = fwdpy11.data_matrix_from_tables(self.pop.tables,
-                                             self.pop.mutations,
                                              [i for i in range(
                                                  2*self.pop.N)],
                                              False, True)
@@ -310,8 +305,10 @@ class testTreeSequences(unittest.TestCase):
 
     def test_VariantIteratorBeginEnd(self):
         for i in np.arange(0, self.pop.tables.genome_length, 0.1):
-            vi = fwdpy11.VariantIterator(self.pop.tables, self.pop.mutations,
-                                         [i for i in range(2*self.pop.N)], i, i+0.1)
+            vi = fwdpy11.VariantIterator(self.pop.tables,
+                                         self.pop.mutations,
+                                         [i for i in range(2*self.pop.N)], i,
+                                         i+0.1)
             nm = len([j for j in self.pop.tables.mutations if self.pop.mutations[j.key].pos >= i and
                       self.pop.mutations[j.key].pos < i+0.1])
             nseen = 0
@@ -598,7 +595,6 @@ class testDataMatrixIterator(unittest.TestCase):
         self.all_samples = [i for i in range(2*self.N)]
         fwdpy11.evolvets(self.rng, self.pop, self.params, 100)
         self.dm = fwdpy11.data_matrix_from_tables(self.pop.tables,
-                                                  self.pop.mutations,
                                                   self.all_samples,
                                                   True, True)
         self.neutral = np.array(self.dm.neutral)
@@ -619,11 +615,9 @@ class testDataMatrixIterator(unittest.TestCase):
             self.assertTrue(np.array_equal(dm.selected, self.selected))
 
     def test_single_slice(self):
-        dmi = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
-                                         self.all_samples,
-                                         [(0.1, 0.2)], True, True)
-        dm = next(dmi)
-
+        dm = fwdpy11.DataMatrixIterator(self.pop.tables, self.pop.mutations,
+                                        self.all_samples,
+                                        [(0.1, 0.2)], True, True)
         rows = np.where((self.spos >= 0.1) & (self.spos < 0.2))[0]
         pos_slice = self.spos[rows]
         selected_slice = self.selected[rows, ]


### PR DESCRIPTION
Only goal is to get package compiling and unit tests working + minimum correctness fixes for existing types. We'll add the site table to the package in a later PR.

- [x] Update numpy DTYPE for mutation_record.
- [x] VariantIterator needs to go through the site table first.
- [x] DataMatrixIterator needs to go through the site table.
- [x] Add Site type (fwdpp::ts::site) so that TableCollection pickling works.
- [x] Document the Python-side API changes via `.. versionchanged::`