### PR TITLE
Add iterators to sites/mutations on current tree during tree sequence traversal.

### DIFF
--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -109,7 +109,7 @@ class tree_visitor_wrapper
             {
                 rv = visitor();
             }
-        double pos = visitor.tree().left;
+        double pos = std::max(visitor.tree().left, from);
         current_site
             = std::lower_bound(current_site, end_of_sites, pos,
                                [](const fwdpp::ts::site& s, double value) {
@@ -252,7 +252,7 @@ class tree_visitor_wrapper
               fwdpp::ts::site_vector::const_iterator>
     get_sites_on_current_tree() const
     {
-        double pos = visitor.tree().right;
+        double pos = std::min(visitor.tree().right, until);
         if (current_site < end_of_sites && current_site->position >= pos)
             {
                 // Return an empty range

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -442,12 +442,24 @@ init_tree_iterator(py::module& m)
                 auto rv = self.get_sites_on_current_tree();
                 return py::make_iterator(rv.first, rv.second);
             },
-            py::keep_alive<0, 1>())
+            py::keep_alive<0, 1>(),
+            R"delim(
+            Return iterator over all :class:`fwdpy11.Site` objects
+            on the current tree.
+
+            .. versionadded:: 0.5.1
+            )delim")
         .def(
             "mutations",
             [](const tree_visitor_wrapper& self) {
                 auto r = self.get_mutations_on_current_tree();
                 return py::make_iterator(r.first, r.second);
             },
-            py::keep_alive<0, 1>());
+            py::keep_alive<0, 1>(),
+            R"delim(
+            Return iterator over all :class:`fwdpy11.MutationRecord` objects
+            on the current tree.
+
+            .. versionadded:: 0.5.1
+            )delim");
 }

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -43,6 +43,9 @@ class tree_visitor_wrapper
     // bad things from happening in the
     // calling environment
     py::object tables_;
+    fwdpp::ts::site_vector::const_iterator first_site, end_of_sites;
+    fwdpp::ts::mutation_key_vector::const_iterator first_mutation,
+        end_of_mutations;
     bool update_samples;
     const double from, until;
 
@@ -52,8 +55,16 @@ class tree_visitor_wrapper
     tree_visitor_wrapper(py::object tables,
                          const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                          bool update_samples_below, double start, double stop)
-        : tables_(tables), update_samples(update_samples_below), from(start),
-          until(stop),
+        : tables_(tables),
+          first_site(tables_.cast<const fwdpp::ts::table_collection&>()
+                         .site_table.begin()),
+          end_of_sites(tables_.cast<const fwdpp::ts::table_collection&>()
+                           .site_table.end()),
+          first_mutation(tables_.cast<const fwdpp::ts::table_collection&>()
+                             .mutation_table.begin()),
+          end_of_mutations(tables_.cast<const fwdpp::ts::table_collection&>()
+                               .mutation_table.end()),
+          update_samples(update_samples_below), from(start), until(stop),
           visitor(tables_.cast<const fwdpp::ts::table_collection&>(), samples,
                   fwdpp::ts::update_samples_list(update_samples_below)),
           samples_below_buffer()
@@ -66,8 +77,16 @@ class tree_visitor_wrapper
         py::object tables, const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
         const std::vector<fwdpp::ts::TS_NODE_INT>& preserved_nodes,
         bool update_samples_below, double start, double stop)
-        : tables_(tables), update_samples(update_samples_below), from(start),
-          until(stop),
+        : tables_(tables),
+          first_site(tables_.cast<const fwdpp::ts::table_collection&>()
+                         .site_table.begin()),
+          end_of_sites(tables_.cast<const fwdpp::ts::table_collection&>()
+                           .site_table.end()),
+          first_mutation(tables_.cast<const fwdpp::ts::table_collection&>()
+                             .mutation_table.begin()),
+          end_of_mutations(tables_.cast<const fwdpp::ts::table_collection&>()
+                               .mutation_table.end()),
+          update_samples(update_samples_below), from(start), until(stop),
           visitor(tables_.cast<const fwdpp::ts::table_collection&>(), samples,
                   fwdpp::ts::update_samples_list(update_samples_below)),
           samples_below_buffer()
@@ -324,7 +343,7 @@ init_tree_iterator(py::module& m)
         .def("samples", &tree_visitor_wrapper::samples,
              "Return the complete sample list")
         .def_property_readonly("tables", &tree_visitor_wrapper::get_tables,
-                      "Return the TableCollection")
+                               "Return the TableCollection")
         .def("samples_below", &tree_visitor_wrapper::samples_below,
              R"delim(
             Return the list of samples descending from a node.

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -183,6 +183,21 @@ class testTreeSequences(unittest.TestCase):
                 nsites_visited += 1
         self.assertEqual(len(self.pop.tables.sites), nsites_visited)
 
+        site_table = np.array(self.pop.tables.sites, copy=False)
+        for i in np.arange(0., 1., 0.1):
+            tv = fwdpy11.TreeIterator(self.pop.tables,
+                                      [i for i in range(2*self.pop.N)], False, i, i+0.1)
+            nsites_visited = 0
+            idx = np.where((site_table['position'] >= i) & (
+                site_table['position'] < i+0.1))[0]
+            nsites_in_interval = len(idx)
+            for tree in tv:
+                for s in tree.sites():
+                    self.assertTrue(s.position >= tree.left)
+                    self.assertTrue(s.position < tree.right)
+                    nsites_visited += 1
+            self.assertEqual(nsites_visited, nsites_in_interval)
+
     def test_leaf_counts_vs_mcounts(self):
         tv = fwdpy11.TreeIterator(self.pop.tables,
                                   [i for i in range(2*self.pop.N)])

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -134,6 +134,15 @@ class testTreeSequences(unittest.TestCase):
             self.assertEqual(d['neutral'], m.neutral)
 
     def test_TreeIterator(self):
+        # The first test ensures that TreeIterator
+        # simply holds a reference to the input tables,
+        # rather than a (deep) copy, which would have
+        # a different address
+        tv = fwdpy11.TreeIterator(self.pop.tables,
+                                  [i for i in range(2*self.pop.N)],
+                                  True, 0, 1)
+        self.assertTrue(tv.tables is self.pop.tables)
+
         with self.assertRaises(ValueError):
             tv = fwdpy11.TreeIterator(self.pop.tables,
                                       [i for i in range(2*self.pop.N)],

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -169,6 +169,20 @@ class testTreeSequences(unittest.TestCase):
                 b = i < ti.right
                 self.assertTrue(a and b)
 
+    def test_TreeIterator_iterate_sites(self):
+        # TODO: need test of empty tree sequence
+        # and tree sequence where mutations aren't
+        # on every tree
+        tv = fwdpy11.TreeIterator(self.pop.tables,
+                                  [i for i in range(2*self.pop.N)])
+        nsites_visited = 0
+        for tree in tv:
+            for s in tree.sites():
+                self.assertTrue(s.position >= tree.left)
+                self.assertTrue(s.position < tree.right)
+                nsites_visited += 1
+        self.assertEqual(len(self.pop.tables.sites), nsites_visited)
+
     def test_leaf_counts_vs_mcounts(self):
         tv = fwdpy11.TreeIterator(self.pop.tables,
                                   [i for i in range(2*self.pop.N)])

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -198,6 +198,32 @@ class testTreeSequences(unittest.TestCase):
                     nsites_visited += 1
             self.assertEqual(nsites_visited, nsites_in_interval)
 
+    def test_TreeIterator_iterate_mutations(self):
+        tv = fwdpy11.TreeIterator(self.pop.tables,
+                                  [i for i in range(2*self.pop.N)])
+        sites = np.array(self.pop.tables.sites, copy=False)
+        nsites_visited = 0
+        for tree in tv:
+            for m in tree.mutations():
+                self.assertTrue(sites['position'][m.site] >= tree.left)
+                self.assertTrue(sites['position'][m.site] < tree.right)
+                nsites_visited += 1
+        self.assertEqual(len(self.pop.tables.sites), nsites_visited)
+
+        for i in np.arange(0., 1., 0.1):
+            tv = fwdpy11.TreeIterator(self.pop.tables,
+                                      [i for i in range(2*self.pop.N)], False, i, i+0.1)
+            nsites_visited = 0
+            idx = np.where((sites['position'] >= i) & (
+                sites['position'] < i+0.1))[0]
+            nsites_in_interval = len(idx)
+            for tree in tv:
+                for m in tree.mutations():
+                    self.assertTrue(sites['position'][m.site] >= tree.left)
+                    self.assertTrue(sites['position'][m.site] < tree.right)
+                    nsites_visited += 1
+            self.assertEqual(nsites_visited, nsites_in_interval)
+
     def test_leaf_counts_vs_mcounts(self):
         tv = fwdpy11.TreeIterator(self.pop.tables,
                                   [i for i in range(2*self.pop.N)])


### PR DESCRIPTION
Allow iteration over `Site` and `Mutation` objects during tree sequence traversal.  The proposal is to allow iteration over:

* All Site objects in current tree
* All Mutation objects "under" (for lack of a better term) the current Site
* All Mutation objects in current tree.

Details:

* TreeIterator now holds references to TableCollection