### PR TITLE
Proof of principle to eliminate the need for edge table sorting.

### DIFF
--- a/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
@@ -63,12 +63,132 @@ namespace fwdpy11
         return offspring_data;
     }
 
+    // NOTE: much of what follows is simply copy-pasted from 
+    // the inner workings of fwdpp::ts::table_collection.
+    inline void
+    split_breakpoints_add_edges(
+        const std::vector<double>& breakpoints, std::size_t parent,
+        const std::tuple<fwdpp::ts::TS_NODE_INT, fwdpp::ts::TS_NODE_INT>&
+            parents,
+        const fwdpp::ts::TS_NODE_INT next_index, double genome_length,
+        std::vector<std::array<fwdpp::ts::edge_vector, 2>>& temp_edges)
+    {
+        auto p1 = std::get<0>(parents), p2 = std::get<1>(parents);
+        std::size_t p1_idx = (p1 < p2) ? 0 : 1;
+        std::size_t p2_idx = !p1_idx;
+        if (breakpoints.front() != 0.0)
+            {
+                temp_edges[parent][p1_idx].push_back(fwdpp::ts::edge{
+                    0., breakpoints.front(), p1, next_index });
+            }
+        // TODO: replace with exception via a debug mode
+        assert(std::count(begin(breakpoints), end(breakpoints),
+                          std::numeric_limits<double>::max())
+               == 1);
+        assert(breakpoints.back() == std::numeric_limits<double>::max());
+        for (unsigned j = 1; j < breakpoints.size(); ++j)
+            {
+                double a = breakpoints[j - 1];
+                double b = (j < breakpoints.size() - 1) ? breakpoints[j]
+                                                        : genome_length;
+                if (b <= a)
+                    {
+                        throw std::invalid_argument("right must be > left");
+                    }
+                if (j % 2 == 0.)
+                    {
+                        temp_edges[parent][p1_idx].push_back(
+                            fwdpp::ts::edge{ a, b, p1, next_index });
+                    }
+                else
+                    {
+                        temp_edges[parent][p2_idx].push_back(
+                            fwdpp::ts::edge{ a, b, p2, next_index });
+                    }
+            }
+    }
+
+    inline void
+    populate_temp_edges(
+        const std::vector<double>& breakpoints, std::size_t parent,
+        const std::tuple<fwdpp::ts::TS_NODE_INT, fwdpp::ts::TS_NODE_INT>&
+            parents,
+        fwdpp::ts::TS_NODE_INT next_index, double genome_length,
+        std::vector<std::array<fwdpp::ts::edge_vector, 2>>& temp_edges)
+    {
+        if (breakpoints.empty())
+            {
+                auto p = std::get<0>(parents);
+                std::size_t p_idx = (p < std::get<1>(parents)) ? 0 : 1;
+                temp_edges[parent][p_idx].push_back(
+                    fwdpp::ts::edge{ 0., genome_length, p, next_index });
+                return;
+            }
+        auto itr = std::adjacent_find(std::begin(breakpoints),
+                                      std::end(breakpoints));
+        if (itr == std::end(breakpoints))
+            {
+                split_breakpoints_add_edges(breakpoints, parent, parents,
+                                            next_index, genome_length,
+                                            temp_edges);
+            }
+        else
+            {
+                // Here, we need to reduce the input
+                // breakpoints to only those seen
+                // an odd number of times.
+                // Even numbers of the same breakpoint
+                // are "double x-overs" and thus
+                // cannot affect the genealogy.
+                std::vector<double> odd_breakpoints;
+                auto start = breakpoints.begin();
+                while (itr < breakpoints.end())
+                    {
+                        auto not_equal = std::find_if(
+                            itr, breakpoints.end(),
+                            [itr](const double d) { return d != *itr; });
+                        int even = (std::distance(itr, not_equal) % 2 == 0.0);
+                        odd_breakpoints.insert(odd_breakpoints.end(), start,
+                                               itr + 1 - even);
+                        start = not_equal;
+                        itr = std::adjacent_find(start, std::end(breakpoints));
+                    }
+                odd_breakpoints.insert(odd_breakpoints.end(), start,
+                                       breakpoints.end());
+                split_breakpoints_add_edges(odd_breakpoints, parent, parents,
+                                            next_index, genome_length,
+                                            temp_edges);
+            }
+    }
+
+    inline fwdpp::ts::TS_NODE_INT
+    register_diploid_offspring(
+        const std::vector<double>& breakpoints, std::size_t parent,
+        const std::tuple<fwdpp::ts::TS_NODE_INT, fwdpp::ts::TS_NODE_INT>&
+            parents,
+        const std::int32_t population, const double time,
+        fwdpp::ts::table_collection& tables,
+        std::vector<std::array<fwdpp::ts::edge_vector, 2>>& temp_edges)
+    {
+        auto next_index = tables.emplace_back_node(population, time);
+        if (next_index >= std::numeric_limits<fwdpp::ts::TS_NODE_INT>::max())
+            {
+                throw std::invalid_argument("node index too large");
+            }
+        populate_temp_edges(breakpoints, parent, parents, next_index,
+                            tables.genome_length(), temp_edges);
+        return next_index;
+    }
+
     template <typename rng_t, typename poptype, typename pick_parent1_fxn,
               typename pick_parent2_fxn, typename offspring_metadata_fxn,
               typename genetic_param_holder>
     void
     evolve_generation_ts(
-        const rng_t& rng, poptype& pop, genetic_param_holder& genetics,
+        const rng_t& rng, poptype& pop,
+        std::vector<std::array<fwdpp::ts::edge_vector, 2>>& temp_edges,
+        std::vector<std::pair<std::size_t, std::size_t>> & offsets,
+        fwdpp::ts::edge_vector& temp_edges2, genetic_param_holder& genetics,
         const fwdpp::uint_t N_next, const pick_parent1_fxn& pick1,
         const pick_parent2_fxn& pick2,
         const offspring_metadata_fxn& update_offspring,
@@ -99,13 +219,15 @@ namespace fwdpy11
                     first_parental_index, p1, offspring_data.first.swapped);
                 auto p2id = fwdpp::ts::get_parent_ids(
                     first_parental_index, p2, offspring_data.second.swapped);
-                next_index_local = tables.register_diploid_offspring(
-                    offspring_data.first.breakpoints, p1id, 0, generation);
+                next_index_local = register_diploid_offspring(
+                    offspring_data.first.breakpoints, p1, p1id, 0, generation,
+                    pop.tables, temp_edges);
                 fwdpp::ts::record_mutations_infinite_sites(
                     next_index_local, pop.mutations,
                     offspring_data.first.mutation_keys, tables);
-                next_index_local = tables.register_diploid_offspring(
-                    offspring_data.second.breakpoints, p2id, 0, generation);
+                next_index_local = register_diploid_offspring(
+                    offspring_data.second.breakpoints, p2, p2id, 0, generation,
+                    pop.tables, temp_edges);
                 fwdpp::ts::record_mutations_infinite_sites(
                     next_index_local, pop.mutations,
                     offspring_data.second.mutation_keys, tables);
@@ -119,11 +241,22 @@ namespace fwdpy11
                 // Update nodes of for offspring
                 offspring_metadata[next_offspring].nodes[0]
                     = next_index_local - 1;
-                offspring_metadata[next_offspring].nodes[1]
-                    = next_index_local;
+                offspring_metadata[next_offspring].nodes[1] = next_index_local;
             }
         assert(next_index_local
                == next_index + 2 * static_cast<std::int32_t>(N_next) - 1);
+        // Copy the temp edges to the edge table
+        auto x = temp_edges2.size();
+        for (std::size_t i = 0; i < pop.diploids.size(); ++i)
+            {
+                temp_edges2.insert(end(temp_edges2), begin(temp_edges[i][0]),
+                                   end(temp_edges[i][0]));
+                temp_edges2.insert(end(temp_edges2), begin(temp_edges[i][1]),
+                                   end(temp_edges[i][1]));
+                temp_edges[i][0].clear();
+                temp_edges[i][1].clear();
+            }
+        offsets.emplace_back(x, temp_edges2.size());
         // This is constant-time
         pop.diploids.swap(offspring);
         pop.diploid_metadata.swap(offspring_metadata);

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -47,7 +47,14 @@ namespace fwdpy11
                     const bool simulating_neutral_variants,
                     const bool suppress_edge_table_indexing)
     {
-        tables.sort_tables_for_simplification();
+        //tables.sort_tables_for_simplification();
+        tables.sort_mutations();
+        if (tables.edge_offset > 0)
+            {
+                std::rotate(tables.edge_table.begin(),
+                            tables.edge_table.begin() + tables.edge_offset,
+                            tables.edge_table.end());
+            }
         std::vector<std::int32_t> samples(num_samples);
         std::iota(samples.begin(), samples.end(), first_sample_node);
         auto rv = simplifier.simplify(tables, samples);


### PR DESCRIPTION
This PR shows how edge table sorting can be completely eliminated.  The implementation is rather hacky, though.  The end result is an identical tree sequence as versions with the sorting.

We might never merge this, but we'll keep it for inspiration.

Next step: can we get rid of all calls to `std::rotate`, and would it be worth it?