### PR TITLE
Numpy array interface

### DIFF
--- a/fwdpy11/headers/fwdpy11/numpy/array.hpp
+++ b/fwdpy11/headers/fwdpy11/numpy/array.hpp
@@ -73,7 +73,7 @@ namespace fwdpy11
 
     template <typename T>
     inline pybind11::array_t<T>
-    make_1d_array_with_capsule(std::vector<T>& v)
+    make_1d_array_with_capsule(std::vector<T>&& v)
     // Steals contents of v! Use with caution.
     {
         std::vector<T>* c = new std::vector<T>(std::move(v));

--- a/fwdpy11/headers/fwdpy11/numpy/array.hpp
+++ b/fwdpy11/headers/fwdpy11/numpy/array.hpp
@@ -57,22 +57,6 @@ namespace fwdpy11
 
     template <typename T>
     inline pybind11::array_t<T>
-    make_1d_array_with_capsule(std::vector<T>* v)
-    // v must not be a pointer to a class member.
-    // Rather, it must be allocated on its own, like
-    // in a function.
-    {
-        if (v == nullptr)
-            {
-                throw std::invalid_argument("pointer to vector is nullptr");
-            }
-        auto capsule = pybind11::capsule(
-            v, [](void* x) { delete reinterpret_cast<std::vector<T>*>(x); });
-        return pybind11::array(v->size(), v->data(), capsule);
-    }
-
-    template <typename T>
-    inline pybind11::array_t<T>
     make_1d_array_with_capsule(std::vector<T>&& v)
     // Steals contents of v! Use with caution.
     {

--- a/fwdpy11/headers/fwdpy11/numpy/array.hpp
+++ b/fwdpy11/headers/fwdpy11/numpy/array.hpp
@@ -54,6 +54,33 @@ namespace fwdpy11
         rv.attr("flags").attr("writeable") = false;
         return rv;
     }
+
+    template <typename T>
+    inline pybind11::array_t<T>
+    make_1d_array_with_capsule(std::vector<T>* v)
+    // v must not be a pointer to a class member.
+    // Rather, it must be allocated on its own, like
+    // in a function.
+    {
+        if (v == nullptr)
+            {
+                throw std::invalid_argument("pointer to vector is nullptr");
+            }
+        auto capsule = pybind11::capsule(
+            v, [](void* x) { delete reinterpret_cast<std::vector<T>*>(x); });
+        return pybind11::array(v->size(), v->data(), capsule);
+    }
+
+    template <typename T>
+    inline pybind11::array_t<T>
+    make_1d_array_with_capsule(std::vector<T>& v)
+    // Steals contents of v! Use with caution.
+    {
+        std::vector<T>* c = new std::vector<T>(std::move(v));
+        auto capsule = pybind11::capsule(
+            c, [](void* x) { delete reinterpret_cast<std::vector<T>*>(x); });
+        return pybind11::array(c->size(), c->data(), capsule);
+    }
 } // namespace fwdpy11
 
 #endif

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -147,28 +147,18 @@ class tree_visitor_wrapper
     py::array_t<fwdpp::ts::TS_NODE_INT>
     nodes()
     {
-        std::vector<fwdpp::ts::TS_NODE_INT>* nodes
-            = new std::vector<fwdpp::ts::TS_NODE_INT>(
-                nodes_preorder(visitor.tree()));
-
-        auto capsule = py::capsule(nodes, [](void* x) {
-            delete reinterpret_cast<std::vector<fwdpp::ts::TS_NODE_INT>*>(x);
-        });
-        return py::array_t<fwdpp::ts::TS_NODE_INT>(nodes->size(),
-                                                   nodes->data(), capsule);
+        std::vector<fwdpp::ts::TS_NODE_INT> vnodes(
+            nodes_preorder(visitor.tree()));
+        return fwdpy11::make_1d_array_with_capsule(std::move(vnodes));
     }
 
-    py::array
+    py::array_t<fwdpp::ts::TS_NODE_INT>
     samples() const
     {
-        std::vector<fwdpp::ts::TS_NODE_INT>* s
-            = new std::vector<fwdpp::ts::TS_NODE_INT>(
-                visitor.tree().samples_list_begin(),
-                visitor.tree().samples_list_end());
-        auto capsule = py::capsule(s, [](void* x) {
-            delete reinterpret_cast<std::vector<fwdpp::ts::TS_NODE_INT>*>(x);
-        });
-        return py::array(s->size(), s->data(), capsule);
+        std::vector<fwdpp::ts::TS_NODE_INT> s(
+            visitor.tree().samples_list_begin(),
+            visitor.tree().samples_list_end());
+        return fwdpy11::make_1d_array_with_capsule(std::move(s));
     }
 
     py::array
@@ -405,16 +395,8 @@ init_tree_iterator(py::module& m)
         .def_property_readonly(
             "roots",
             [](const tree_visitor_wrapper& self) {
-                std::vector<fwdpp::ts::TS_NODE_INT>* roots
-                    = new std::vector<fwdpp::ts::TS_NODE_INT>(
-                        fwdpp::ts::get_roots(self.visitor.tree()));
-
-                auto capsule = py::capsule(roots, [](void* x) {
-                    delete reinterpret_cast<
-                        std::vector<fwdpp::ts::TS_NODE_INT>*>(x);
-                });
-
-                return py::array(roots->size(), roots->data(), capsule);
+                auto roots = fwdpp::ts::get_roots(self.visitor.tree());
+                return fwdpy11::make_1d_array_with_capsule(std::move(roots));
             },
             R"delim(
             Return marginal tree roots as numpy.ndarray

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -193,11 +193,7 @@ class tree_visitor_wrapper
                 std::sort(begin(samples_below_buffer),
                           end(samples_below_buffer));
             }
-        auto capsule = py::capsule(&samples_below_buffer, [](void* x) {
-            reinterpret_cast<decltype(samples_below_buffer)*>(x)->clear();
-        });
-        return py::array(samples_below_buffer.size(),
-                         samples_below_buffer.data(), capsule);
+        return fwdpy11::make_1d_ndarray_readonly(samples_below_buffer);
     }
 
     fwdpp::ts::TS_NODE_INT

--- a/fwdpy11/src/ts/count_mutations.cc
+++ b/fwdpy11/src/ts/count_mutations.cc
@@ -2,6 +2,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 #include <fwdpy11/types/Population.hpp>
+#include <fwdpy11/numpy/array.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
 
 namespace py = pybind11;
@@ -11,19 +12,15 @@ PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::Mutation>);
 void
 init_count_mutations(py::module& m)
 {
-    m.def("count_mutations",
-          [](const fwdpy11::Population& pop,
-             const std::vector<fwdpp::ts::TS_NODE_INT>& samples) {
-              std::vector<fwdpp::uint_t>* mc
-                  = new std::vector<fwdpp::uint_t>(pop.mutations.size(), 0);
-              fwdpp::ts::count_mutations(pop.tables, pop.mutations, samples,
-                                         *mc);
-              py::capsule cap(mc, [](void* v) {
-                  delete reinterpret_cast<std::vector<fwdpp::uint_t>*>(v);
-              });
-              return py::array(mc->size(), mc->data(), cap);
-          },
-          R"delim(
+    m.def(
+        "count_mutations",
+        [](const fwdpy11::Population& pop,
+           const std::vector<fwdpp::ts::TS_NODE_INT>& samples) {
+            std::vector<fwdpp::uint_t> mc(pop.mutations.size(), 0);
+            fwdpp::ts::count_mutations(pop.tables, pop.mutations, samples, mc);
+            return fwdpy11::make_1d_array_with_capsule(std::move(mc));
+        },
+        R"delim(
           Count mutation occurrences in a sample of nodes.
 
           :param pop: A population
@@ -35,19 +32,16 @@ init_count_mutations(py::module& m)
           :rtype: numpy.ndarray
           )delim");
 
-    m.def("count_mutations",
-          [](const fwdpp::ts::table_collection& tables,
-             const std::vector<fwdpy11::Mutation>& mutations,
-             const std::vector<fwdpp::ts::TS_NODE_INT>& samples) {
-              std::vector<fwdpp::uint_t>* mc
-                  = new std::vector<fwdpp::uint_t>(mutations.size(), 0);
-              fwdpp::ts::count_mutations(tables, mutations, samples, *mc);
-              py::capsule cap(mc, [](void* v) {
-                  delete reinterpret_cast<std::vector<fwdpp::uint_t>*>(v);
-              });
-              return py::array(mc->size(), mc->data(), cap);
-          },
-          R"delim(
+    m.def(
+        "count_mutations",
+        [](const fwdpp::ts::table_collection& tables,
+           const std::vector<fwdpy11::Mutation>& mutations,
+           const std::vector<fwdpp::ts::TS_NODE_INT>& samples) {
+            std::vector<fwdpp::uint_t> mc(mutations.size(), 0);
+            fwdpp::ts::count_mutations(tables, mutations, samples, mc);
+            return fwdpy11::make_1d_array_with_capsule(std::move(mc));
+        },
+        R"delim(
           Count mutation occurrences in a sample of nodes.
 
           :param tables: A table collection

--- a/fwdpy11/src/ts/simplify.cc
+++ b/fwdpy11/src/ts/simplify.cc
@@ -1,4 +1,5 @@
 #include <fwdpy11/types/Population.hpp>
+#include <fwdpy11/numpy/array.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
@@ -42,12 +43,8 @@ simplify(const fwdpy11::Population& pop,
     fwdpp::ts::table_simplifier simplifier(pop.tables.genome_length());
     auto rv = simplifier.simplify(t, samples);
     t.build_indexes();
-    decltype(rv.first)* idmap = new decltype(rv.first)(std::move(rv.first));
-    py::capsule cap(idmap, [](void* v) {
-        delete reinterpret_cast<decltype(rv.first)*>(v);
-    });
-    return py::make_tuple(std::move(t),
-                          py::array(idmap->size(), idmap->data(), cap));
+    return py::make_tuple(std::move(t), fwdpy11::make_1d_array_with_capsule(
+                                            std::move(rv.first)));
 }
 
 void
@@ -102,13 +99,7 @@ init_simplify_functions(py::module& m)
             fwdpp::ts::table_simplifier simplifier(tables.genome_length());
             auto rv = simplifier.simplify(t, samples);
             t.build_indexes();
-            decltype(rv.first)* idmap
-                = new decltype(rv.first)(std::move(rv.first));
-            py::capsule cap(idmap, [](void* v) {
-                delete reinterpret_cast<decltype(rv.first)*>(v);
-            });
-            return py::make_tuple(
-                std::move(t), py::array(idmap->size(), idmap->data(), cap));
+            return py::make_tuple(std::move(t),fwdpy11::make_1d_array_with_capsule(std::move(rv.first)));
         },
         py::arg("tables"), py::arg("samples"),
         R"delim(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,5 @@ set_target_properties(custom_stateless_genotype PROPERTIES LIBRARY_OUTPUT_DIRECT
 pybind11_add_module(custom_additive custom_additive.cpp)
 target_link_libraries(custom_additive PRIVATE GSL::gsl GSL::gslcblas)
 set_target_properties(custom_additive PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+pybind11_add_module(numpy_array_interface numpy_array_interface.cpp)
+set_target_properties(numpy_array_interface PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/tests/numpy_array_interface.cpp
+++ b/tests/numpy_array_interface.cpp
@@ -34,14 +34,7 @@ PYBIND11_MODULE(numpy_array_interface, m)
              [](const VecBackedArray& self) {
                  return fwdpy11::make_1d_ndarray_readonly(self.x);
              })
-        .def("x_readwrite_via_capsule",
-             [](const VecBackedArray& self) {
-                 decltype(VecBackedArray::x)* v
-                     = new (decltype(VecBackedArray::x));
-                 v->assign(begin(self.x), end(self.x));
-                 return fwdpy11::make_1d_array_with_capsule(v);
-             })
-        .def("x_readwrite_via_capsule_with_steal", [](VecBackedArray& self) {
+        .def("x_readwrite_via_capsule", [](VecBackedArray& self) {
             return fwdpy11::make_1d_array_with_capsule(std::move(self.x));
         });
 

--- a/tests/numpy_array_interface.cpp
+++ b/tests/numpy_array_interface.cpp
@@ -30,8 +30,19 @@ PYBIND11_MODULE(numpy_array_interface, m)
              [](const VecBackedArray& self) {
                  return fwdpy11::make_1d_ndarray(self.x);
              })
-        .def("x_readonly", [](const VecBackedArray& self) {
-            return fwdpy11::make_1d_ndarray_readonly(self.x);
+        .def("x_readonly",
+             [](const VecBackedArray& self) {
+                 return fwdpy11::make_1d_ndarray_readonly(self.x);
+             })
+        .def("x_readwrite_via_capsule",
+             [](const VecBackedArray& self) {
+                 decltype(VecBackedArray::x)* v
+                     = new (decltype(VecBackedArray::x));
+                 v->assign(begin(self.x), end(self.x));
+                 return fwdpy11::make_1d_array_with_capsule(v);
+             })
+        .def("x_readwrite_via_capsule_with_steal", [](VecBackedArray& self) {
+            return fwdpy11::make_1d_array_with_capsule(self.x);
         });
 
     py::class_<VecBacked2DArray>(m, "VecBacked2DArray")

--- a/tests/numpy_array_interface.cpp
+++ b/tests/numpy_array_interface.cpp
@@ -1,0 +1,27 @@
+#include <vector>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <fwdpy11/numpy/array.hpp>
+
+namespace py = pybind11;
+
+struct VecBackedArray
+{
+    std::vector<double> x;
+    VecBackedArray() : x(std::vector<double>(5, 1.0)) {}
+};
+
+PYBIND11_MODULE(numpy_array_interface, m)
+{
+    py::class_<VecBackedArray>(m, "VecBackedArray")
+        .def(py::init<>())
+        .def("x_readwrite", [](const VecBackedArray& self) {
+            return fwdpy11::make_1d_ndarray(self.x);
+        })
+        .def("x_readonly", [](const VecBackedArray& self) {
+            return fwdpy11::make_1d_ndarray_readonly(self.x);
+        });
+
+}
+

--- a/tests/numpy_array_interface.cpp
+++ b/tests/numpy_array_interface.cpp
@@ -42,7 +42,7 @@ PYBIND11_MODULE(numpy_array_interface, m)
                  return fwdpy11::make_1d_array_with_capsule(v);
              })
         .def("x_readwrite_via_capsule_with_steal", [](VecBackedArray& self) {
-            return fwdpy11::make_1d_array_with_capsule(self.x);
+            return fwdpy11::make_1d_array_with_capsule(std::move(self.x));
         });
 
     py::class_<VecBacked2DArray>(m, "VecBacked2DArray")

--- a/tests/numpy_array_interface.cpp
+++ b/tests/numpy_array_interface.cpp
@@ -12,16 +12,41 @@ struct VecBackedArray
     VecBackedArray() : x(std::vector<double>(5, 1.0)) {}
 };
 
+struct VecBacked2DArray
+{
+    std::size_t nrow, ncol;
+    std::vector<double> x;
+    VecBacked2DArray(std::size_t nr, std::size_t nc)
+        : nrow(nr), ncol(nc), x(std::vector<double>(ncol * nrow, 0.0))
+    {
+    }
+};
+
 PYBIND11_MODULE(numpy_array_interface, m)
 {
     py::class_<VecBackedArray>(m, "VecBackedArray")
         .def(py::init<>())
-        .def("x_readwrite", [](const VecBackedArray& self) {
-            return fwdpy11::make_1d_ndarray(self.x);
-        })
+        .def("x_readwrite",
+             [](const VecBackedArray& self) {
+                 return fwdpy11::make_1d_ndarray(self.x);
+             })
         .def("x_readonly", [](const VecBackedArray& self) {
             return fwdpy11::make_1d_ndarray_readonly(self.x);
         });
 
+    py::class_<VecBacked2DArray>(m, "VecBacked2DArray")
+        .def(py::init<std::size_t, std::size_t>())
+        .def("x_readwrite",
+             [](const VecBacked2DArray& self) {
+                 return fwdpy11::make_2d_ndarray(self.x, self.nrow, self.ncol);
+             })
+        .def("x_readonly",
+             [](const VecBacked2DArray& self) {
+                 return fwdpy11::make_2d_ndarray_readonly(self.x, self.nrow,
+                                                          self.ncol);
+             })
+        .def_property_readonly("shape", [](const VecBacked2DArray& self) {
+            return py::make_tuple(self.nrow, self.ncol);
+        });
 }
 

--- a/tests/test_numpy_array_interface.py
+++ b/tests/test_numpy_array_interface.py
@@ -17,6 +17,18 @@ class TestNumpyArrayInterface1D(unittest.TestCase):
         self.assertEqual(a.flags.owndata, False)
         self.assertEqual(a.flags.writeable, False)
 
+    def test_readwrite_via_capsule(self):
+        a = self.v.x_readwrite_via_capsule()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, True)
+
+    def test_readwrite_via_capsule_with_steal(self):
+        a = self.v.x_readwrite_via_capsule_with_steal()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, True)
+        b = self.v.x_readwrite()
+        self.assertEqual(b.shape[0], 0)
+
 
 class TestNumpyArrayInterface2D(unittest.TestCase):
     @classmethod

--- a/tests/test_numpy_array_interface.py
+++ b/tests/test_numpy_array_interface.py
@@ -1,0 +1,22 @@
+import unittest
+import numpy_array_interface
+
+
+class TestNumpyArrayInterface(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.v = numpy_array_interface.VecBackedArray()
+
+    def test_readwrite(self):
+        a = self.v.x_readwrite()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, True)
+
+    def test_readonly(self):
+        a = self.v.x_readonly()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numpy_array_interface.py
+++ b/tests/test_numpy_array_interface.py
@@ -21,11 +21,6 @@ class TestNumpyArrayInterface1D(unittest.TestCase):
         a = self.v.x_readwrite_via_capsule()
         self.assertEqual(a.flags.owndata, False)
         self.assertEqual(a.flags.writeable, True)
-
-    def test_readwrite_via_capsule_with_steal(self):
-        a = self.v.x_readwrite_via_capsule_with_steal()
-        self.assertEqual(a.flags.owndata, False)
-        self.assertEqual(a.flags.writeable, True)
         b = self.v.x_readwrite()
         self.assertEqual(b.shape[0], 0)
 

--- a/tests/test_numpy_array_interface.py
+++ b/tests/test_numpy_array_interface.py
@@ -2,10 +2,30 @@ import unittest
 import numpy_array_interface
 
 
-class TestNumpyArrayInterface(unittest.TestCase):
+class TestNumpyArrayInterface1D(unittest.TestCase):
     @classmethod
     def setUp(self):
         self.v = numpy_array_interface.VecBackedArray()
+
+    def test_readwrite(self):
+        a = self.v.x_readwrite()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, True)
+
+    def test_readonly(self):
+        a = self.v.x_readonly()
+        self.assertEqual(a.flags.owndata, False)
+        self.assertEqual(a.flags.writeable, False)
+
+
+class TestNumpyArrayInterface2D(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.v = numpy_array_interface.VecBacked2DArray(7, 3)
+
+    def test_shape(self):
+        a = self.v.x_readwrite()
+        self.assertEqual(a.shape, self.v.shape)
 
     def test_readwrite(self):
         a = self.v.x_readwrite()


### PR DESCRIPTION
* Adds tests of the C++ back-end for returning non-owning numpy arrays where the memory is based on a `std::vector`.  
* Change implementation of `fwdpy11.TreeIterator.samples_below`. 
