### PR TITLE
Simplify with respect to a sample list derived from individual metadata.

### DIFF
--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -42,15 +42,18 @@ namespace fwdpy11
                     std::vector<fwdpp::uint_t> &mcounts_from_preserved_nodes,
                     fwdpp::ts::table_collection &tables,
                     fwdpp::ts::table_simplifier &simplifier,
-                    const fwdpp::ts::TS_NODE_INT first_sample_node,
-                    const std::size_t num_samples,
                     const bool preserve_selected_fixations,
                     const bool simulating_neutral_variants,
                     const bool suppress_edge_table_indexing)
     {
         tables.sort_tables_for_simplification();
-        std::vector<std::int32_t> samples(num_samples);
-        std::iota(samples.begin(), samples.end(), first_sample_node);
+        std::vector<std::int32_t> samples;
+        samples.reserve(2*pop.diploids.size());
+        for(auto & m : pop.diploid_metadata)
+        {
+            samples.push_back(m.nodes[0]);
+            samples.push_back(m.nodes[1]);
+        }
         auto rv = simplifier.simplify(tables, samples);
 
         for (auto &s : samples)

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -203,8 +203,7 @@ evolve_with_tree_sequences(
                     // TODO: update this to allow neutral mutations to be simulated
                     auto rv = fwdpy11::simplify_tables(
                         pop, pop.mcounts_from_preserved_nodes, pop.tables,
-                        simplifier, pop.tables.num_nodes() - 2 * pop.N,
-                        2 * pop.N, preserve_selected_fixations, false,
+                        simplifier, preserve_selected_fixations, false,
                         suppress_edge_table_indexing);
                     if (suppress_edge_table_indexing == false)
                         {
@@ -294,7 +293,6 @@ evolve_with_tree_sequences(
             // TODO: update this to allow neutral mutations to be simulated
             auto rv = fwdpy11::simplify_tables(
                 pop, pop.mcounts_from_preserved_nodes, pop.tables, simplifier,
-                pop.tables.num_nodes() - 2 * pop.N, 2 * pop.N,
                 preserve_selected_fixations, false,
                 suppress_edge_table_indexing);
 


### PR DESCRIPTION
Change implementation of `fwdpy11::simplify_tables` to pull sample nodes from alive individual metadata.  This change pre-adapts the back-end for things like overlapping generations.