### PR TITLE
Allow neutral mutations when tree seq recording

### DIFF
--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -23,7 +23,8 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
              suppress_table_indexing=False, record_gvalue_matrix=False,
              stopping_criterion=None,
              track_mutation_counts=False,
-             remove_extinct_variants=True):
+             remove_extinct_variants=True,
+             put_neutral_variants_in_genomes=False):
     """
     Evolve a population with tree sequence recording
 
@@ -104,4 +105,5 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
                                track_mutation_counts,
                                remove_extinct_variants,
                                reset_treeseqs_after_simplify,
-                               post_simplification_recorder)
+                               post_simplification_recorder,
+                               put_neutral_variants_in_genomes)

--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -65,13 +65,6 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
     """
     import warnings
 
-    # Currently, we do not support simulating neutral mutations
-    # during tree sequence simulations, so we make sure that there
-    # are no neutral regions/rates:
-    if len(params.nregions) != 0:
-        raise ValueError(
-            "Simulation of neutral mutations on tree sequences not supported (yet).")
-
     # Test parameters while suppressing warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -96,15 +89,14 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
     from ._fwdpy11 import MutationRegions
     from ._fwdpy11 import dispatch_create_GeneticMap
     from ._fwdpy11 import evolve_with_tree_sequences
-    # TODO: update to allow neutral mutations
-    pneutral = 0
+    pneutral = params.mutrate_n/(params.mutrate_n + params.mutrate_s)
     mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
     rm = dispatch_create_GeneticMap(params.recrate, params.recregions)
 
     from ._fwdpy11 import SampleRecorder
     sr = SampleRecorder()
     evolve_with_tree_sequences(rng, pop, sr, simplification_interval,
-                               params.demography, params.mutrate_s,
+                               params.demography, params.mutrate_n, params.mutrate_s,
                                mm, rm, params.gvalue,
                                recorder, stopping_criterion,
                                params.pself, params.prune_selected is False,

--- a/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
@@ -42,11 +42,19 @@ namespace fwdpy11
               fwdpp::ts::mut_rec_intermediates>
     generate_offspring(
         const rng_t& rng,
-        const std::pair<std::size_t, std::size_t> parent_indexes, poptype& pop,
+        const std::pair<std::size_t, std::size_t> parent_indexes,
+        const bool put_neutral_mutations_in_genomes, poptype& pop,
         typename poptype::diploid_t& offspring, genetic_param_holder& genetics)
     {
+        if (put_neutral_mutations_in_genomes == false)
+            {
+                return fwdpp::ts::generate_offspring(
+                    rng.get(), parent_indexes,
+                    fwdpp::ts::selected_variants_only(), pop, genetics,
+                    offspring);
+            }
         auto offspring_data = fwdpp::ts::generate_offspring(
-            rng.get(), parent_indexes, fwdpp::ts::selected_variants_only(),
+            rng.get(), parent_indexes, fwdpp::ts::all_mutations(),
             pop, genetics, offspring);
 #ifndef NDEBUG
         for (auto& m : offspring_data.first.mutation_keys)
@@ -73,7 +81,8 @@ namespace fwdpy11
         const pick_parent2_fxn& pick2,
         const offspring_metadata_fxn& update_offspring,
         const fwdpp::uint_t generation, fwdpp::ts::table_collection& tables,
-        std::int32_t first_parental_index, std::int32_t next_index)
+        std::int32_t first_parental_index, std::int32_t next_index,
+        const bool put_neutral_mutations_in_genomes)
     {
         fwdpp::debug::all_haploid_genomes_extant(pop);
 
@@ -94,7 +103,7 @@ namespace fwdpy11
                 auto p2 = pick2(p1);
                 auto& dip = offspring[next_offspring];
                 auto offspring_data = generate_offspring(
-                    rng, std::make_pair(p1, p2), pop, dip, genetics);
+                    rng, std::make_pair(p1, p2), put_neutral_mutations_in_genomes, pop, dip, genetics);
                 auto p1id = fwdpp::ts::get_parent_ids(
                     first_parental_index, p1, offspring_data.first.swapped);
                 auto p2id = fwdpp::ts::get_parent_ids(
@@ -119,8 +128,7 @@ namespace fwdpy11
                 // Update nodes of for offspring
                 offspring_metadata[next_offspring].nodes[0]
                     = next_index_local - 1;
-                offspring_metadata[next_offspring].nodes[1]
-                    = next_index_local;
+                offspring_metadata[next_offspring].nodes[1] = next_index_local;
             }
         assert(next_index_local
                == next_index + 2 * static_cast<std::int32_t>(N_next) - 1);

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -88,7 +88,8 @@ namespace fwdpy11
             }
         // TODO: update this to allow neutral mutations to be simulated
         // TODO: better fixation handling via accounting for number of ancient samples
-        if (!preserve_selected_fixations && !simulating_neutral_variants)
+        // NOTE: not checking re: simulating_neutral_variants may be dangerous! Need test!
+        if (!preserve_selected_fixations) // && !simulating_neutral_variants)
             {
                 auto itr = std::remove_if(
                     tables.mutation_table.begin(), tables.mutation_table.end(),
@@ -111,13 +112,14 @@ namespace fwdpy11
 
         // TODO: the blocks below should be abstracted out into a closure
         // that removes these if statements
-        if (!preserve_selected_fixations && !simulating_neutral_variants)
+        // NOTE: not checking re: simulating_neutral_variants may be dangerous! Need test!
+        if (!preserve_selected_fixations) // && !simulating_neutral_variants)
             {
                 fwdpp::ts::flag_mutations_for_recycling(
                     pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
                     pop.generation, std::false_type(), std::false_type());
             }
-        else if (preserve_selected_fixations && !simulating_neutral_variants)
+        else if (preserve_selected_fixations) // && !simulating_neutral_variants)
             {
                 fwdpp::ts::flag_mutations_for_recycling(
                     pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(),

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -62,9 +62,15 @@ namespace fwdpy11
             fwdpy11::serialize_ancient_sample_records()(
                 buffer, pop->ancient_sample_records);
             fwdpp::io::serialize_population(buffer, *pop);
-            //preserved mutation counts added in 0.5.2, which is format version 4
+            //mcounts and preserved mutation counts added in 0.5.2, which is format version 4
             fwdpp::io::scalar_writer w;
-            std::size_t msize = pop->mcounts_from_preserved_nodes.size();
+            std::size_t msize = pop->mcounts.size();
+            w(buffer, &msize);
+            if (msize > 0)
+                {
+                    w(buffer, pop->mcounts.data(), msize);
+                }
+            msize = pop->mcounts_from_preserved_nodes.size();
             w(buffer, &msize);
             if (msize > 0)
                 {
@@ -128,6 +134,12 @@ namespace fwdpy11
                 fwdpp::io::scalar_reader r;
                 if (version >= 4) // >= version 0.5.2
                     {
+                        r(buffer, &msize);
+                        pop.mcounts.resize(msize);
+                        if (msize > 0)
+                            {
+                                r(buffer, pop.mcounts.data(), msize);
+                            }
                         r(buffer, &msize);
                         pop.mcounts_from_preserved_nodes.resize(msize);
                         if (msize > 0)

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -219,6 +219,7 @@ evolve_with_tree_sequences(
     bool simplified = false;
     fwdpp::ts::table_simplifier simplifier(pop.tables.genome_length());
     bool stopping_criteron_met = false;
+    const bool simulating_neutral_variants = (mu_neutral > 0.0) ? true : false;
     for (std::uint32_t gen = 0;
          gen < num_generations && !stopping_criteron_met; ++gen)
         {
@@ -247,18 +248,10 @@ evolve_with_tree_sequences(
                     // TODO: update this to allow neutral mutations to be simulated
                     auto rv = fwdpy11::simplify_tables(
                         pop, pop.mcounts_from_preserved_nodes, pop.tables,
-                        simplifier, preserve_selected_fixations, false,
+                        simplifier, preserve_selected_fixations, simulating_neutral_variants,
                         suppress_edge_table_indexing);
-                    if (suppress_edge_table_indexing == false)
-                        {
-                            genetics.mutation_recycling_bin = fwdpp::ts::make_mut_queue(
-                                pop.mcounts, pop.mcounts_from_preserved_nodes);
-                        }
-                    else
-                        {
-                            genetics.mutation_recycling_bin = fwdpp::ts::make_mut_queue(
-                                rv.second, pop.mutations.size());
-                        }
+                    genetics.mutation_recycling_bin = fwdpp::ts::make_mut_queue(
+                        rv.second, pop.mutations.size());
                     simplified = true;
                     next_index = pop.tables.num_nodes();
                     first_parental_index = 0;
@@ -343,7 +336,7 @@ evolve_with_tree_sequences(
             // TODO: update this to allow neutral mutations to be simulated
             auto rv = fwdpy11::simplify_tables(
                 pop, pop.mcounts_from_preserved_nodes, pop.tables, simplifier,
-                preserve_selected_fixations, false,
+                preserve_selected_fixations, simulating_neutral_variants,
                 suppress_edge_table_indexing);
 
             remap_metadata(pop.ancient_sample_metadata, rv.first);

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -101,7 +101,16 @@ evolve_with_tree_sequences(
             throw std::invalid_argument(
                 "selected mutation rate must be non-negative");
         }
-    if (mu_selected > 0.0 && mmodel.weights.empty())
+    if (!std::isfinite(mu_neutral))
+        {
+            throw std::invalid_argument("neutral mutation rate is not finite");
+        }
+    if (mu_neutral < 0.0)
+        {
+            throw std::invalid_argument(
+                "neutral mutation rate must be non-negative");
+        }
+    if (mu_selected + mu_neutral > 0.0 && mmodel.weights.empty())
         {
             throw std::invalid_argument(
                 "nonzero mutation rate incompatible with empty regions");

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -127,11 +127,13 @@ evolve_with_tree_sequences(
             throw std::invalid_argument("node table is not initialized");
         }
 
-    const auto bound_mmodel = [&rng, &mmodel, &pop, mu_selected](
+    const double ttl_mutation_rate = mu_neutral + mu_selected;
+
+    const auto bound_mmodel = [&rng, &mmodel, &pop, ttl_mutation_rate](
                                   fwdpp::flagged_mutation_queue &recycling_bin,
                                   std::vector<fwdpy11::Mutation> &mutations) {
         std::vector<fwdpp::uint_t> rv;
-        unsigned nmuts = gsl_ran_poisson(rng.get(), mu_selected);
+        unsigned nmuts = gsl_ran_poisson(rng.get(), ttl_mutation_rate);
         for (unsigned i = 0; i < nmuts; ++i)
             {
                 std::size_t x

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -68,7 +68,7 @@ void
 evolve_with_tree_sequences(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
     fwdpy11::SampleRecorder &sr, const unsigned simplification_interval,
-    py::array_t<std::uint32_t> popsizes, //const double mu_neutral,
+    py::array_t<std::uint32_t> popsizes, const double mu_neutral,
     const double mu_selected, const fwdpy11::MutationRegions &mmodel,
     const fwdpy11::GeneticMap &rmodel,
     fwdpy11::DiploidPopulationGeneticValue &genetic_value_fxn,

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -83,7 +83,8 @@ evolve_with_tree_sequences(
     const bool remove_extinct_mutations_at_finish,
     const bool reset_treeseqs_to_alive_nodes_after_simplification,
     const fwdpy11::DiploidPopulation_temporal_sampler
-        &post_simplification_recorder)
+        &post_simplification_recorder,
+    const bool put_neutral_mutations_in_genomes)
 {
     //validate the input params
     if (pop.tables.genome_length() == std::numeric_limits<double>::max())
@@ -228,7 +229,8 @@ evolve_with_tree_sequences(
             fwdpy11::evolve_generation_ts(
                 rng, pop, genetics, N_next, pick_first_parent,
                 pick_second_parent, generate_offspring_metadata,
-                pop.generation, pop.tables, first_parental_index, next_index);
+                pop.generation, pop.tables, first_parental_index, next_index,
+                put_neutral_mutations_in_genomes);
 
             //N_next, mu_selected, pick_first_parent,
             //pick_second_parent, generate_offspring_metadata, bound_mmodel,

--- a/tests/test_tree_sequences_with_neutral_mutations.py
+++ b/tests/test_tree_sequences_with_neutral_mutations.py
@@ -55,6 +55,61 @@ class TestKeepFixations(unittest.TestCase):
         """
         pop2 = copy.deepcopy(self.pop)
         rng = fwdpy11.GSLrng(101*45*110*210)  # Use same seed!!!
+        self.params.prune_selected = False
+        params = copy.deepcopy(self.params)
+        fwdpy11.evolvets(rng, pop2, params, 100,
+                         put_neutral_variants_in_genomes=True,
+                         suppress_table_indexing=True)
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         put_neutral_variants_in_genomes=False,
+                         suppress_table_indexing=True)
+        ti = fwdpy11.TreeIterator(
+            self.pop.tables, [i for i in range(2*self.pop.N)])
+        mc = _count_mutations_from_diploids(self.pop)
+        for t in ti:
+            for m in t.mutations():
+                # Have to skip neutral mutations b/c they won't
+                # end up in mc b/c it is obtained from genomes
+                if pop2.mutations[m.key].neutral is False:
+                    self.assertEqual(mc[m.key], self.pop.mcounts[m.key])
+                self.assertEqual(t.leaf_counts(m.node), pop2.mcounts[m.key])
+
+
+class TestPruneFixations(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.params, self.rng, self.pop = set_up_standard_pop_gen_model()
+        self.params.rates = (1e-3, self.params.rates[1], self.params.rates[2])
+        self.params.nregions = [fwdpy11.Region(0, 1, 1)]
+
+    def test_mutation_counts_with_indexing(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         put_neutral_variants_in_genomes=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(np.array_equal(
+            mc, np.array(self.pop.mcounts, dtype=np.uint32)))
+
+    def test_mutation_counts_with_indexing_suppressed(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         suppress_table_indexing=True,
+                         put_neutral_variants_in_genomes=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(np.array_equal(
+            mc, np.array(self.pop.mcounts, dtype=np.uint32)))
+
+    def test_mutation_counts_with_indexing_suppressed_no_neutral_muts_in_genomes(self):
+        """
+        A sim w/ and w/o putting neutral variants in genomes
+        should give the same mutation counts.
+        """
+        pop2 = copy.deepcopy(self.pop)
+        rng = fwdpy11.GSLrng(666**2)  # Use same seed!!!
         params = copy.deepcopy(self.params)
         fwdpy11.evolvets(rng, pop2, params, 100,
                          put_neutral_variants_in_genomes=True,

--- a/tests/test_tree_sequences_with_neutral_mutations.py
+++ b/tests/test_tree_sequences_with_neutral_mutations.py
@@ -1,0 +1,78 @@
+import unittest
+import fwdpy11
+import numpy as np
+import copy
+from test_tree_sequences import set_up_quant_trait_model
+from test_tree_sequences import set_up_standard_pop_gen_model
+
+
+def _count_mutations_from_diploids(pop):
+    mc = np.zeros(len(pop.mutations), dtype=np.uint32)
+    for d in pop.diploids:
+        for k in pop.haploid_genomes[d.first].mutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.first].smutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.second].mutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.second].smutations:
+            mc[k] += 1
+    return mc
+
+
+class TestKeepFixations(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.params, self.rng, self.pop = set_up_quant_trait_model()
+        self.params.rates = (1e-3, self.params.rates[1], self.params.rates[2])
+        self.params.nregions = [fwdpy11.Region(0, 1, 1)]
+
+    def test_mutation_counts_with_indexing(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         put_neutral_variants_in_genomes=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(np.array_equal(
+            mc, np.array(self.pop.mcounts, dtype=np.uint32)))
+
+    def test_mutation_counts_with_indexing_suppressed(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         suppress_table_indexing=True,
+                         put_neutral_variants_in_genomes=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(np.array_equal(
+            mc, np.array(self.pop.mcounts, dtype=np.uint32)))
+
+    def test_mutation_counts_with_indexing_suppressed_no_neutral_muts_in_genomes(self):
+        """
+        A sim w/ and w/o putting neutral variants in genomes
+        should give the same mutation counts.
+        """
+        pop2 = copy.deepcopy(self.pop)
+        rng = fwdpy11.GSLrng(101*45*110*210)  # Use same seed!!!
+        params = copy.deepcopy(self.params)
+        fwdpy11.evolvets(rng, pop2, params, 100,
+                         put_neutral_variants_in_genomes=True,
+                         suppress_table_indexing=True)
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         put_neutral_variants_in_genomes=False,
+                         suppress_table_indexing=True)
+        ti = fwdpy11.TreeIterator(
+            self.pop.tables, [i for i in range(2*self.pop.N)])
+        mc = _count_mutations_from_diploids(self.pop)
+        for t in ti:
+            for m in t.mutations():
+                # Have to skip neutral mutations b/c they won't
+                # end up in mc b/c it is obtained from genomes
+                if pop2.mutations[m.key].neutral is False:
+                    self.assertEqual(mc[m.key], self.pop.mcounts[m.key])
+                self.assertEqual(t.leaf_counts(m.node), pop2.mcounts[m.key])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Change API of `fwdpy11.evolvets` to allow neutral mutations

- [x] Remove error status when attempting to generate neutral mutations during a sim
- [x] Allow for putting neutral mutations into genomes. 
- [ ] Unit tests with table indexing
- [ ] Unit tests with table indexing suppressed
- [ ] Unit tests need to be done with and w/o ancient samples
- [ ] Unit tests need to be done with and w/o preserving fixations during a sim.
- [ ] Need tests of serialization to binary
- [ ] Need tests of pickling
- [x] Initial creation of mutation recycling queue should be done purely from mutation table, so that we can later start from tskit tree seqs including mutations that are not put into diploid genomes.
- [ ] Cleanup TODO comments in the code about neutral mutations.

This PR also updates the fwdpp submodule to be even with fwdpp/dev.

cc @apragsdale