### PR TITLE
Remove extinct genomes

### DIFF
--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -93,7 +93,8 @@ set(EVOLVE_POPULATION_SOURCES src/evolve_population/init.cc
     src/evolve_population/track_mutation_counts.cc
     src/evolve_population/no_stopping.cc
     src/evolve_population/remove_extinct_mutations.cc
-    src/evolve_population/track_ancestral_counts.cc)
+    src/evolve_population/track_ancestral_counts.cc
+    src/evolve_population/remove_extinct_genomes.cc)
 
 set(ALL_SOURCES ${FWDPP_TYPES_SOURCES}
     ${FWDPP_FUNCTIONS_SOURCES}

--- a/fwdpy11/src/evolve_population/remove_extinct_genomes.cc
+++ b/fwdpy11/src/evolve_population/remove_extinct_genomes.cc
@@ -1,0 +1,63 @@
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <stdexcept>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+
+namespace
+{
+    template <typename gcont_t>
+    std::size_t
+    process_genome(const std::size_t current_index, gcont_t& input_genomes,
+                   gcont_t& output_genomes,
+                   std::vector<std::size_t>& genome_index,
+                   std::vector<int>& processed)
+    {
+        std::size_t rv = genome_index[current_index];
+        if (!processed[current_index])
+            {
+                output_genomes.emplace_back(
+                    std::move(input_genomes[current_index]));
+                processed[current_index] = 1;
+                genome_index[current_index] = output_genomes.size() - 1;
+                rv = genome_index[current_index];
+            }
+        return rv;
+    }
+
+    template<typename gcont_t> 
+    void validate(const std::size_t i, const gcont_t & haploid_genomes)
+    {
+        if(i ==std::numeric_limits<std::size_t>::max() || i >= haploid_genomes.size())
+        {
+            throw std::runtime_error("error remapping genome indexes");
+        }
+        if(haploid_genomes[i].n == 0)
+        {
+            throw std::runtime_error("remapped genome is extinct");
+        }
+    }
+} // namespace
+
+void
+remove_extinct_genomes(fwdpy11::DiploidPopulation& pop)
+{
+    decltype(pop.haploid_genomes) genomes;
+    std::vector<std::size_t> genome_index(
+        pop.haploid_genomes.size(), std::numeric_limits<std::size_t>::max());
+    std::vector<int> processed(genome_index.size(), 0);
+    std::vector<int> isizes(genome_index.size(),0);
+    for (auto& dip : pop.diploids)
+        {
+            dip.first = process_genome(dip.first, pop.haploid_genomes, genomes,
+                                       genome_index, processed);
+            validate(dip.first, genomes);
+            dip.second = process_genome(dip.second, pop.haploid_genomes,
+                                        genomes, genome_index, processed);
+            validate(dip.second, genomes);
+        }
+    pop.haploid_genomes.swap(genomes);
+}
+

--- a/fwdpy11/src/evolve_population/remove_extinct_genomes.hpp
+++ b/fwdpy11/src/evolve_population/remove_extinct_genomes.hpp
@@ -1,0 +1,10 @@
+#ifndef FWDPY11_EVOLVE_REMOVE_EXTINCT_GENOMES_HPP
+#define FWDPY11_EVOLVE_REMOVE_EXTINCT_GENOMES_HPP
+
+#include <fwdpy11/types/DiploidPopulation.hpp>
+
+void
+remove_extinct_genomes(fwdpy11::DiploidPopulation& pop);
+
+#endif
+

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -44,6 +44,7 @@
 #include "track_mutation_counts.hpp"
 #include "remove_extinct_mutations.hpp"
 #include "track_ancestral_counts.hpp"
+#include "remove_extinct_genomes.hpp"
 
 namespace py = pybind11;
 
@@ -363,6 +364,7 @@ evolve_with_tree_sequences(
         {
             remove_extinct_mutations(pop);
         }
+    remove_extinct_genomes(pop);
 }
 
 void

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -637,6 +637,28 @@ class TestMutationCounts(unittest.TestCase):
         self.assertTrue(
             all([i == j for i, j in zip(self.pop.mcounts, mc)]) is True)
 
+    def test_mutation_counts_from_genomes(self):
+        """
+        Removing extinct genomes happens after
+        the final mutation count, so let's
+        make sure we can reconstruct the counts
+        from the remapped genomes
+        """
+        mc = [0] * len(self.pop.mutations)
+        mc2 = [0] * len(self.pop2.mutations)
+        for g in self.pop.haploid_genomes:
+            if g.n > 0:
+                for k in g.smutations:
+                    mc[k] += g.n
+        for g in self.pop2.haploid_genomes:
+            if g.n > 0:
+                for k in g.smutations:
+                    mc2[k] += g.n
+        self.assertTrue(
+            all([i == j for i, j in zip(mc, self.pop.mcounts)]) is True)
+        self.assertTrue(
+            all([i == j for i, j in zip(mc2, self.pop2.mcounts)]) is True)
+
 
 class testTreeSequencesNoAncientSamplesPruneFixations(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
At the end of a simulation w/tree sequences, remove all extinct genome objects from the population.

The main effect is to reduce the memory allocated for genomes.