### PR TITLE
Allow neutral mutations during sims with tree sequence recording

### DIFF
--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -65,13 +65,6 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
     """
     import warnings
 
-    # Currently, we do not support simulating neutral mutations
-    # during tree sequence simulations, so we make sure that there
-    # are no neutral regions/rates:
-    if len(params.nregions) != 0:
-        raise ValueError(
-            "Simulation of neutral mutations on tree sequences not supported (yet).")
-
     # Test parameters while suppressing warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -96,15 +89,14 @@ def evolvets(rng, pop, params, simplification_interval, recorder=None,
     from ._fwdpy11 import MutationRegions
     from ._fwdpy11 import dispatch_create_GeneticMap
     from ._fwdpy11 import evolve_with_tree_sequences
-    # TODO: update to allow neutral mutations
-    pneutral = 0
+    pneutral = params.mutrate_n/(params.mutrate_n + params.mutrate_s)
     mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
     rm = dispatch_create_GeneticMap(params.recrate, params.recregions)
 
     from ._fwdpy11 import SampleRecorder
     sr = SampleRecorder()
     evolve_with_tree_sequences(rng, pop, sr, simplification_interval,
-                               params.demography, params.mutrate_s,
+                               params.demography, params.mutrate_n, params.mutrate_s,
                                mm, rm, params.gvalue,
                                recorder, stopping_criterion,
                                params.pself, params.prune_selected is False,

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -27,7 +27,6 @@
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
 #include <fwdpp/ts/remove_fixations_from_gametes.hpp>
-#include <fwdpp/ts/recycling.hpp>
 #include <fwdpp/internal/sample_diploid_helpers.hpp>
 //#include "confirm_mutation_counts.hpp"
 

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -48,12 +48,12 @@ namespace fwdpy11
     {
         tables.sort_tables_for_simplification();
         std::vector<std::int32_t> samples;
-        samples.reserve(2*pop.diploids.size());
-        for(auto & m : pop.diploid_metadata)
-        {
-            samples.push_back(m.nodes[0]);
-            samples.push_back(m.nodes[1]);
-        }
+        samples.reserve(2 * pop.diploids.size());
+        for (auto &m : pop.diploid_metadata)
+            {
+                samples.push_back(m.nodes[0]);
+                samples.push_back(m.nodes[1]);
+            }
         auto rv = simplifier.simplify(tables, samples);
 
         for (auto &s : samples)
@@ -86,45 +86,72 @@ namespace fwdpy11
                 fwdpp::fwdpp_internal::process_haploid_genomes(
                     pop.haploid_genomes, pop.mutations, pop.mcounts);
             }
-        // TODO: update this to allow neutral mutations to be simulated
-        // TODO: better fixation handling via accounting for number of ancient samples
-        if (!preserve_selected_fixations && !simulating_neutral_variants)
-            {
-                auto itr = std::remove_if(
-                    tables.mutation_table.begin(), tables.mutation_table.end(),
-                    [&pop, &mcounts_from_preserved_nodes](
-                        const fwdpp::ts::mutation_record &mr) {
-                        return pop.mcounts[mr.key] == 2 * pop.diploids.size()
-                               && mcounts_from_preserved_nodes[mr.key] == 0;
-                    });
-                auto d = std::distance(itr, end(tables.mutation_table));
-                tables.mutation_table.erase(itr, end(tables.mutation_table));
-                if (d)
+
+        // If we are here, then the tables are indexed and mutations are counted.
+        // If there are ancient samples and we are simulating neutral variants,
+        // then we do not know their frequencies.  Thus, neutral
+        // fixations will not be removed until the end of the simulation.
+        // To change this behavior, the logic above would need to allow
+        // for mutation counting from tree seqs w/ancient samples or to
+        // force a tree traversal here if there are ancient samples.
+        // Such a traversal would allow for the purging of "global" fixations,
+        // e.g., mutations on root nodes in trees w/only 1 root.
+        // NOTE: if we use tree sequences to globablly purge fixations,
+        // then we cannot test that genetic values of ancient sample metadata
+        // equal genetic values calculated from tree sequences.
+        // Behavior change in 0.5.3: check for fixations
+        // no matter what.
+
+        auto itr = std::remove_if(
+            tables.mutation_table.begin(), tables.mutation_table.end(),
+            [&pop, &mcounts_from_preserved_nodes, preserve_selected_fixations](
+                const fwdpp::ts::mutation_record &mr) {
+                if (pop.mutations[mr.key].neutral == false
+                    && preserve_selected_fixations)
                     {
-                        tables.rebuild_site_table();
+                        return false;
                     }
+                return pop.mcounts[mr.key] == 2 * pop.diploids.size()
+                       && mcounts_from_preserved_nodes[mr.key] == 0;
+            });
+        auto d = std::distance(itr, end(tables.mutation_table));
+        tables.mutation_table.erase(itr, end(tables.mutation_table));
+        if (d)
+            {
+                tables.rebuild_site_table();
+            }
+        if (preserve_selected_fixations == false)
+            {
+                // b/c neutral mutations not in genomes!
                 fwdpp::ts::remove_fixations_from_haploid_genomes(
                     pop.haploid_genomes, pop.mutations, pop.mcounts,
                     mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
                     preserve_selected_fixations);
             }
 
-        // TODO: the blocks below should be abstracted out into a closure
-        // that removes these if statements
-        if (!preserve_selected_fixations && !simulating_neutral_variants)
+        // Behavior change in 0.5.3: set all fixation counts to 0
+        // to flag for recycling if possible.
+        // NOTE: this may slow things down a touch?
+        for (auto &i : rv.second)
             {
-                fwdpp::ts::flag_mutations_for_recycling(
-                    pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
-                    pop.generation, std::false_type(), std::false_type());
+                if (pop.mcounts[i] == 2 * pop.diploids.size()
+                    && mcounts_from_preserved_nodes[i] == 0)
+                    {
+                        if (pop.mutations[i].neutral
+                            || !preserve_selected_fixations)
+                            {
+                                // flag variant for recycling
+                                pop.mcounts[i] = 0;
+                                // flag item for removal from return value,
+                                // as mutation is no longer considered "preserved"
+                                i = std::numeric_limits<std::size_t>::max();
+                            }
+                    }
             }
-        else if (preserve_selected_fixations && !simulating_neutral_variants)
-            {
-                fwdpp::ts::flag_mutations_for_recycling(
-                    pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
-                    pop.generation, std::true_type(), std::false_type());
-            }
-        //confirm_mutation_counts(pop, tables);
+        rv.second.erase(std::remove(begin(rv.second), end(rv.second),
+                                    std::numeric_limits<std::size_t>::max()),
+                        end(rv.second));
         return rv;
-    }
+    } // namespace fwdpy11
 } // namespace fwdpy11
 #endif

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -43,7 +43,11 @@ namespace fwdpy11
             // Changed to 4 in 0.5.2 to explicitly
             // handle the mutation counts, so that we can dodge tree
             // sequence traversal.
-            return 4;
+            // Changed to 5 in 0.5.3 to handle pop.mcounts explicitly.
+            // The reason is that the fwdpp back-end regenerates
+            // them by traversing genomes, but we may have neutral
+            // mutations not in the genomes.
+            return 5;
         }
 
         template <typename streamtype, typename poptype>
@@ -69,6 +73,13 @@ namespace fwdpy11
             if (msize > 0)
                 {
                     w(buffer, pop->mcounts_from_preserved_nodes.data(), msize);
+                }
+            // Added in 0.5.3/file version 5:
+            msize = pop->mcounts.size();
+            w(buffer, &msize);
+            if (msize > 0)
+                {
+                    w(buffer, pop->mcounts.data(), msize);
                 }
             fwdpp::ts::io::serialize_tables(buffer, pop->tables);
             msize = pop->genetic_value_matrix.size();
@@ -135,6 +146,15 @@ namespace fwdpy11
                                 r(buffer,
                                   pop.mcounts_from_preserved_nodes.data(),
                                   msize);
+                            }
+                    }
+                if (version >= 5) // 0.5.3
+                    {
+                        r(buffer, &msize);
+                        pop.mcounts.resize(msize);
+                        if (msize > 0)
+                            {
+                                r(buffer, pop.mcounts.data(), msize);
                             }
                     }
 

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -37,6 +37,7 @@
 #include <fwdpy11/regions/MutationRegions.hpp>
 #include <fwdpy11/regions/RecombinationRegions.hpp>
 #include <fwdpy11/samplers.hpp>
+#include <fwdpp/ts/recycling.hpp>
 #include "util.hpp"
 #include "diploid_pop_fitness.hpp"
 #include "index_and_count_mutations.hpp"

--- a/tests/test_tree_sequences_with_neutral_mutations.py
+++ b/tests/test_tree_sequences_with_neutral_mutations.py
@@ -1,0 +1,115 @@
+import unittest
+import fwdpy11
+import numpy as np
+import copy
+from test_tree_sequences import set_up_quant_trait_model
+from test_tree_sequences import set_up_standard_pop_gen_model
+
+
+def _count_mutations_from_diploids(pop):
+    mc = np.zeros(len(pop.mutations), dtype=np.uint32)
+    for d in pop.diploids:
+        for k in pop.haploid_genomes[d.first].mutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.first].smutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.second].mutations:
+            mc[k] += 1
+        for k in pop.haploid_genomes[d.second].smutations:
+            mc[k] += 1
+    return mc
+
+
+def _compare_counts_for_nonneutral_variants(pop, mc):
+    w = np.array(
+        [i for i, j in enumerate(pop.mutations) if j.neutral is False], dtype=np.uint32)
+    return all(pop.mcounts[w] == mc[w]) is True
+
+
+class TestKeepFixations(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.params, self.rng, self.pop = set_up_quant_trait_model()
+        self.params.rates = (1e-3, self.params.rates[1], self.params.rates[2])
+        self.params.nregions = [fwdpy11.Region(0, 1, 1)]
+
+    def test_mutation_counts_with_indexing(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(_compare_counts_for_nonneutral_variants(self.pop, mc))
+
+    def test_mutation_counts_with_indexing_suppressed(self):
+        """
+        Tests atypical use case where neutral mutations are placed into genomes
+        """
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         suppress_table_indexing=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(_compare_counts_for_nonneutral_variants(self.pop, mc))
+
+    def test_mutation_counts_with_indexing_suppressed_no_neutral_muts_in_genomes(self):
+        """
+        A sim w/ and w/o putting neutral variants in genomes
+        should give the same mutation counts.
+        """
+        pop2 = copy.deepcopy(self.pop)
+        rng = fwdpy11.GSLrng(101*45*110*210)  # Use same seed!!!
+        self.params.prune_selected = False
+        params = copy.deepcopy(self.params)
+        fwdpy11.evolvets(rng, pop2, params, 100,
+                         suppress_table_indexing=True)
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         suppress_table_indexing=True)
+        ti = fwdpy11.TreeIterator(
+            self.pop.tables, [i for i in range(2*self.pop.N)])
+        mc = _count_mutations_from_diploids(self.pop)
+        for t in ti:
+            for m in t.mutations():
+                # Have to skip neutral mutations b/c they won't
+                # end up in mc b/c it is obtained from genomes
+                if pop2.mutations[m.key].neutral is False:
+                    self.assertEqual(mc[m.key], self.pop.mcounts[m.key])
+                self.assertEqual(t.leaf_counts(m.node), pop2.mcounts[m.key])
+
+
+class TestPruneFixations(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.params, self.rng, self.pop = set_up_standard_pop_gen_model()
+        self.params.rates = (1e-3, self.params.rates[1], self.params.rates[2])
+        self.params.nregions = [fwdpy11.Region(0, 1, 1)]
+
+    def test_mutation_counts_with_indexing(self):
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(_compare_counts_for_nonneutral_variants(self.pop, mc))
+        self.assertEqual(len(np.where(mc == 2*self.pop.N)[0]), 0)
+
+    def test_mutation_counts_with_indexing_suppressed(self):
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100,
+                         suppress_table_indexing=True)
+        mc = _count_mutations_from_diploids(self.pop)
+        self.assertTrue(_compare_counts_for_nonneutral_variants(self.pop, mc))
+        self.assertEqual(len(np.where(mc == 2*self.pop.N)[0]), 0)
+
+
+class TestNeutralMutRegions(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.params, self.rng, self.pop = set_up_standard_pop_gen_model()
+        self.params.rates = (1e-3, self.params.rates[1], self.params.rates[2])
+        self.params.nregions = [fwdpy11.Region(0, 0.25, 1),
+                                fwdpy11.Region(0.5, 1, 1)]
+
+    def test_neutral_mut_locations(self):
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 100)
+        pos = [self.pop.tables.sites[i.site].position for
+               i in self.pop.tables.mutations if i.neutral]
+        self.assertTrue(all([i < 0.25 or i >= 0.5 for i in pos]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR replaces #307 

- [x] Update API to allow neutral mutations
- [x] Change file format to 5 and explicitly write/read `pop.mcounts`
- [x] Add unit tests


cc @apragsdale