### PR TITLE
C++ back-end changes.

### DIFF
--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -46,16 +46,10 @@ namespace fwdpy11
                     const bool suppress_edge_table_indexing)
     {
         tables.sort_tables_for_simplification();
-        std::vector<std::int32_t> samples;
-        samples.reserve(2 * pop.diploids.size());
-        for (auto &m : pop.diploid_metadata)
-            {
-                samples.push_back(m.nodes[0]);
-                samples.push_back(m.nodes[1]);
-            }
-        auto rv = simplifier.simplify(tables, samples);
+        pop.fill_alive_nodes();
+        auto rv = simplifier.simplify(tables, pop.alive_nodes);
 
-        for (auto &s : samples)
+        for (auto &s : pop.alive_nodes)
             {
                 s = rv.first[s];
             }
@@ -76,8 +70,8 @@ namespace fwdpy11
         tables.build_indexes();
         if (pop.tables.preserved_nodes.empty())
             {
-                fwdpp::ts::count_mutations(tables, pop.mutations, samples,
-                                           pop.mcounts,
+                fwdpp::ts::count_mutations(tables, pop.mutations,
+                                           pop.alive_nodes, pop.mcounts,
                                            mcounts_from_preserved_nodes);
             }
         else

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -30,6 +30,19 @@ namespace fwdpy11
             this->validate_haploid_genome_counts(gcounts);
         }
 
+        void
+        fill_sample_nodes_from_metadata(
+            std::vector<fwdpp::ts::TS_NODE_INT> &n,
+            const std::vector<fwdpy11::DiploidMetadata> &metadata)
+        {
+            n.clear();
+            for (auto &md : metadata)
+                {
+                    n.push_back(md.nodes[0]);
+                    n.push_back(md.nodes[1]);
+                }
+        }
+
       public:
         using dipvector_t = std::vector<DiploidGenotype>;
         using diploid_t = dipvector_t::value_type;
@@ -41,10 +54,13 @@ namespace fwdpy11
                                            typename popbase_t::mcont_t>;
 
         dipvector_t diploids;
+        std::vector<fwdpp::ts::TS_NODE_INT> alive_nodes,
+            preserved_sample_nodes;
 
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
-            : Population{ N, length }, diploids(N, { 0, 0 })
+            : Population{ N, length },
+              diploids(N, { 0, 0 }), alive_nodes{}, preserved_sample_nodes{}
         {
             if (!N)
                 {
@@ -85,7 +101,8 @@ namespace fwdpy11
             : Population(static_cast<fwdpp::uint_t>(d.size()),
                          std::forward<genomes_input>(g),
                          std::forward<mutations_input>(m), 100),
-              diploids(std::forward<diploids_input>(d))
+              diploids(std::forward<diploids_input>(d)), alive_nodes{},
+              preserved_sample_nodes{}
         //! Constructor for pre-determined population status
         {
             this->process_individual_input();
@@ -165,6 +182,19 @@ namespace fwdpy11
         {
             return sample_random_individuals_details(*this, rng, nsam,
                                                      haplotype, remove_fixed);
+        }
+
+        void
+        fill_alive_nodes()
+        {
+            fill_sample_nodes_from_metadata(alive_nodes, diploid_metadata);
+        }
+
+        void
+        fill_preserved_nodes()
+        {
+            fill_sample_nodes_from_metadata(preserved_sample_nodes,
+                                            ancient_sample_metadata);
         }
     };
 } // namespace fwdpy11


### PR DESCRIPTION
This PR makes some tweaks to the back-end:

* DiploidPopulation now can populate a reusable buffer to track nodes for alive individuals.  This is not visible to Python
* The tree sequence evolution back end is updated to use this new buffer and to streamline how nodes are tracked.