### PR TITLE
Population class organization.

### DIFF
--- a/fwdpy11/headers/fwdpy11/types/Diploid.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Diploid.hpp
@@ -48,6 +48,22 @@ namespace fwdpy11
         std::int32_t nodes[2]; // Nodes in TreeSequence
     };
 
+    inline bool
+    operator==(const DiploidMetadata& lhs, const DiploidMetadata& rhs)
+    {
+        return std::tie(lhs.g, lhs.e, lhs.w) == std::tie(rhs.g, rhs.e, rhs.w)
+               && std::tie(lhs.label, lhs.deme, lhs.sex)
+                      == std::tie(rhs.label, rhs.deme, rhs.sex)
+               && std::tie(lhs.nodes[0], lhs.nodes[1])
+                      == std::tie(rhs.nodes[0], rhs.nodes[1])
+               && std::tie(lhs.parents[0], lhs.parents[1])
+                      == std::tie(rhs.parents[0], rhs.parents[1])
+               && std::tie(lhs.geography[0], lhs.geography[1],
+                           lhs.geography[2])
+                      == std::tie(rhs.geography[0], rhs.geography[1],
+                                  rhs.geography[2]);
+    }
+
     struct ancient_sample_record
     /*! When tracking ancient samples, 
      * We want to be able to provide access to

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -108,11 +108,18 @@ namespace fwdpy11
         dipvector_t diploids;
         std::vector<fwdpp::ts::TS_NODE_INT> alive_nodes,
             preserved_sample_nodes;
+        //TODO: initalized ancient_sample_metadata and tables,
+        //TODO figure out what to do with class constructor??
+        //TODO Introduce types for ancient sample individual and node tracking
+        std::vector<DiploidMetadata> diploid_metadata, ancient_sample_metadata;
+        std::vector<ancient_sample_record> ancient_sample_records;
 
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
             : Population{ N, length },
-              diploids(N, { 0, 0 }), alive_nodes{}, preserved_sample_nodes{}
+              diploids(N, { 0, 0 }), alive_nodes{}, preserved_sample_nodes{},
+              diploid_metadata(N), ancient_sample_metadata{},
+              ancient_sample_records{}
         {
             finish_construction({ N });
         }
@@ -124,10 +131,13 @@ namespace fwdpy11
                           length },
               diploids(std::accumulate(begin(deme_sizes), end(deme_sizes), 0u),
                        { 0, 0 }),
-              alive_nodes{}, preserved_sample_nodes{}
+              alive_nodes{}, preserved_sample_nodes{}, diploid_metadata(N),
+              ancient_sample_metadata{}, ancient_sample_records{}
+
         {
             finish_construction(deme_sizes);
         }
+
         template <typename diploids_input, typename genomes_input,
                   typename mutations_input>
         explicit DiploidPopulation(diploids_input &&d, genomes_input &&g,
@@ -136,7 +146,8 @@ namespace fwdpy11
                          std::forward<genomes_input>(g),
                          std::forward<mutations_input>(m), 100),
               diploids(std::forward<diploids_input>(d)), alive_nodes{},
-              preserved_sample_nodes{}
+              preserved_sample_nodes{}, diploid_metadata(N),
+              ancient_sample_metadata{}, ancient_sample_records{}
         //! Constructor for pre-determined population status
         {
             this->process_individual_input();
@@ -151,7 +162,11 @@ namespace fwdpy11
         virtual bool
         operator==(const DiploidPopulation &rhs) const
         {
-            return this->diploids == rhs.diploids && popbase_t::test_equality(rhs);
+            return this->diploids == rhs.diploids
+                   && this->diploid_metadata == rhs.diploid_metadata
+                   && this->ancient_sample_metadata
+                          == rhs.ancient_sample_metadata
+                   && popbase_t::test_equality(rhs);
         };
 
         void
@@ -228,6 +243,11 @@ namespace fwdpy11
         {
             fill_sample_nodes_from_metadata(preserved_sample_nodes,
                                             ancient_sample_metadata);
+        }
+
+        virtual std::size_t ancient_sample_metadata_size() const override
+        {
+            return ancient_sample_metadata.size();
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/PyPopulation.hpp
@@ -11,7 +11,6 @@
 #include <fwdpp/data_matrix.hpp>
 #include <fwdpp/ts/table_collection.hpp>
 #include "../rng.hpp"
-#include "Diploid.hpp"
 
 namespace fwdpy11
 {
@@ -52,11 +51,6 @@ namespace fwdpy11
         fwdpp::uint_t N;
         fwdpp::uint_t generation;
 
-        //TODO: initalized ancient_sample_metadata and tables,
-        //TODO figure out what to do with class constructor??
-        //TODO Introduce types for ancient sample individual and node tracking
-        std::vector<DiploidMetadata> diploid_metadata, ancient_sample_metadata;
-        std::vector<ancient_sample_record> ancient_sample_records;
         fwdpp::ts::table_collection tables;
 
         // These track genetic values for the individuals differently
@@ -67,8 +61,7 @@ namespace fwdpy11
             ancient_sample_genetic_value_matrix;
 
         PyPopulation(fwdpp::uint_t N_, const double L)
-            : fwdpp_base{ N_ }, N{ N_ }, generation{ 0 }, diploid_metadata(N),
-              ancient_sample_metadata{}, ancient_sample_records{},
+            : fwdpp_base{ N_ }, N{ N_ }, generation{ 0 },
               tables(init_tables(N_, L)), genetic_value_matrix{},
               ancient_sample_genetic_value_matrix{}
         {
@@ -81,8 +74,7 @@ namespace fwdpy11
                                   mutation_container::size_type reserve_size)
             : fwdpp_base{ std::forward<gametes_input>(g),
                           std::forward<mutations_input>(m), reserve_size },
-              N{ N_ }, generation{ 0 }, diploid_metadata(N),
-              ancient_sample_metadata{}, ancient_sample_records{},
+              N{ N_ }, generation{ 0 },
               tables(std::numeric_limits<double>::max()),
               genetic_value_matrix{}, ancient_sample_genetic_value_matrix{}
         {
@@ -250,6 +242,8 @@ namespace fwdpy11
                    && this->ancient_sample_genetic_value_matrix
                           == rhs.ancient_sample_genetic_value_matrix;
         }
+
+        virtual std::size_t ancient_sample_metadata_size() const = 0;
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
+++ b/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
@@ -30,6 +30,7 @@
 #include <fwdpy11/serialization.hpp>
 #include <fwdpy11/serialization/Mutation.hpp>
 #include <fwdpy11/serialization/Diploid.hpp>
+#include <fwdpy11/numpy/array.hpp>
 #include "get_individuals.hpp"
 
 namespace py = pybind11;
@@ -66,6 +67,7 @@ namespace
 } // namespace
 
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidGenotype>);
+PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidMetadata>);
 PYBIND11_MAKE_OPAQUE(fwdpy11::DiploidPopulation::gcont_t);
 PYBIND11_MAKE_OPAQUE(fwdpy11::DiploidPopulation::mcont_t);
 
@@ -105,6 +107,12 @@ init_DiploidPopulation(py::module& m)
                 const fwdpy11::DiploidPopulation& rhs) { return lhs == rhs; })
         .def_readonly("diploids", &fwdpy11::DiploidPopulation::diploids,
                       DIPLOIDS_DOCSTRING)
+        .def_readwrite("diploid_metadata",
+                       &fwdpy11::DiploidPopulation::diploid_metadata,
+                       "Container of diploid metadata.")
+        .def_readwrite("ancient_sample_metadata",
+                       &fwdpy11::DiploidPopulation::ancient_sample_metadata,
+                       "Container of metadata for ancient samples.")
         .def_static(
             "create",
             [](fwdpy11::DiploidPopulation::dipvector_t& diploids,


### PR DESCRIPTION
Remove any notion of "diploidy" from population base class.
Add equality comparison to C++ back-end of DiploidMetadata.
See #392 