### PR TITLE
Update mutation hash table after simpification

### DIFF
--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -26,6 +26,7 @@
 #include <fwdpp/ts/table_collection.hpp>
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
+#include <fwdpp/ts/recycling.hpp>
 #include <fwdpp/ts/remove_fixations_from_gametes.hpp>
 #include <fwdpp/internal/sample_diploid_helpers.hpp>
 //#include "confirm_mutation_counts.hpp"
@@ -63,6 +64,21 @@ namespace fwdpy11
                     }
             }
 #endif
+        // Remove mutations that are simplified out
+        // from the population hash table.
+        std::vector<int> preserved(pop.mutations.size(), 0);
+        for(auto p : rv.second)
+        {
+            preserved[p]=1;
+        }
+        for(std::size_t p=0; p < preserved.size(); ++p)
+        {
+            if(!preserved[p])
+            {
+                fwdpp::ts::detail::process_mutation_index(pop.mutations, pop.mut_lookup, p);
+            }
+        }
+                
         if (suppress_edge_table_indexing == true)
             {
                 pop.mcounts.resize(pop.mutations.size(), 0);

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -161,6 +161,12 @@ class TestTreeSequencesNoAncientSamplesKeepFixations(unittest.TestCase):
         assert max(self.pop.mcounts) == 2 * \
             self.pop.N, "Nothing fixed, so test case is not helpful"
 
+    def test_mut_lookup(self):
+        self.assertEqual(len(self.pop.mut_lookup),
+                         len(self.pop.tables.mutations))
+        self.assertEqual(len(self.pop.mut_lookup), len(self.pop.tables.sites))
+        self.assertTrue(validate_mut_lookup_content(self.pop))
+
     def test_simplify(self):
         tables, idmap = fwdpy11.simplify(self.pop, [i for i in range(10)])
         for i in range(10):
@@ -685,6 +691,12 @@ class TestMutationCounts(unittest.TestCase):
         fwdpy11.evolvets(self.rng2, self.pop2, params2,
                          100, remove_extinct_variants=False)
 
+    def test_mut_lookup(self):
+        self.assertEqual(len(self.pop.mut_lookup),
+                         len(self.pop.tables.mutations))
+        self.assertEqual(len(self.pop.mut_lookup), len(self.pop.tables.sites))
+        self.assertTrue(validate_mut_lookup_content(self.pop))
+
     def test_mutation_counts(self):
         self.assertEqual(sum(self.pop.mcounts), sum(self.pop2.mcounts))
 
@@ -724,6 +736,12 @@ class TestTreeSequencesNoAncientSamplesPruneFixations(unittest.TestCase):
                          100, track_mutation_counts=True)
         assert len(
             self.pop.fixations) > 0, "Nothing fixed, so test case is not helpful"
+
+    def test_mut_lookup(self):
+        self.assertEqual(len(self.pop.mut_lookup),
+                         len(self.pop.tables.mutations))
+        self.assertEqual(len(self.pop.mut_lookup), len(self.pop.tables.sites))
+        self.assertTrue(validate_mut_lookup_content(self.pop))
 
     def test_max_mcounts(self):
         self.assertTrue(max(self.pop.mcounts) < 2*self.pop.N)
@@ -795,6 +813,12 @@ class TestTreeSequencesWithAncientSamplesPruneFixations(unittest.TestCase):
                          100, self.recorder, track_mutation_counts=True)
         assert len(
             self.pop.fixations) > 0, "Nothing fixed, so test case is not helpful"
+
+    def test_mut_lookup(self):
+        self.assertEqual(len(self.pop.mut_lookup),
+                         len(self.pop.tables.mutations))
+        self.assertEqual(len(self.pop.mut_lookup), len(self.pop.tables.sites))
+        self.assertTrue(validate_mut_lookup_content(self.pop))
 
     def test_mutation_table_contents(self):
         self.assertEqual(len(self.pop.mcounts), len(
@@ -896,6 +920,12 @@ class TestSimplificationInterval(unittest.TestCase):
         samples = [i for i in range(2*self.pop.N)] + \
             self.pop.tables.preserved_nodes
         vi = fwdpy11.TreeIterator(self.pop.tables, samples)
+
+    def test_mut_lookup(self):
+        self.assertEqual(len(self.pop.mut_lookup),
+                         len(self.pop.tables.mutations))
+        self.assertEqual(len(self.pop.mut_lookup), len(self.pop.tables.sites))
+        self.assertTrue(validate_mut_lookup_content(self.pop))
 
 
 class TestFixationPreservation(unittest.TestCase):


### PR DESCRIPTION
Candidate fix for #422.

This PR fixes a bug in updating an internal data structure.  This bug has the potential to cause some simulations to throw exceptions due to invalid mutations in the mutation table.