### PR TITLE
Remove "ancient sample records". 

### DIFF
--- a/fwdpy11/headers/fwdpy11/serialization/diploid_metadata.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization/diploid_metadata.hpp
@@ -35,8 +35,7 @@ namespace fwdpy11
     {
         template <typename streamtype>
         inline void
-        operator()(streamtype& buffer,
-                   std::vector<fwdpy11::DiploidMetadata>& vmd) const
+        operator()(streamtype& buffer, std::vector<fwdpy11::DiploidMetadata>& vmd) const
         {
             fwdpp::io::scalar_reader r;
             std::size_t s;
@@ -60,31 +59,16 @@ namespace fwdpy11
         }
     };
 
-    struct serialize_ancient_sample_records
-    {
-        template <typename streamtype>
-        inline void
-        operator()(
-            streamtype& buffer,
-            const std::vector<fwdpy11::ancient_sample_record>& var) const
-        {
-            fwdpp::io::scalar_writer w;
-            std::size_t s = var.size();
-            w(buffer, &s);
-            for (const auto& ar : var)
-                {
-                    w(buffer, &ar.time);
-                    w(buffer, &ar.n1);
-                    w(buffer, &ar.n2);
-                }
-        }
-    };
     struct deserialize_ancient_sample_records
     {
+        struct ancient_sample_record
+        {
+            double time;
+            fwdpp::ts::TS_NODE_INT n1, n2;
+        };
         template <typename streamtype>
         inline void
-        operator()(streamtype& buffer,
-                   std::vector<fwdpy11::ancient_sample_record>& var) const
+        operator()(streamtype& buffer, std::vector<ancient_sample_record>& var) const
         {
             fwdpp::io::scalar_reader r;
             std::size_t s = var.size();

--- a/fwdpy11/headers/fwdpy11/types/Diploid.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Diploid.hpp
@@ -58,23 +58,9 @@ namespace fwdpy11
                       == std::tie(rhs.nodes[0], rhs.nodes[1])
                && std::tie(lhs.parents[0], lhs.parents[1])
                       == std::tie(rhs.parents[0], rhs.parents[1])
-               && std::tie(lhs.geography[0], lhs.geography[1],
-                           lhs.geography[2])
-                      == std::tie(rhs.geography[0], rhs.geography[1],
-                                  rhs.geography[2]);
+               && std::tie(lhs.geography[0], lhs.geography[1], lhs.geography[2])
+                      == std::tie(rhs.geography[0], rhs.geography[1], rhs.geography[2]);
     }
-
-    struct ancient_sample_record
-    /*! When tracking ancient samples, 
-     * We want to be able to provide access to
-     * the individual's metadata PLUS
-     * when they existed and what nodes 
-     * on the tree they are.
-     */
-    {
-        double time;
-        fwdpp::ts::TS_NODE_INT n1, n2;
-    };
 
     //! Typedef for container of diploids
     using dipvector_t = std::vector<DiploidGenotype>;

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -110,13 +110,11 @@ namespace fwdpy11
         //TODO figure out what to do with class constructor??
         //TODO Introduce types for ancient sample individual and node tracking
         std::vector<DiploidMetadata> diploid_metadata, ancient_sample_metadata;
-        std::vector<ancient_sample_record> ancient_sample_records;
 
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
             : Population{ N, length }, diploids(N, { 0, 0 }),
-              diploid_metadata(N), ancient_sample_metadata{},
-              ancient_sample_records{}
+              diploid_metadata(N), ancient_sample_metadata{}
         {
             finish_construction({ N });
         }
@@ -128,9 +126,7 @@ namespace fwdpy11
                           length },
               diploids(std::accumulate(begin(deme_sizes), end(deme_sizes), 0u),
                        { 0, 0 }),
-              diploid_metadata(N), ancient_sample_metadata{},
-              ancient_sample_records{}
-
+              diploid_metadata(N), ancient_sample_metadata{}
         {
             finish_construction(deme_sizes);
         }
@@ -143,7 +139,7 @@ namespace fwdpy11
                          std::forward<genomes_input>(g),
                          std::forward<mutations_input>(m), 100),
               diploids(std::forward<diploids_input>(d)), diploid_metadata(N),
-              ancient_sample_metadata{}, ancient_sample_records{}
+              ancient_sample_metadata{}
         //! Constructor for pre-determined population status
         {
             this->process_individual_input();

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -60,7 +60,6 @@ apply_treseq_resetting_of_ancient_samples(
         {
             pop.tables.preserved_nodes.clear();
             pop.ancient_sample_metadata.clear();
-            pop.ancient_sample_records.clear();
             pop.ancient_sample_genetic_value_matrix.clear();
         }
 }
@@ -485,11 +484,6 @@ evolve_with_tree_sequences(
                                             + offset
                                             + genetics.gvalue[0]->total_dim);
                                 }
-                            // Record the time and nodes for this individual
-                            pop.ancient_sample_records.emplace_back(
-                                fwdpy11::ancient_sample_record{
-                                    static_cast<double>(pop.generation),
-                                    x.first, x.second });
                         }
                     track_ancestral_counts(pop, sr.samples);
                     // Finally, clear the input


### PR DESCRIPTION
Removes some C++ stuff that was still lurking around since early days of tree sequence recording.  The types are redundant with ancient sample metadata, which is a better approach, and they weren't even exposed to Python.