### PR TITLE
Add test of data structure integrity when selected mutations

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,6 @@ set_target_properties(discrete_demography_roundtrips PROPERTIES LIBRARY_OUTPUT_D
 pybind11_add_module(inherit_noise inherit_noise.cpp)
 target_link_libraries(inherit_noise PRIVATE GSL::gsl GSL::gslcblas)
 set_target_properties(inherit_noise PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+pybind11_add_module(EsizeZero EsizeZero.cpp)
+target_link_libraries(EsizeZero PRIVATE GSL::gsl GSL::gslcblas)
+set_target_properties(EsizeZero PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/tests/EsizeZero.cpp
+++ b/tests/EsizeZero.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <fwdpy11/regions/Sregion.hpp>
+#include <fwdpy11/policies/mutation.hpp>
+
+using namespace pybind11::literals;
+
+struct EsizeZero : public fwdpy11::Sregion
+{
+    EsizeZero(const fwdpy11::Region& r) : fwdpy11::Sregion(r, 1.)
+    {
+    }
+
+    std::unique_ptr<fwdpy11::Sregion>
+    clone() const override
+    {
+        return std::unique_ptr<EsizeZero>(new EsizeZero(*this));
+    }
+
+    std::string
+    repr() const override
+    {
+        return "EsizeZero()"_s;
+    }
+
+    pybind11::tuple
+    pickle() const override
+    {
+        return pybind11::make_tuple(Sregion::pickle_Sregion());
+    }
+
+    static EsizeZero
+    unpickle(pybind11::tuple t)
+    {
+        return EsizeZero(fwdpy11::Region::unpickle(t[0]));
+    }
+
+    std::uint32_t
+    operator()(fwdpp::flagged_mutation_queue& recycling_bin,
+               std::vector<fwdpy11::Mutation>& mutations,
+               std::unordered_multimap<double, std::uint32_t>& lookup_table,
+               const std::uint32_t generation,
+               const fwdpy11::GSLrng_t& rng) const override
+    {
+        return fwdpy11::infsites_Mutation(
+            recycling_bin, mutations, lookup_table, false, generation,
+            [this, &rng]() { return region(rng); }, []() { return 0.; },
+            []() { return 1.; }, this->label());
+    }
+};
+
+PYBIND11_MODULE(EsizeZero, m)
+{
+    pybind11::object base = pybind11::module::import("fwdpy11").attr("Sregion");
+    pybind11::class_<EsizeZero, fwdpy11::Sregion>(m, "EsizeZero")
+        .def(pybind11::init([](double beg, double end, double weight, bool coupled,
+                               std::uint16_t label) {
+            return EsizeZero(fwdpy11::Region(beg, end, weight, coupled, label));
+        }));
+}
+

--- a/tests/test_tree_sequences_esize_zero_selected_variants.py
+++ b/tests/test_tree_sequences_esize_zero_selected_variants.py
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2020 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This test is motivated by GitHub issue #432.
+# When a DES/DFE returns an effect size of zero,
+# such variants were not put into the 'smutations'
+# field of a genome, due to the way the fwdpp mutation
+# base class constructor was being called.  In PR #433,
+# we now require a DFE to tell the Mutation type if the
+# variant is neutral or not, and the expectation is that
+# the answer is "False".  This test creates a new Sregion
+# type where all variants have effect size zero and we run
+# a quick sim to make sure that they are all in both genomes
+# and in the mutation table.
+
+import fwdpy11
+import unittest
+import EsizeZero
+
+
+class Recorder(object):
+    def __init__(self):
+        self.data = []
+
+    def __call__(self, pop, sampler):
+        in_genome = [False]*len(pop.mutations)
+        for i in pop.diploids:
+            for g in [i.first, i.second]:
+                for k in pop.haploid_genomes[g].smutations:
+                    in_genome[k] = True
+        temp = [in_genome[i.key] for i in pop.tables.mutations]
+        self.data.append(all([i is True for i in temp]) is True)
+
+
+class TestEsizeZero(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        pdict = {'nregions': [],
+                 'sregions': [EsizeZero.EsizeZero(0, 1, 1, True, 0)],
+                 'recregions': [fwdpy11.PoissonInterval(0, 1, 1)],
+                 'rates': (0, 5, None),
+                 'gvalue': fwdpy11.Multiplicative(2.),
+                 'demography': fwdpy11.DiscreteDemography(),
+                 'simlen': 10
+                 }
+        self.params = fwdpy11.ModelParams(**pdict)
+        self.pop = fwdpy11.DiploidPopulation(500, 1.)
+        self.rng = fwdpy11.GSLrng(512035)
+
+    def test_simulation(self):
+        r = Recorder()
+        fwdpy11.evolvets(self.rng, self.pop, self.params, 1, r)
+        self.assertTrue(all([i is True for i in r.data]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
have effect sizes of zero.  Closes #435.