### PR TITLE
More ModelParams changes

### DIFF
--- a/tests/quick_pops.py
+++ b/tests/quick_pops.py
@@ -69,7 +69,8 @@ def quick_slocus_qtrait_pop_params(N=1000, simlen=100):
         "sregions": [GaussianS(0, 1, 1, 0.25)],
         "recregions": [Region(0, 1, 1)],
         "rates": (0.0, 2e-3, 1e-3),
-        "demography": np.array([N] * simlen, dtype=np.uint32),
+        "popsizes": np.array([N] * simlen, dtype=np.uint32),
+        "simlen": simlen,
         "gvalue": Additive(2.0, GSS(VS=1.0, optimum=0.0)),
         "prune_selected": False,
     }

--- a/tests/test_fixation_properties.py
+++ b/tests/test_fixation_properties.py
@@ -95,7 +95,8 @@ class testFixationPreservation(unittest.TestCase):
             "recregions": [fwdpy11.Region(0, 1, 1)],
             "rates": (0.0, 0.00005, r),
             "gvalue": a,
-            "demography": demography,
+            "popsizes": demography,
+            "simlen": len(demography),
         }
         self.pop = fwdpy11.DiploidPopulation(N)
         self.rng = fwdpy11.GSLrng(101 * 45 * 110 * 210)

--- a/tests/test_wright_fisher.py
+++ b/tests/test_wright_fisher.py
@@ -22,7 +22,8 @@ class testWFevolve(unittest.TestCase):
         self.recorder = GenerationRecorder()
         self.p = {
             "rates": (1e-3, 1e-3, 1e-3),
-            "demography": np.array([1000] * 100, dtype=np.uint32),
+            "popsizes": np.array([1000] * 100, dtype=np.uint32),
+            "simlen": 100,
             "nregions": [fwdpy11.Region(0, 1, 1)],
             "sregions": [fwdpy11.ExpS(0, 1, 1, -1e-2)],
             "recregions": [fwdpy11.Region(0, 1, 1)],
@@ -34,7 +35,8 @@ class testWFevolve(unittest.TestCase):
         params = fwdpy11.ModelParams(**self.p)
         fwdpy11.evolve_genomes(self.rng, self.pop, params, self.recorder)
         self.assertEqual(self.recorder.generations, [i + 1 for i in range(100)])
-        self.p["demography"] = np.array([self.pop.N] * 24, dtype=np.uint32)
+        self.p["popsizes"] = np.array([self.pop.N] * 24, dtype=np.uint32)
+        self.p["simlen"] = len(self.p["popsizes"])
         params = fwdpy11.ModelParams(**self.p)
         fwdpy11.evolve_genomes(self.rng, self.pop, params, self.recorder)
         self.assertEqual(self.recorder.generations, [i + 1 for i in range(124)])


### PR DESCRIPTION
* Change the order of the validators, etc., to be in declaration and execution order
* Force separation of `demography` and `popsizes` `kwargs.`