### PR TITLE
Pickle DiscreteDemography's internal state

### DIFF
--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -166,7 +166,15 @@ class DemographyDebugger(object):
         # FIXME: a more Pythonic approach would be only to
         # pull out attributes that are not None, are iterable,
         # and whose elements contain a "when" attribute.
-        not_allowed = ["migmatrix", "asblack", "asdict", "fromdict", "_timed_events"]
+        not_allowed = [
+            "migmatrix",
+            "asblack",
+            "asdict",
+            "fromdict",
+            "_timed_events",
+            "_state_asdict",
+            "_reset_state",
+        ]
         return [i for i in events.__dir__() if "__" not in i and i not in not_allowed]
 
     def _make_event_queues(self, events):

--- a/fwdpy11/discrete_demography.py
+++ b/fwdpy11/discrete_demography.py
@@ -426,7 +426,6 @@ def _convert_migmatrix(o):
 
 
 @attr_add_asblack
-@attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class DiscreteDemography(fwdpy11._fwdpy11._ll_DiscreteDemography):
@@ -489,6 +488,14 @@ class DiscreteDemography(fwdpy11._fwdpy11._ll_DiscreteDemography):
             migmatrix=self.migmatrix,
             set_migration_rates=self.set_migration_rates,
         )
+
+    def __getstate__(self):
+        return (self.asdict(), self._state_asdict())
+
+    def __setstate__(self, t):
+        self.__dict__.update(t[0])
+        super(DiscreteDemography, self).__init__(**t[0])
+        self._reset_state(t[1])
 
     def _timed_events(self):
         for i in [

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/deme_properties.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/deme_properties.hpp
@@ -31,13 +31,11 @@ namespace fwdpy11
         {
             template <typename METADATATYPE>
             current_deme_sizes_vector
-            init_deme_sizes_from_metadata(
-                std::uint32_t max_number_demes,
-                const std::vector<METADATATYPE>& metadata)
+            init_deme_sizes_from_metadata(std::uint32_t max_number_demes,
+                                          const std::vector<METADATATYPE>& metadata)
             {
                 current_deme_sizes_vector v(
-                    current_deme_sizes_vector::value_type(max_number_demes,
-                                                          0));
+                    current_deme_sizes_vector::value_type(max_number_demes, 0));
                 auto& ref = v.get();
                 std::fill(begin(ref), end(ref), 0);
                 for (auto&& i : metadata)
@@ -62,13 +60,24 @@ namespace fwdpy11
                   next_deme_sizes(
                       next_deme_sizes_vector::value_type(max_number_demes, 0)),
                   growth_rate_onset_times(
-                      growth_rates_onset_times_vector::value_type(
-                          max_number_demes, 0)),
+                      growth_rates_onset_times_vector::value_type(max_number_demes, 0)),
                   growth_initial_sizes(current_deme_sizes.get()),
-                  growth_rates(growth_rates_vector::value_type(
-                      max_number_demes, NOGROWTH)),
-                  selfing_rates(
-                      selfing_rates_vector::value_type(max_number_demes, 0.))
+                  growth_rates(
+                      growth_rates_vector::value_type(max_number_demes, NOGROWTH)),
+                  selfing_rates(selfing_rates_vector::value_type(max_number_demes, 0.))
+            {
+            }
+
+            deme_properties(current_deme_sizes_vector _cdsv,
+                            next_deme_sizes_vector _ndsv,
+                            growth_rates_onset_times_vector _grotv,
+                            growth_initial_size_vector _gisv, growth_rates_vector _sgrv,
+                            selfing_rates_vector _srv)
+                : current_deme_sizes(std::move(_cdsv)),
+                  next_deme_sizes(std::move(_ndsv)),
+                  growth_rate_onset_times(std::move(_grotv)),
+                  growth_initial_sizes(std::move(_gisv)), growth_rates(std::move(_sgrv)),
+                  selfing_rates(std::move(_srv))
             {
             }
         };

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/demographic_model_state.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/demographic_model_state.hpp
@@ -39,15 +39,13 @@ namespace fwdpy11
         {
           private:
             std::unique_ptr<MigrationMatrix>
-            init_migmatrix(
-                const std::unique_ptr<const MigrationMatrix> &Minput)
+            init_migmatrix(const std::unique_ptr<const MigrationMatrix> &Minput)
             {
                 if (Minput == nullptr)
                     {
                         return nullptr;
                     }
-                return std::unique_ptr<MigrationMatrix>(
-                    new MigrationMatrix(*Minput));
+                return std::unique_ptr<MigrationMatrix>(new MigrationMatrix(*Minput));
             }
 
             std::uint32_t next_global_N;
@@ -70,6 +68,21 @@ namespace fwdpy11
                   M(init_migmatrix(demography.migmatrix)),
                   miglookup(maxdemes, M == nullptr)
             {
+            }
+
+
+            // This constructor is only used when resetting
+            // the state from an event like pickling a DiscreteDemography
+            // instance.
+            demographic_model_state(std::int32_t maxdemes_, deme_properties sizes_rates_,
+                                    std::unique_ptr<MigrationMatrix> M_)
+                : next_global_N(0), maxdemes(maxdemes_), fitnesses(maxdemes),
+                  sizes_rates(std::move(sizes_rates_)), M(std::move(M_)),
+                  miglookup(maxdemes, M == nullptr)
+            {
+                next_global_N
+                    = std::accumulate(begin(sizes_rates.next_deme_sizes.get()),
+                                      end(sizes_rates.next_deme_sizes.get()), 0u);
             }
 
             void


### PR DESCRIPTION
See #380.  The current pickling behavior simply ignores what's happened to an object if it has been used to evolve a population, creating a corner case.  If, for some reason, the objects are pickled "part way" through a demographic model, restoring the objects and evolving again gives incorrect results.  This PR fixes the problem by sending the internal state through the pickling round trip.