### PR TITLE
Add strict typing in __init__ methods for trait optima types.

### DIFF
--- a/examples/discrete_demography/localadaptation.py
+++ b/examples/discrete_demography/localadaptation.py
@@ -201,13 +201,13 @@ def runsim(args):
 
     GSSmo0 = fwdpy11.GSSmo(
         [
-            fwdpy11.Optimum(when=0, optimum=0, VS=args.VS),
+            fwdpy11.Optimum(when=0, optimum=0.0, VS=args.VS),
             fwdpy11.Optimum(when=10 * args.popsize, optimum=args.opt, VS=args.VS),
         ]
     )
     GSSmo1 = fwdpy11.GSSmo(
         [
-            fwdpy11.Optimum(when=0, optimum=0, VS=args.VS),
+            fwdpy11.Optimum(when=0, optimum=0.0, VS=args.VS),
             fwdpy11.Optimum(
                 when=10 * args.popsize, optimum=-1.0 * args.opt, VS=args.VS
             ),

--- a/examples/gss/DiploidPopulationGSSmo.py
+++ b/examples/gss/DiploidPopulationGSSmo.py
@@ -206,7 +206,7 @@ def runsim(args):
 
     GSSmo = fwdpy11.GSSmo(
         [
-            fwdpy11.Optimum(when=0, optimum=0, VS=args.VS),
+            fwdpy11.Optimum(when=0, optimum=0.0, VS=args.VS),
             fwdpy11.Optimum(when=10 * args.popsize, optimum=args.opt, VS=args.VS),
         ]
     )

--- a/examples/gss_divergent_optima/gss_divergent_optima.py
+++ b/examples/gss_divergent_optima/gss_divergent_optima.py
@@ -10,14 +10,14 @@ rho = float(sys.argv[2])
 
 moving_optimum_deme_0 = fwdpy11.GSSmo(
     [
-        fwdpy11.Optimum(when=0, optimum=0, VS=1),
-        fwdpy11.Optimum(when=10 * N, optimum=1, VS=1),
+        fwdpy11.Optimum(when=0, optimum=0.0, VS=1.0),
+        fwdpy11.Optimum(when=10 * N, optimum=1.0, VS=1.0),
     ]
 )
 moving_optimum_deme_1 = fwdpy11.GSSmo(
     [
-        fwdpy11.Optimum(when=0, optimum=0, VS=1),
-        fwdpy11.Optimum(when=10 * N, optimum=-1, VS=1),
+        fwdpy11.Optimum(when=0, optimum=0.0, VS=1.0),
+        fwdpy11.Optimum(when=10 * N, optimum=-1.0, VS=1.0),
     ]
 )
 

--- a/fwdpy11/genetic_values.py
+++ b/fwdpy11/genetic_values.py
@@ -65,9 +65,14 @@ class Optimum(fwdpy11._fwdpy11._ll_Optimum):
         low-level C++ class
     """
 
-    optimum: float
-    VS: float
-    when: typing.Optional[int] = None
+    optimum: float = attr.ib(validator=attr.validators.instance_of(float))
+    VS: float = attr.ib(validator=attr.validators.instance_of(float))
+    when: typing.Optional[int] = attr.ib(default=None)
+
+    @when.validator
+    def validate_when(self, attribute, value):
+        if value is not None:
+            attr.validators.instance_of(int)(self, attribute, value)
 
     def __attrs_post_init__(self):
         super(Optimum, self).__init__(self.optimum, self.VS, self.when)
@@ -108,8 +113,13 @@ class PleiotropicOptima(fwdpy11._fwdpy11._ll_PleiotropicOptima):
     """
 
     optima: typing.List[float]
-    VS: float
-    when: typing.Optional[int] = None
+    VS: float = attr.ib(validator=attr.validators.instance_of(float))
+    when: typing.Optional[int] = attr.ib(default=None)
+
+    @when.validator
+    def validate_when(self, attribute, value):
+        if value is not None:
+            attr.validators.instance_of(int)(self, attribute, value)
 
     def __attrs_post_init__(self):
         super(PleiotropicOptima, self).__init__(self.optima, self.VS, self.when)

--- a/tests/test_ModelParams.py
+++ b/tests/test_ModelParams.py
@@ -33,7 +33,7 @@ def _starting_pdict():
         "demography": fwdpy11.DiscreteDemography(),
         "simlen": 10,
         "gvalue": fwdpy11.Multiplicative(
-            2.0, fwdpy11.GSS(fwdpy11.Optimum(VS=1, optimum=0.0))
+            2.0, fwdpy11.GSS(fwdpy11.Optimum(VS=1.0, optimum=0.0))
         ),
     }
 

--- a/tests/test_genetic_value_to_fitness.py
+++ b/tests/test_genetic_value_to_fitness.py
@@ -92,7 +92,7 @@ class testMultivariateGSSmo(unittest.TestCase):
         timepoints = [0, 100]
         po = []
         for i, t in enumerate(timepoints):
-            po.append(fwdpy11.PleiotropicOptima(when=t, optima=optima[i, :], VS=1))
+            po.append(fwdpy11.PleiotropicOptima(when=t, optima=optima[i, :], VS=1.0))
         self.mvgssmo = fwdpy11.MultivariateGSSmo(po)
 
     def test_pickle(self):

--- a/tests/test_multivariate_effects.py
+++ b/tests/test_multivariate_effects.py
@@ -19,7 +19,7 @@ def set_up_quant_trait_model():
     PO = fwdpy11.PleiotropicOptima
     po = []
     for i, j in enumerate(timepoints):
-        po.append(PO(when=j, optima=optima[i, :], VS=1))
+        po.append(PO(when=int(j), optima=optima[i, :], VS=1.0))
     GSSmo = fwdpy11.MultivariateGSSmo(po)
     cmat = np.identity(ntraits)
     np.fill_diagonal(cmat, 0.1)
@@ -78,7 +78,7 @@ class TestMultivariateGSSmoCPP(unittest.TestCase):
         PO = fwdpy11.PleiotropicOptima
         po = []
         for i, t in enumerate(timepoints):
-            po.append(PO(when=t, optima=optima[i, :], VS=1))
+            po.append(PO(when=int(t), optima=optima[i, :], VS=1.0))
         GSSmo = fwdpy11.MultivariateGSSmo(po)
 
         co = testMultivariateGSSmo.get_optima(GSSmo)

--- a/tests/test_record_genetic_value_matrix.py
+++ b/tests/test_record_genetic_value_matrix.py
@@ -39,7 +39,7 @@ def set_up_quant_trait_model():
     r = rho / (4 * N)
     Opt = fwdpy11.Optimum
     GSSmo = fwdpy11.GSSmo(
-        [Opt(when=0, optimum=0, VS=1), Opt(when=10 * N, optimum=1, VS=1)]
+        [Opt(when=0, optimum=0.0, VS=1.0), Opt(when=10 * N, optimum=1.0, VS=1.0)]
     )
     a = fwdpy11.Additive(2.0, GSSmo)
     p = {
@@ -64,9 +64,9 @@ def set_up_two_trait_quant_trait_model():
     r = rho / (4 * N)
 
     optima = [
-        fwdpy11.PleiotropicOptima(when=0, optima=np.zeros(2), VS=2),
+        fwdpy11.PleiotropicOptima(when=0, optima=np.zeros(2), VS=2.0),
         fwdpy11.PleiotropicOptima(
-            when=10 * N, optima=np.array([np.sqrt(2.0), 0]), VS=2
+            when=10 * N, optima=np.array([np.sqrt(2.0), 0]), VS=2.0
         ),
     ]
     GSSmo = fwdpy11.MultivariateGSSmo(optima)

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -57,7 +57,9 @@ def set_up_quant_trait_model(simlen=1.0):
     # mu = theta/(4*N)
     r = rho / (4 * N)
     Opt = fwdpy11.Optimum
-    GSSmo = fwdpy11.GSSmo([Opt(when=0, optimum=0, VS=1), Opt(when=N, optimum=1, VS=1)])
+    GSSmo = fwdpy11.GSSmo(
+        [Opt(when=0, optimum=0.0, VS=1.0), Opt(when=N, optimum=1.0, VS=1.0)]
+    )
     a = fwdpy11.Additive(2.0, GSSmo)
     p = {
         "nregions": [],


### PR DESCRIPTION
We are changing the kwarg order for these types, so let's add very strict input checking to prevent people silently getting the wrong results.