### PR TITLE
Use attrs to initialize DemographyDebugger

### DIFF
--- a/doc/misc/upgrade_path.rst
+++ b/doc/misc/upgrade_path.rst
@@ -6,6 +6,13 @@ Upgrade path
 This document outlines how to upgrade existing scripts to new versions of fwdpy11.  This guide is likely
 imperfect/incomplete.
 
+0.8.2
+-------------------------------------------------
+
+* The first `kwarg`/positional argument for initializing a :class:`fwdpy11.DemographyDebugger` has been renamed `initial_deme_sizes`.  As the argument
+is required, and previously only took one possible type, we expect this
+change to not really break anyone's code.
+
 0.8.0
 -------------------------------------------------
 

--- a/doc/pages/demographydebugger.rst
+++ b/doc/pages/demographydebugger.rst
@@ -17,5 +17,19 @@ Debugging Demographic models
         pop.N, 0.3, 0.2, (2, 3.33), [0.01, 0.1]
     )
 
+    # Let the debugger figure out initial deme
+    # sizes from pop
     d = fwdpy11.DemographyDebugger(pop, dmodel)
+
+    # A list of integers also works for the
+    # initial deme sizes
+    d = fwdpy11.DemographyDebugger(
+        [100],
+        dmodel,
+        simlen=dmodel.metadata.simlen,
+        deme_labels={0: "ANCESTRAL", 1: "DERIVED"},
+    )
+
     print(d.report)
+
+

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -41,6 +41,12 @@ def _create_initial_deme_sizes(o):
         return o
 
 
+def _convert_simlen(simlen):
+    if simlen is None:
+        return simlen
+    return int(simlen)
+
+
 @attr.s()
 class DemographyDebugger(object):
     """
@@ -55,12 +61,29 @@ class DemographyDebugger(object):
     is raised. The types of errors are the same as would
     result in an exception during a simulation.
 
+    The class initialized with the following arguments,
+    which may be either positional or keyword:
+
+    :param initial_deme_sizes: The initial sizes of each deme
+    :type initial_deme_sizes: list or fwdpy11.DiploidPopulation
+    :param events: The demographic model
+    :type events: fwdpy11.DiscreteDemography or fwdpy11.DemographicModelDetails
+    :param simlen: The length of the simulation.  Defaults to `None`.
+    :type simlen: int
+    :param deme_labels: A map from deme index to a printable name
+    :type deme_labels: dict
+
     .. versionadded:: 0.6.0
+
+    .. versionchanged:: 0.8.1
+
+        Initialization now done with attr.
+        A list of initial deme sizes is now accepted.
     """
 
     initial_deme_sizes = attr.ib(converter=_create_initial_deme_sizes)
     _events = attr.ib(converter=_create_event_list)
-    simlen = attr.ib(default=None)
+    simlen = attr.ib(converter=_convert_simlen, default=None)
     deme_labels = attr.ib(default=None)
 
     def __attrs_post_init__(self):

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -150,7 +150,9 @@ class DemographyDebugger(object):
                     if len(i.migrates) != self._events.migmatrix.shape[0]:
                         raise ValueError("Migration rates mismatch")
                 else:  # Are replacing the entire matrix
-                    if len(i.migrates.flatten()) != len(self._events.migmatrix.M.flatten()):
+                    if len(i.migrates.flatten()) != len(
+                        self._events.migmatrix.M.flatten()
+                    ):
                         raise ValueError("Migration rates mismatch")
 
     def _get_event_names(self, events):
@@ -371,9 +373,12 @@ class DemographyDebugger(object):
                     "\tMigration rates into " "deme {} set to {}\n".format(*temp)
                 )
             else:
-                self._events.migmatrix.M[:] = e.migrates.reshape(self._events.migmatrix.M.shape)
+                self._events.migmatrix.M[:] = e.migrates.reshape(
+                    self._events.migmatrix.M.shape
+                )
                 self._report.append(
-                    "\tMigration matrix " "reset to:\n\t\t{}".format(self._events.migmatrix.M)
+                    "\tMigration matrix "
+                    "reset to:\n\t\t{}".format(self._events.migmatrix.M)
                 )
 
     def _apply_growth_rates(self, t, event_queues):

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -58,7 +58,7 @@ class DemographyDebugger(object):
     of the model details for double-checking.
 
     If model errors are found, a ``ValueError`` exception
-    is raised. The types of errors are the same as would
+    is raised. The goal is to catch the types of errors that would
     result in an exception during a simulation.
 
     The class initialized with the following arguments,

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -428,8 +428,6 @@ class DemographyDebugger(object):
                     s = "deme {} has size {} at time {} " + "but has no valid parents"
                     temp = (self._label_deme(i), N, t)
                     raise ValueError(s.format(*temp))
-                # FIXME: if M[i, i] == 0 and M[i, ].sum() > 0,
-                # then deme i will have metadata.
                 elif self._events.migmatrix.M[i, i] != 0.0:
                     s = (
                         "deme {} at time {} "

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -406,7 +406,7 @@ class DemographyDebugger(object):
 
         return next_deme_sizes
 
-    def _validate_migraton_rates(self, t, next_deme_sizes):
+    def _validate_migration_rates(self, t, next_deme_sizes):
         if self._events.migmatrix is None:
             return
         for i, j in enumerate(next_deme_sizes):
@@ -488,7 +488,7 @@ class DemographyDebugger(object):
                 temp = "Global extinction occurs at time {}".format(t)
                 warnings.warn(temp)
                 self._report.append(temp + "\n")
-            self._validate_migraton_rates(t, next_deme_sizes)
+            self._validate_migration_rates(t, next_deme_sizes)
             self.current_deme_sizes = next_deme_sizes
             last_t = t
             t = self._get_next_event_time(event_queues)


### PR DESCRIPTION
* Take advantage of `DiscreteDemography.asdict` to get events into the DemographyDebugger.
* No longer require a `DiploidPopulation` to get initial deme sizes.  We now also accept a list of integers.