### PR TITLE
Fill tskit.TableCollection provenance table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ message(STATUS "Found pybind11: ${pybind11_VERSION}")
 if(${pybind11_VERSION} VERSION_LESS '2.4.3')
     message(FATAL_ERROR "pybind11 version must be >= '2.4.3'")
 endif()
+add_definitions(-DPYBIND11_VERSION="${pybind11_VERSION}")
 
 find_package(GSL REQUIRED)
 option(USE_WEFFCPP "Use -Weffc++ during compilation" OFF)

--- a/fwdpy11/src/_fwdpy11.cc
+++ b/fwdpy11/src/_fwdpy11.cc
@@ -9,8 +9,7 @@ static_assert(GSL_MAJOR_VERSION >= 2, "GSL major version >= 2 required");
 static_assert(GSL_MINOR_VERSION >= 3, "GSL minor version >= 3 required");
 
 void
-gsl_error_to_exception(const char *reason, const char *file, int line,
-                       int gsl_errno)
+gsl_error_to_exception(const char *reason, const char *file, int line, int gsl_errno)
 {
     std::ostringstream o;
     o << "GSL error raised: " << reason << ", " << file << ", " << line << ", "
@@ -29,9 +28,9 @@ void initialize_genetic_value_noise(py::module &);
 void initialize_genetic_value_to_fitness(py::module &);
 void init_genetic_values(py::module &);
 void init_GSL(py::module &);
-void init_ts(py::module&);
-void init_evolution_functions(py::module&);
-void init_discrete_demography(py::module & m);
+void init_ts(py::module &);
+void init_evolution_functions(py::module &);
+void init_discrete_demography(py::module &m);
 
 PYBIND11_MODULE(_fwdpy11, m)
 {
@@ -42,9 +41,9 @@ PYBIND11_MODULE(_fwdpy11, m)
     // When the module exits, restore the old handler.
     // We re-use variables to suppress unused variable warnings.
     py::module::import("atexit").attr("register")(
-        py::cpp_function{ [&handler, &custom_handler]() {
+        py::cpp_function{[&handler, &custom_handler]() {
             custom_handler = gsl_set_error_handler(handler);
-        } });
+        }});
 
     initialize_fwdpp_types(m);
     initialize_fwdpp_functions(m);
@@ -58,4 +57,18 @@ PYBIND11_MODULE(_fwdpy11, m)
     init_ts(m);
     init_evolution_functions(m);
     init_discrete_demography(m);
+
+    m.def(
+        "pybind11_version",
+        []() {
+            py::dict rv;
+            std::ostringstream o;
+            o << PYBIND11_VERSION;
+            rv["pybind11_version"] = o.str();
+            return rv;
+        },
+        R"delim(
+    Returns the version of pybind11 used to
+    compile fwdpy11.
+    )delim");
 }

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -321,6 +321,23 @@ class TestTreeSequencesNoAncientSamplesKeepFixations(unittest.TestCase):
 
         self.assertEqual(mcounts_comparison(self.pop, dumped_ts), True)
 
+    def test_dump_to_tskit_parameters_round_trip(self):
+        import json
+        import tskit
+
+        dumped_ts = self.pop.dump_tables_to_tskit(
+            parameters={"model": str(self.params)}
+        )
+        p = json.loads(dumped_ts.provenance(0).record)
+        try:
+            tskit.validate_provenance(p)
+        except:  # NOQA
+            self.fail("unexpected exception")
+
+        array = np.array  # NOQA
+        mp = eval(p["parameters"]["model"])
+        self.assertTrue(mp == self.params)
+
     def test_TreeIterator(self):
         # The first test ensures that TreeIterator
         # simply holds a reference to the input tables,


### PR DESCRIPTION
To get the provenance information complete, also add ability to record pybind11 version used and get it via Python.