### PR TITLE
Allow Python genetic value noise classes.

### DIFF
--- a/fwdpy11/custom_genetic_value_decorators.py
+++ b/fwdpy11/custom_genetic_value_decorators.py
@@ -18,6 +18,23 @@ class genetic_value_is_trait_default_clone(object):
         return cls
 
 
+def genetic_value_noise_default_clone(cls):
+    from fwdpy11 import GeneticValueNoise
+
+    def clone(self):
+
+        # create a new object without initializing it
+        cloned = cls.__new__(cls)
+        # clone C++ state
+        GeneticValueNoise.__init__(cloned)
+        # clone Python state
+        cloned.__dict__.update(self.__dict__)
+        return cloned
+
+    cls.clone = clone
+    return cls
+
+
 def default_update(cls):
     def update(self, pop):
         pass

--- a/fwdpy11/custom_genetic_value_decorators.py
+++ b/fwdpy11/custom_genetic_value_decorators.py
@@ -1,3 +1,17 @@
+def _make_cloner(cls, base, *args):
+    def clone(self):
+        # create a new object without initializing it
+        cloned = cls.__new__(cls)
+        # clone C++ state
+        base.__init__(cloned, *args)
+        # clone Python state
+        cloned.__dict__.update(self.__dict__)
+        return cloned
+
+    cls.clone = clone
+    return cls
+
+
 class genetic_value_is_trait_default_clone(object):
     def __init__(self, ndim=1):
         self.ndim = ndim
@@ -5,33 +19,13 @@ class genetic_value_is_trait_default_clone(object):
     def __call__(self, cls):
         from fwdpy11 import GeneticValueIsTrait
 
-        def clone(me):
-            # create a new object without initializing it
-            cloned = cls.__new__(cls)
-            # clone C++ state
-            GeneticValueIsTrait.__init__(cloned, self.ndim)
-            # clone Python state
-            cloned.__dict__.update(me.__dict__)
-            return cloned
-
-        cls.clone = clone
-        return cls
+        return _make_cloner(cls, GeneticValueIsTrait, self.ndim)
 
 
 def genetic_value_noise_default_clone(cls):
     from fwdpy11 import GeneticValueNoise
 
-    def clone(self):
-
-        # create a new object without initializing it
-        cloned = cls.__new__(cls)
-        # clone C++ state
-        GeneticValueNoise.__init__(cloned)
-        # clone Python state
-        cloned.__dict__.update(self.__dict__)
-        return cloned
-
-    cls.clone = clone
+    return _make_cloner(cls, GeneticValueNoise)
     return cls
 
 

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
@@ -33,8 +33,6 @@ namespace fwdpy11
         virtual double
         operator()(const GSLrng_t& /* rng */,
                    const DiploidMetadata& /*offspring_metadata*/,
-                   const std::size_t /*parent1*/,
-                   const std::size_t /*parent2*/,
                    const DiploidPopulation& /*pop*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;
         virtual std::shared_ptr<GeneticValueNoise> clone() const = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
@@ -37,7 +37,7 @@ namespace fwdpy11
                    const std::size_t /*parent2*/,
                    const DiploidPopulation& /*pop*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;
-        virtual std::unique_ptr<GeneticValueNoise> clone() const = 0;
+        virtual std::shared_ptr<GeneticValueNoise> clone() const = 0;
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
@@ -41,10 +41,10 @@ namespace fwdpy11
         {
         }
 
-        std::unique_ptr<GeneticValueNoise>
+        std::shared_ptr<GeneticValueNoise>
         clone() const override
         {
-            return std::unique_ptr<NoNoise>(new NoNoise());
+            return std::make_shared<NoNoise>();
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
@@ -29,8 +29,6 @@ namespace fwdpy11
         double
         operator()(const GSLrng_t& /*rng*/,
                    const DiploidMetadata& /*offspring_metadata*/,
-                   const std::size_t /*parent1*/,
-                   const std::size_t /*parent2*/,
                    const DiploidPopulation& /*pop*/) const override
         {
             return 0.;

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -60,18 +60,14 @@ namespace fwdpy11
 
         explicit DiploidGeneticValue(std::size_t ndim)
             : total_dim(ndim), gvalues(total_dim, 0.),
-              gv2w{ new GeneticValueIsFitness{ total_dim } }, noise_fxn{
-                  new NoNoise()
-              }
+              gv2w{new GeneticValueIsFitness{total_dim}}, noise_fxn{new NoNoise()}
         {
         }
 
         DiploidGeneticValue(std::size_t dimensonality,
                             const GeneticValueToFitnessMap& gv2w_)
             : total_dim(dimensonality),
-              gvalues(total_dim, 0.0), gv2w{ gv2w_.clone() }, noise_fxn{
-                  new NoNoise
-              }
+              gvalues(total_dim, 0.0), gv2w{gv2w_.clone()}, noise_fxn{new NoNoise}
         {
         }
 
@@ -79,9 +75,7 @@ namespace fwdpy11
                             const GeneticValueToFitnessMap& gv2w_,
                             const GeneticValueNoise& noise_)
             : total_dim(dimensonality),
-              gvalues(total_dim, 0.0), gv2w{ gv2w_.clone() }, noise_fxn{
-                  noise_.clone()
-              }
+              gvalues(total_dim, 0.0), gv2w{gv2w_.clone()}, noise_fxn{noise_.clone()}
         {
         }
 
@@ -92,10 +86,9 @@ namespace fwdpy11
         DiploidGeneticValue& operator=(const DiploidGeneticValue&) = delete;
 
         // Callable from Python
-        virtual double
-        calculate_gvalue(const std::size_t /*diploid_index*/,
-                         const DiploidMetadata & /*diploid_metadata*/,
-                         const DiploidPopulation& /*pop*/) const = 0;
+        virtual double calculate_gvalue(const std::size_t /*diploid_index*/,
+                                        const DiploidMetadata& /*diploid_metadata*/,
+                                        const DiploidPopulation& /*pop*/) const = 0;
 
         virtual void
         update(const DiploidPopulation& pop)
@@ -107,12 +100,10 @@ namespace fwdpy11
         // To be called from w/in a simulation
         virtual void
         operator()(const GSLrng_t& rng, std::size_t diploid_index,
-                   const DiploidPopulation& pop,
-                   DiploidMetadata& metadata) const
+                   const DiploidPopulation& pop, DiploidMetadata& metadata) const
         {
             metadata.g = calculate_gvalue(diploid_index, metadata, pop);
-            metadata.e = noise(rng, metadata, metadata.parents[0],
-                               metadata.parents[1], pop);
+            metadata.e = noise(rng, metadata, pop);
             metadata.w = genetic_value_to_fitness(metadata);
         }
 
@@ -124,17 +115,15 @@ namespace fwdpy11
 
         virtual double
         noise(const GSLrng_t& rng, const DiploidMetadata& offspring_metadata,
-              const std::size_t parent1, const std::size_t parent2,
               const DiploidPopulation& pop) const
         {
-            return noise_fxn->operator()(rng, offspring_metadata, parent1,
-                                         parent2, pop);
+            return noise_fxn->operator()(rng, offspring_metadata, pop);
         }
 
         virtual pybind11::tuple
         shape() const
         {
-            if (total_dim>1 && total_dim != gvalues.size())
+            if (total_dim > 1 && total_dim != gvalues.size())
                 {
                     throw std::runtime_error("dimensionality mismatch");
                 }

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -56,7 +56,7 @@ namespace fwdpy11
         /// from their own update functions.
         std::shared_ptr<GeneticValueToFitnessMap> gv2w;
         /// This must be updated, too:
-        std::unique_ptr<GeneticValueNoise> noise_fxn;
+        std::shared_ptr<GeneticValueNoise> noise_fxn;
 
         explicit DiploidGeneticValue(std::size_t ndim)
             : total_dim(ndim), gvalues(total_dim, 0.),

--- a/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
@@ -13,7 +13,6 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     double
     operator()(const fwdpy11::GSLrng_t& rng,
                const fwdpy11::DiploidMetadata& /*offspring_metadata*/,
-               const std::size_t /*parent1*/, const std::size_t /*parent2*/,
                const fwdpy11::DiploidPopulation& /*pop*/) const override
     {
         return mean + gsl_ran_gaussian_ziggurat(rng.get(), sd);

--- a/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
@@ -24,10 +24,10 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     {
     }
 
-    std::unique_ptr<fwdpy11::GeneticValueNoise>
+    std::shared_ptr<fwdpy11::GeneticValueNoise>
     clone() const override
     {
-        return std::unique_ptr<GaussianNoise>(new GaussianNoise(*this));
+        return std::make_shared<GaussianNoise>(*this);
     }
 };
 

--- a/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
@@ -3,10 +3,46 @@
 
 namespace py = pybind11;
 
+class GeneticValueNoiseTrampoline : public fwdpy11::GeneticValueNoise
+{
+  public:
+    using fwdpy11::GeneticValueNoise::GeneticValueNoise;
+
+    double
+    operator()(const fwdpy11::GSLrng_t& rng,
+               const fwdpy11::DiploidMetadata& offspring_metadata,
+               const std::size_t parent1, const std::size_t parent2,
+               const fwdpy11::DiploidPopulation& pop) const override
+    {
+        PYBIND11_OVERLOAD_PURE_NAME(double, fwdpy11::GeneticValueNoise,
+                                    "__call__", operator(), rng, offspring_metadata, parent1,
+                                    parent2, pop);
+    }
+
+    void
+    update(const fwdpy11::DiploidPopulation& pop) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, fwdpy11::GeneticValueNoise, update, pop);
+    }
+
+    std::shared_ptr<fwdpy11::GeneticValueNoise>
+    clone() const override
+    // Implementation details from pybind11 issue 1049
+    {
+        auto self = py::cast(this);
+        auto cloned = self.attr("clone")();
+
+        auto keep_python_state_alive = std::make_shared<py::object>(cloned);
+        auto ptr = cloned.cast<GeneticValueNoiseTrampoline*>();
+        return std::shared_ptr<GeneticValueNoise>(keep_python_state_alive, ptr);
+    }
+};
+
 void
 init_GeneticValueNoise(py::module& m)
 {
-    py::class_<fwdpy11::GeneticValueNoise>(
+    py::class_<fwdpy11::GeneticValueNoise, GeneticValueNoiseTrampoline>(
         m, "GeneticValueNoise",
-        "ABC for noise classes affecting :class:`fwdpy11.DiploidPopulation`.");
+        "ABC for noise classes affecting :class:`fwdpy11.DiploidPopulation`.")
+        .def(py::init<>());
 }

--- a/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
@@ -11,12 +11,11 @@ class GeneticValueNoiseTrampoline : public fwdpy11::GeneticValueNoise
     double
     operator()(const fwdpy11::GSLrng_t& rng,
                const fwdpy11::DiploidMetadata& offspring_metadata,
-               const std::size_t parent1, const std::size_t parent2,
                const fwdpy11::DiploidPopulation& pop) const override
     {
         PYBIND11_OVERLOAD_PURE_NAME(double, fwdpy11::GeneticValueNoise,
-                                    "__call__", operator(), rng, offspring_metadata, parent1,
-                                    parent2, pop);
+                                    "__call__", operator(), rng, offspring_metadata,
+                                    pop);
     }
 
     void

--- a/tests/inherit_noise.cc
+++ b/tests/inherit_noise.cc
@@ -24,11 +24,10 @@ struct IneritedNoise : public fwdpy11::GeneticValueNoise
 {
     double
     operator()(const fwdpy11::GSLrng_t& /*rng*/,
-               const fwdpy11::DiploidMetadata& /*offspring_metadata*/,
-               const std::size_t parent1, const std::size_t /*parent2*/,
+               const fwdpy11::DiploidMetadata& offspring_metadata,
                const fwdpy11::DiploidPopulation& pop) const override
     {
-        return pop.diploid_metadata[parent1].e + pop.generation;
+        return pop.diploid_metadata[offspring_metadata.parents[0]].e + pop.generation;
     }
 
     void
@@ -65,8 +64,7 @@ PYBIND11_MODULE(inherit_noise, m)
     pybind11::object imported_base
         = pybind11::module::import("fwdpy11").attr("GeneticValueNoise");
 
-    pybind11::class_<IneritedNoise, fwdpy11::GeneticValueNoise>(
-        m, "IneritedNoise")
+    pybind11::class_<IneritedNoise, fwdpy11::GeneticValueNoise>(m, "IneritedNoise")
         .def(pybind11::init<>())
         .def(pybind11::pickle(
             [](const IneritedNoise& self) { return self.pickle(); },

--- a/tests/inherit_noise.cc
+++ b/tests/inherit_noise.cc
@@ -36,10 +36,10 @@ struct IneritedNoise : public fwdpy11::GeneticValueNoise
     {
     }
 
-    std::unique_ptr<fwdpy11::GeneticValueNoise>
+    std::shared_ptr<fwdpy11::GeneticValueNoise>
     clone() const override
     {
-        return std::unique_ptr<IneritedNoise>(new IneritedNoise());
+        return std::make_shared<IneritedNoise>();
     }
 
     pybind11::object

--- a/tests/pygss.py
+++ b/tests/pygss.py
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
 import math
 
 import attr
@@ -18,7 +36,7 @@ class PyGSS(fwdpy11.GeneticValueIsTrait):
         fwdpy11.GeneticValueIsTrait.__init__(self)
 
     def __call__(self, metadata, genetic_values):
-        return math.e ** (-((metadata.g - self.opt) ** 2) / (2 * self.VS))
+        return math.e ** (-((metadata.g + metadata.e - self.opt) ** 2) / (2 * self.VS))
 
 
 @fwdpy11.custom_genetic_value_decorators.genetic_value_is_trait_default_clone()
@@ -32,7 +50,7 @@ class PyGSSRandomOptimum(fwdpy11.GeneticValueIsTrait):
         self.optima = []
 
     def __call__(self, metadata, genetic_values):
-        return math.e ** (-((metadata.g - self.opt) ** 2) / (2 * self.VS))
+        return math.e ** (-((metadata.g + metadata.e - self.opt) ** 2) / (2 * self.VS))
 
     def update(self, pop):
         self.opt = np.random.normal(0.0, 1.0, 1,)[0]

--- a/tests/pynoise.py
+++ b/tests/pynoise.py
@@ -23,5 +23,5 @@ import fwdpy11.custom_genetic_value_decorators
 @fwdpy11.custom_genetic_value_decorators.default_update
 @fwdpy11.custom_genetic_value_decorators.genetic_value_noise_default_clone
 class PyNoise(fwdpy11.GeneticValueNoise):
-    def __call__(self, rng, metadata, p1, p2, pop):
+    def __call__(self, rng, metadata, pop):
         return fwdpy11.gsl_ran_gaussian_ziggurat(rng, 0.1)

--- a/tests/pynoise.py
+++ b/tests/pynoise.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+import fwdpy11
+import fwdpy11.custom_genetic_value_decorators
+
+
+@fwdpy11.custom_genetic_value_decorators.default_update
+@fwdpy11.custom_genetic_value_decorators.genetic_value_noise_default_clone
+class PyNoise(fwdpy11.GeneticValueNoise):
+    def __call__(self, rng, metadata, p1, p2, pop):
+        return fwdpy11.gsl_ran_gaussian_ziggurat(rng, 0.1)

--- a/tests/test_custom_genetic_values.py
+++ b/tests/test_custom_genetic_values.py
@@ -24,31 +24,37 @@ import numpy as np
 import fwdpy11
 
 
+def build_model(gvalue_to_fitness, noise, simlen):
+    pdict = {
+        "nregions": [],
+        "sregions": [
+            fwdpy11.mvDES(
+                fwdpy11.MultivariateGaussianEffects(
+                    0, 1, 1, h=0.25, cov_matrix=np.identity(2)
+                ),
+                np.zeros(2),
+            )
+        ],
+        "recregions": [fwdpy11.PoissonInterval(0, 1, 0.5)],
+        "rates": (0, 1e-2, None),
+        "demography": fwdpy11.DiscreteDemography(
+            migmatrix=np.array([0.9, 0.1, 0.1, 0.9]).reshape((2, 2))
+        ),
+        "simlen": simlen,
+        "gvalue": fwdpy11.Additive(
+            ndemes=2, scaling=2, gvalue_to_fitness=gvalue_to_fitness, noise=noise,
+        ),
+    }
+    return pdict
+
+
 class TestCustomGeneticValueisTrait(unittest.TestCase):
     def test_run(self):
 
         import pygss
 
         GSS = pygss.PyGSS(opt=0.0, VS=1.0)
-
-        pdict = {
-            "nregions": [],
-            "sregions": [
-                fwdpy11.mvDES(
-                    fwdpy11.MultivariateGaussianEffects(
-                        0, 1, 1, h=0.25, cov_matrix=np.identity(2)
-                    ),
-                    np.zeros(2),
-                )
-            ],
-            "recregions": [fwdpy11.PoissonInterval(0, 1, 0.5)],
-            "rates": (0, 1e-2, None),
-            "demography": fwdpy11.DiscreteDemography(
-                migmatrix=np.array([0.9, 0.1, 0.1, 0.9]).reshape((2, 2))
-            ),
-            "simlen": 100,
-            "gvalue": fwdpy11.Additive(ndemes=2, scaling=2, gvalue_to_fitness=GSS,),
-        }
+        pdict = build_model(GSS, None, 100)
 
         params = fwdpy11.ModelParams(**pdict)
         pop = fwdpy11.DiploidPopulation([1000, 1000], 1.0)
@@ -77,26 +83,7 @@ class TestCustomGeneticValueisTrait(unittest.TestCase):
         import pygss
 
         GSS = pygss.PyGSSRandomOptimum(opt=0.0, VS=1.0)
-
-        pdict = {
-            "nregions": [],
-            "sregions": [
-                fwdpy11.mvDES(
-                    fwdpy11.MultivariateGaussianEffects(
-                        0, 1, 1, h=0.25, cov_matrix=np.identity(2)
-                    ),
-                    np.zeros(2),
-                )
-            ],
-            "recregions": [fwdpy11.PoissonInterval(0, 1, 0.5)],
-            "rates": (0, 1e-2, None),
-            "demography": fwdpy11.DiscreteDemography(
-                migmatrix=np.array([0.9, 0.1, 0.1, 0.9]).reshape((2, 2))
-            ),
-            "simlen": 5,
-            "gvalue": fwdpy11.Additive(ndemes=2, scaling=2, gvalue_to_fitness=GSS,),
-        }
-
+        pdict = build_model(GSS, None, 5)
         params = fwdpy11.ModelParams(**pdict)
         pop = fwdpy11.DiploidPopulation([1000, 1000], 1.0)
 
@@ -114,28 +101,7 @@ class TestCustomGeneticValueNoise(unittest.TestCase):
 
         GSS = fwdpy11.GSS(optimum=0.0, VS=1.0)
         Noise = pynoise.PyNoise()
-
-        pdict = {
-            "nregions": [],
-            "sregions": [
-                fwdpy11.mvDES(
-                    fwdpy11.MultivariateGaussianEffects(
-                        0, 1, 1, h=0.25, cov_matrix=np.identity(2)
-                    ),
-                    np.zeros(2),
-                )
-            ],
-            "recregions": [fwdpy11.PoissonInterval(0, 1, 0.5)],
-            "rates": (0, 1e-2, None),
-            "demography": fwdpy11.DiscreteDemography(
-                migmatrix=np.array([0.9, 0.1, 0.1, 0.9]).reshape((2, 2))
-            ),
-            "simlen": 100,
-            "gvalue": fwdpy11.Additive(
-                ndemes=2, scaling=2, gvalue_to_fitness=GSS, noise=Noise
-            ),
-        }
-
+        pdict = build_model(GSS, Noise, 5)
         params = fwdpy11.ModelParams(**pdict)
         pop = fwdpy11.DiploidPopulation([1000, 1000], 1.0)
 
@@ -144,7 +110,7 @@ class TestCustomGeneticValueNoise(unittest.TestCase):
 
         self.assertEqual(pop.generation, params.simlen)
         md = np.array(pop.diploid_metadata)
-        self.assertTrue(len(np.where(md['e'] > 0)[0]) > 0)
+        self.assertTrue(len(np.where(md["e"] > 0)[0]) > 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_custom_genetic_values.py
+++ b/tests/test_custom_genetic_values.py
@@ -107,5 +107,45 @@ class TestCustomGeneticValueisTrait(unittest.TestCase):
         )
 
 
+class TestCustomGeneticValueNoise(unittest.TestCase):
+    def test_run(self):
+
+        import pynoise
+
+        GSS = fwdpy11.GSS(optimum=0.0, VS=1.0)
+        Noise = pynoise.PyNoise()
+
+        pdict = {
+            "nregions": [],
+            "sregions": [
+                fwdpy11.mvDES(
+                    fwdpy11.MultivariateGaussianEffects(
+                        0, 1, 1, h=0.25, cov_matrix=np.identity(2)
+                    ),
+                    np.zeros(2),
+                )
+            ],
+            "recregions": [fwdpy11.PoissonInterval(0, 1, 0.5)],
+            "rates": (0, 1e-2, None),
+            "demography": fwdpy11.DiscreteDemography(
+                migmatrix=np.array([0.9, 0.1, 0.1, 0.9]).reshape((2, 2))
+            ),
+            "simlen": 100,
+            "gvalue": fwdpy11.Additive(
+                ndemes=2, scaling=2, gvalue_to_fitness=GSS, noise=Noise
+            ),
+        }
+
+        params = fwdpy11.ModelParams(**pdict)
+        pop = fwdpy11.DiploidPopulation([1000, 1000], 1.0)
+
+        rng = fwdpy11.GSLrng(1010)
+        fwdpy11.evolvets(rng, pop, params, 100, suppress_table_indexing=True)
+
+        self.assertEqual(pop.generation, params.simlen)
+        md = np.array(pop.diploid_metadata)
+        self.assertTrue(len(np.where(md['e'] > 0)[0]) > 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
See #460.

This PR also removes redundant info passed to `GeneticValueNoise::operator()`.  The parents are already in the metadata.