### PR TITLE
Use proxy objects to streamline Python API for custom genetic value types.

### DIFF
--- a/tests/pygss.py
+++ b/tests/pygss.py
@@ -35,8 +35,11 @@ class PyGSS(fwdpy11.GeneticValueIsTrait):
     def __attrs_post_init__(self):
         fwdpy11.GeneticValueIsTrait.__init__(self)
 
-    def __call__(self, metadata, genetic_values):
-        return math.e ** (-((metadata.g + metadata.e - self.opt) ** 2) / (2 * self.VS))
+    def __call__(self, data):
+        return math.e ** (
+            -((data.offspring_metadata.g + data.offspring_metadata.e - self.opt) ** 2)
+            / (2 * self.VS)
+        )
 
 
 @fwdpy11.custom_genetic_value_decorators.genetic_value_is_trait_default_clone()
@@ -49,8 +52,11 @@ class PyGSSRandomOptimum(fwdpy11.GeneticValueIsTrait):
         fwdpy11.GeneticValueIsTrait.__init__(self)
         self.optima = []
 
-    def __call__(self, metadata, genetic_values):
-        return math.e ** (-((metadata.g + metadata.e - self.opt) ** 2) / (2 * self.VS))
+    def __call__(self, data):
+        return math.e ** (
+            -((data.offspring_metadata.g + data.offspring_metadata.e - self.opt) ** 2)
+            / (2 * self.VS)
+        )
 
     def update(self, pop):
         self.opt = np.random.normal(0.0, 1.0, 1,)[0]

--- a/tests/pynoise.py
+++ b/tests/pynoise.py
@@ -23,5 +23,5 @@ import fwdpy11.custom_genetic_value_decorators
 @fwdpy11.custom_genetic_value_decorators.default_update
 @fwdpy11.custom_genetic_value_decorators.genetic_value_noise_default_clone
 class PyNoise(fwdpy11.GeneticValueNoise):
-    def __call__(self, rng, metadata, pop):
+    def __call__(self, rng, data):
         return fwdpy11.gsl_ran_gaussian_ziggurat(rng, 0.1)


### PR DESCRIPTION
Simplify the Python API introduced in #550 and #549