### PR TITLE
Expose mutation list

### DIFF
--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -47,14 +47,17 @@ struct genome_data_proxy
     mutation_key_array_proxy smutations_proxy;
     py::object effect_sizes, dominance, smutations, positions;
     std::vector<double> effect_sizes_cpp, dominance_cpp, positions_cpp;
+    py::list pymutations;
+    bool filling_mutations;
 
-    genome_data_proxy()
+    genome_data_proxy(bool fill_mutations_list)
         : effect_sizes_proxy{}, dominance_proxy{}, positions_proxy{}, smutations_proxy{},
           effect_sizes{py::cast<double_array_proxy*>(&effect_sizes_proxy)},
           dominance{py::cast<double_array_proxy*>(&dominance_proxy)},
           smutations{py::cast<mutation_key_array_proxy*>(&smutations_proxy)},
           positions{py::cast<double_array_proxy*>(&positions_proxy)}, effect_sizes_cpp{},
-          dominance_cpp{}, positions_cpp{}
+          dominance_cpp{}, positions_cpp{}, pymutations{}, filling_mutations{
+                                                               fill_mutations_list}
     {
     }
 
@@ -65,12 +68,21 @@ struct genome_data_proxy
         effect_sizes_cpp.clear();
         dominance_cpp.clear();
         positions_cpp.clear();
+        if (filling_mutations)
+            {
+                pymutations.attr("clear")();
+            }
         for (auto k : smutations)
             {
                 auto& m = mutations[k];
                 effect_sizes_cpp.push_back(m.s);
                 dominance_cpp.push_back(m.h);
                 positions_cpp.push_back(m.pos);
+                if (filling_mutations)
+                    {
+                        pymutations.append(
+                            py::cast<const fwdpy11::Mutation*>(&mutations[k]));
+                    }
             }
         effect_sizes_proxy.set(effect_sizes_cpp);
         dominance_proxy.set(dominance_cpp);
@@ -97,8 +109,8 @@ struct PyDiploidGeneticValueData
     py::object offspring_metadata, parent1_metadata, parent2_metadata, genome1, genome2,
         gvalues;
     py::list genomes, parental_metadata;
-    PyDiploidGeneticValueData()
-        : metadata_proxy{}, genome1_data{}, genome2_data{},
+    PyDiploidGeneticValueData(bool fill_mutations_list)
+        : metadata_proxy{}, genome1_data{fill_mutations_list}, genome2_data{fill_mutations_list},
           offspring_metadata{py::cast<fwdpy11::DiploidMetadata*>(&metadata_proxy)},
           parent1_metadata{py::cast<fwdpy11::DiploidMetadata*>(&parent1_metadata_proxy)},
           parent2_metadata{py::cast<fwdpy11::DiploidMetadata*>(&parent2_metadata_proxy)},
@@ -137,10 +149,11 @@ class PyDiploidGeneticValue : public fwdpy11::DiploidGeneticValue
     }
 
   public:
+    bool filling_mutations;
     PyDiploidGeneticValue(std::size_t ndim, py::object gvalue_to_fitness_map,
-                          py::object noise)
+                          py::object noise, bool fill_mutations_list)
         : fwdpy11::DiploidGeneticValue(ndim, *dispatch_gv2w(ndim, gvalue_to_fitness_map),
-                                       *dispatch_noise(noise))
+                                       *dispatch_noise(noise)), filling_mutations{fill_mutations_list}
     {
     }
 };
@@ -153,8 +166,8 @@ class PyDiploidGeneticValueTrampoline : public PyDiploidGeneticValue
 
   public:
     PyDiploidGeneticValueTrampoline(std::size_t ndim, py::object gvalue_to_fitness_map,
-                                    py::object noise)
-        : PyDiploidGeneticValue(ndim, gvalue_to_fitness_map, noise), data{},
+                                    py::object noise, bool fill_mutations_list)
+        : PyDiploidGeneticValue(ndim, gvalue_to_fitness_map, noise, fill_mutations_list), data{fill_mutations_list},
           pydata{py::cast<PyDiploidGeneticValueData*>(&data)}
     {
     }
@@ -200,7 +213,7 @@ init_PyDiploidGeneticValue(py::module& m)
 {
     py::class_<PyDiploidGeneticValue, fwdpy11::DiploidGeneticValue,
                PyDiploidGeneticValueTrampoline>(m, "PyDiploidGeneticValue")
-        .def(py::init<std::size_t, py::object, py::object>())
+        .def(py::init<std::size_t, py::object, py::object, bool>())
         .def("update_members",
              [](PyDiploidGeneticValue& self, const fwdpy11::DiploidPopulation& pop) {
                  self.gv2w->update(pop);
@@ -210,8 +223,7 @@ init_PyDiploidGeneticValue(py::module& m)
     py::class_<PyDiploidGeneticValueData>(m, "PyDiploidGeneticValueData")
         .def_readwrite("offspring_metadata",
                        &PyDiploidGeneticValueData::offspring_metadata)
-        .def_readwrite("parent1_metadata",
-                       &PyDiploidGeneticValueData::parent1_metadata)
+        .def_readwrite("parent1_metadata", &PyDiploidGeneticValueData::parent1_metadata)
         .def_readwrite("parental_metadata",
                        &PyDiploidGeneticValueData::parental_metadata)
         .def_readwrite("gvalues", &PyDiploidGeneticValueData::gvalues)
@@ -221,7 +233,8 @@ init_PyDiploidGeneticValue(py::module& m)
         .def_readonly("effect_sizes", &genome_data_proxy::effect_sizes)
         .def_readonly("dominance", &genome_data_proxy::dominance)
         .def_readonly("positions", &genome_data_proxy::positions)
-        .def_readonly("smutations", &genome_data_proxy::smutations);
+        .def_readonly("smutations", &genome_data_proxy::smutations)
+        .def_readonly("mutations", &genome_data_proxy::pymutations);
 
     py::class_<double_array_proxy>(m, "_FloatProxy", py::buffer_protocol())
         .def_buffer([](const double_array_proxy& self) {

--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -233,8 +233,8 @@ init_PyDiploidGeneticValue(py::module& m)
     py::class_<mutation_key_array_proxy>(m, "_MutationKeyArrayProxy",
                                          py::buffer_protocol())
         .def_buffer([](const mutation_key_array_proxy& self) {
-            return py::buffer_info(self.data, sizeof(double),
-                                   py::format_descriptor<double>::format(), 1,
-                                   {self.size}, {sizeof(double)});
+            return py::buffer_info(self.data, sizeof(std::uint32_t),
+                                   py::format_descriptor<std::uint32_t>::format(), 1,
+                                   {self.size}, {sizeof(std::uint32_t)});
         });
 }

--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -244,7 +244,14 @@ init_PyDiploidGeneticValue(py::module& m)
         .def_readonly("dominance", &genome_data_proxy::dominance)
         .def_readonly("positions", &genome_data_proxy::positions)
         .def_readonly("smutations", &genome_data_proxy::smutations)
-        .def_readonly("mutations", &genome_data_proxy::pymutations);
+        .def_property_readonly("mutations",
+                               [](const genome_data_proxy& self) -> py::object {
+                                   if (self.filling_mutations == false)
+                                       {
+                                           return py::none();
+                                       }
+                                   return self.pymutations;
+                               });
 
     py::class_<double_array_proxy>(m, "_FloatProxy", py::buffer_protocol())
         .def_buffer([](const double_array_proxy& self) { return as_buffer(self); });

--- a/tests/pyadditive.py
+++ b/tests/pyadditive.py
@@ -24,7 +24,7 @@ import fwdpy11
 
 class PyAdditive(fwdpy11.PyDiploidGeneticValue):
     def __init__(self, gvalue_to_fitness=None, noise=None):
-        fwdpy11.PyDiploidGeneticValue.__init__(self, 1, gvalue_to_fitness, noise)
+        fwdpy11.PyDiploidGeneticValue.__init__(self, 1, gvalue_to_fitness, noise, False)
 
     def calculate_gvalue(self, data):
         s = 0.0

--- a/tests/test_custom_genetic_values.py
+++ b/tests/test_custom_genetic_values.py
@@ -132,6 +132,34 @@ class TestCustomPyGeneticValue(unittest.TestCase):
         import pyadditive
         import pynoise
 
+        f = pyadditive.PyAdditive.calculate_gvalue
+
+        def intercept(self, data):
+            for g in data.genomes:
+                assert g.mutations is None
+                p = memoryview(g.positions)
+                if len(p) > 0:
+                    for i in p:
+                        assert i >= 0.0 and i < 1.
+                    assert type(p[0]) == float
+                m = memoryview(g.smutations)
+                if len(m) > 0:
+                    assert type(m[0]) == int
+                e = memoryview(g.effect_sizes)
+                if len(e) > 0:
+                    assert type(e[0]) == float
+                h = memoryview(g.dominance)
+                if len(h) > 0:
+                    for i in h:
+                        assert i == 1.0
+                    assert type(h[0]) == float
+                assert len(p) == len(m)
+                assert len(m) == len(e)
+                assert len(h) == len(e)
+            return f(self, data)
+
+        pyadditive.PyAdditive.calculate_gvalue = intercept
+
         PyA = pyadditive.PyAdditive(
             pygss.PyGSS(opt=0.0, VS=1.0), noise=pynoise.PyNoise()
         )
@@ -147,8 +175,8 @@ class TestCustomPyGeneticValue(unittest.TestCase):
         if len(pop_PyA.tables.mutations) == 0:
             self.fail("simulation ended with no mutations")
         md = np.array(pop_PyA.diploid_metadata, copy=False)
-        self.assertTrue(md['g'].var() > 0.)
-        self.assertTrue(md['e'].var() > 0.)
+        self.assertTrue(md["g"].var() > 0.0)
+        self.assertTrue(md["e"].var() > 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows a PyDiploidGeneticValue to provide access to a Python list of all mutations in each haploid genome.

Also fixes a type error in one of the proxy arrays.