### PR TITLE
Create parameter objects for genetic value classes.

### DIFF
--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -106,6 +106,8 @@ set(DISCRETE_DEMOGRAPHY_SOURCES src/discrete_demography/init.cc
     src/discrete_demography/DiscreteDemography.cc
     src/discrete_demography/exceptions.cc)
 
+set (ARRAY_PROXY_SOURCES src/array_proxies/init.cc)
+
 set(ALL_SOURCES ${FWDPP_TYPES_SOURCES}
     ${FWDPP_FUNCTIONS_SOURCES}
     ${FWDPY11_TYPES_SOURCES}
@@ -117,7 +119,8 @@ set(ALL_SOURCES ${FWDPP_TYPES_SOURCES}
     ${TS_SOURCES}
     ${GSL_SOURCES}
     ${EVOLVE_POPULATION_SOURCES}
-    ${DISCRETE_DEMOGRAPHY_SOURCES})
+    ${DISCRETE_DEMOGRAPHY_SOURCES}
+    ${ARRAY_PROXY_SOURCES})
 
 set(LTO_OPTIONS)
 if(ENABLE_PROFILING OR DISABLE_LTO)

--- a/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
@@ -75,7 +75,7 @@ namespace fwdpy11
         std::size_t metadata_index;
         std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
 
-        DiploidGeneticValueToFitnessData(const DiploidGeneticValueData& data,
+        explicit DiploidGeneticValueToFitnessData(const DiploidGeneticValueData& data,
                                          const std::vector<double>& gvalues_)
             : rng(data.rng), parent1_metadata(data.parent1_metadata),
               parent2_metadata(data.parent2_metadata), gvalues(gvalues_),

--- a/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
@@ -47,21 +47,20 @@ namespace fwdpy11
         }
     };
 
-    // NOTE: the next two structs may be collabsible into one?
+    // NOTE: the next two structs may be collapsible into one?
 
     struct DiploidGeneticValueNoiseData
     {
         std::reference_wrapper<const fwdpy11::GSLrng_t> rng;
         std::reference_wrapper<const fwdpy11::DiploidMetadata> parent1_metadata,
-            parent2_metadata;
+            parent2_metadata, offspring_metadata;
         std::size_t metadata_index;
-        std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
 
         explicit DiploidGeneticValueNoiseData(const DiploidGeneticValueData& data)
             : rng(data.rng), parent1_metadata(data.parent1_metadata),
               parent2_metadata(data.parent2_metadata),
-              metadata_index(data.metadata_index),
-              offspring_metadata(data.offspring_metadata)
+              offspring_metadata(data.offspring_metadata),
+              metadata_index(data.metadata_index)
         {
         }
     };
@@ -70,17 +69,17 @@ namespace fwdpy11
     {
         std::reference_wrapper<const fwdpy11::GSLrng_t> rng;
         std::reference_wrapper<const fwdpy11::DiploidMetadata> parent1_metadata,
-            parent2_metadata;
+            parent2_metadata, offspring_metadata;
         std::reference_wrapper<const std::vector<double>> gvalues;
         std::size_t metadata_index;
-        std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
 
         explicit DiploidGeneticValueToFitnessData(const DiploidGeneticValueData& data,
-                                         const std::vector<double>& gvalues_)
+                                                  const std::vector<double>& gvalues_)
             : rng(data.rng), parent1_metadata(data.parent1_metadata),
-              parent2_metadata(data.parent2_metadata), gvalues(gvalues_),
-              metadata_index(data.metadata_index),
-              offspring_metadata(data.offspring_metadata)
+              parent2_metadata(data.parent2_metadata),
+              offspring_metadata(data.offspring_metadata),
+              gvalues(gvalues_),
+              metadata_index(data.metadata_index)
         {
         }
     };

--- a/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_data/genetic_value_data.hpp
@@ -1,0 +1,89 @@
+//
+// Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWDPY11_GENETIC_DATA_HPP__
+#define FWDPY11_GENETIC_DATA_HPP__
+
+#include <fwdpy11/rng.hpp>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+
+namespace fwdpy11
+{
+    struct DiploidGeneticValueData
+    {
+        std::reference_wrapper<const fwdpy11::GSLrng_t> rng;
+        std::reference_wrapper<const fwdpy11::DiploidPopulation> pop;
+        std::reference_wrapper<const fwdpy11::DiploidMetadata> parent1_metadata,
+            parent2_metadata;
+        std::size_t metadata_index;
+        std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
+
+        DiploidGeneticValueData(const fwdpy11::GSLrng_t& rng_,
+                                const fwdpy11::DiploidPopulation& pop_,
+                                const fwdpy11::DiploidMetadata& parent1_metadata_,
+                                const fwdpy11::DiploidMetadata& parent2_metadata_,
+                                std::size_t metadata_index_,
+                                fwdpy11::DiploidMetadata& offspring_metadata_)
+            : rng(rng_), pop(pop_), parent1_metadata(parent1_metadata_),
+              parent2_metadata(parent2_metadata_), metadata_index(metadata_index_),
+              offspring_metadata(offspring_metadata_)
+        {
+        }
+    };
+
+    // NOTE: the next two structs may be collabsible into one?
+
+    struct DiploidGeneticValueNoiseData
+    {
+        std::reference_wrapper<const fwdpy11::GSLrng_t> rng;
+        std::reference_wrapper<const fwdpy11::DiploidMetadata> parent1_metadata,
+            parent2_metadata;
+        std::size_t metadata_index;
+        std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
+
+        explicit DiploidGeneticValueNoiseData(const DiploidGeneticValueData& data)
+            : rng(data.rng), parent1_metadata(data.parent1_metadata),
+              parent2_metadata(data.parent2_metadata),
+              metadata_index(data.metadata_index),
+              offspring_metadata(data.offspring_metadata)
+        {
+        }
+    };
+
+    struct DiploidGeneticValueToFitnessData
+    {
+        std::reference_wrapper<const fwdpy11::GSLrng_t> rng;
+        std::reference_wrapper<const fwdpy11::DiploidMetadata> parent1_metadata,
+            parent2_metadata;
+        std::reference_wrapper<const std::vector<double>> gvalues;
+        std::size_t metadata_index;
+        std::reference_wrapper<fwdpy11::DiploidMetadata> offspring_metadata;
+
+        DiploidGeneticValueToFitnessData(const DiploidGeneticValueData& data,
+                                         const std::vector<double>& gvalues_)
+            : rng(data.rng), parent1_metadata(data.parent1_metadata),
+              parent2_metadata(data.parent2_metadata), gvalues(gvalues_),
+              metadata_index(data.metadata_index),
+              offspring_metadata(data.offspring_metadata)
+        {
+        }
+    };
+}
+
+#endif

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
@@ -23,6 +23,7 @@
 #include <fwdpy11/types/Diploid.hpp>
 #include <fwdpy11/types/DiploidPopulation.hpp>
 #include <fwdpy11/rng.hpp>
+#include <fwdpy11/genetic_value_data/genetic_value_data.hpp>
 
 namespace fwdpy11
 {
@@ -31,9 +32,7 @@ namespace fwdpy11
     {
         virtual ~GeneticValueNoise() = default;
         virtual double
-        operator()(const GSLrng_t& /* rng */,
-                   const DiploidMetadata& /*offspring_metadata*/,
-                   const DiploidPopulation& /*pop*/) const = 0;
+        operator()(const DiploidGeneticValueNoiseData /*data*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;
         virtual std::shared_ptr<GeneticValueNoise> clone() const = 0;
     };

--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/NoNoise.hpp
@@ -27,9 +27,7 @@ namespace fwdpy11
     struct NoNoise : public GeneticValueNoise
     {
         double
-        operator()(const GSLrng_t& /*rng*/,
-                   const DiploidMetadata& /*offspring_metadata*/,
-                   const DiploidPopulation& /*pop*/) const override
+        operator()(const DiploidGeneticValueNoiseData /*data*/) const override
         {
             return 0.;
         }

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GSSmo.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GSSmo.hpp
@@ -43,11 +43,12 @@ namespace fwdpy11
         }
 
         double
-        operator()(const DiploidMetadata &metadata,
-                   const std::vector<double> & /*genetic_values*/) const override
+        operator()(const DiploidGeneticValueToFitnessData data) const override
         {
-            return std::exp(
-                -(std::pow(metadata.g + metadata.e - opt, 2.0) / (2.0 * VS)));
+            return std::exp(-(std::pow(data.offspring_metadata.get().g
+                                           + data.offspring_metadata.get().e - opt,
+                                       2.0)
+                              / (2.0 * VS)));
         }
 
         template <typename poptype>

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueIsFitness.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueIsFitness.hpp
@@ -32,11 +32,9 @@ namespace fwdpy11
         }
 
         double
-        operator()(
-            const DiploidMetadata &metadata,
-            const std::vector<double> & /*genetic_values*/) const override
+        operator()(const DiploidGeneticValueToFitnessData data) const override
         {
-            return metadata.g;
+            return data.offspring_metadata.get().g;
         }
 
         void

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueToFitnessMap.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueToFitnessMap.hpp
@@ -24,6 +24,7 @@
 #include <fwdpy11/types/DiploidPopulation.hpp>
 #include <fwdpy11/genetic_values/default_update.hpp>
 #include <fwdpp/util/named_type.hpp>
+#include <fwdpy11/genetic_value_data/genetic_value_data.hpp>
 
 namespace fwdpy11
 {
@@ -44,8 +45,7 @@ namespace fwdpy11
         }
         virtual ~GeneticValueToFitnessMap() = default;
         virtual double
-        operator()(const DiploidMetadata& /*metadata*/,
-                   const std::vector<double>& /*genetic_values*/) const = 0;
+        operator()(const DiploidGeneticValueToFitnessData /*data*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;
         virtual std::shared_ptr<GeneticValueToFitnessMap> clone() const = 0;
         virtual pybind11::tuple

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/MultivariateGSSmo.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/MultivariateGSSmo.hpp
@@ -66,17 +66,17 @@ namespace fwdpy11
         }
 
         double
-        operator()(const DiploidMetadata & /*metadata*/,
-                   const std::vector<double> &values) const override
+        operator()(const DiploidGeneticValueToFitnessData data) const override
         {
-            if (values.size() != total_dim)
+            if (data.gvalues.get().size() != total_dim)
                 {
                     throw std::runtime_error("dimension mismatch");
                 }
             double sqdiff = 0.0;
-            for (std::size_t i = 0; i < values.size(); ++i)
+            for (std::size_t i = 0; i < data.gvalues.get().size(); ++i)
                 {
-                    sqdiff += gsl_pow_2(values[i] - optima[current_timepoint].optima[i]);
+                    sqdiff += gsl_pow_2(data.gvalues.get()[i]
+                                        - optima[current_timepoint].optima[i]);
                 }
             return std::exp(-sqdiff / (2.0 * optima[current_timepoint].VW));
         }

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -29,6 +29,7 @@
 #include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
 #include <fwdpy11/genetic_value_noise/GeneticValueNoise.hpp>
 #include <fwdpy11/genetic_value_noise/NoNoise.hpp>
+#include <fwdpy11/genetic_value_data/genetic_value_data.hpp>
 
 namespace fwdpy11
 {
@@ -99,12 +100,15 @@ namespace fwdpy11
 
         // To be called from w/in a simulation
         virtual void
-        operator()(const GSLrng_t& rng, std::size_t diploid_index,
-                   const DiploidPopulation& pop, DiploidMetadata& metadata) const
+        operator()(DiploidGeneticValueData data) const
         {
-            metadata.g = calculate_gvalue(diploid_index, metadata, pop);
-            metadata.e = noise(rng, metadata, pop);
-            metadata.w = genetic_value_to_fitness(metadata);
+            data.offspring_metadata.get().g
+                = calculate_gvalue(data.offspring_metadata.get().label,
+                                   data.offspring_metadata.get(), data.pop.get());
+            data.offspring_metadata.get().e
+                = noise(data.rng.get(), data.offspring_metadata.get(), data.pop.get());
+            data.offspring_metadata.get().w
+                = genetic_value_to_fitness(data.offspring_metadata.get());
         }
 
         virtual double

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -87,9 +87,7 @@ namespace fwdpy11
         DiploidGeneticValue& operator=(const DiploidGeneticValue&) = delete;
 
         // Callable from Python
-        virtual double calculate_gvalue(const std::size_t /*diploid_index*/,
-                                        const DiploidMetadata& /*diploid_metadata*/,
-                                        const DiploidPopulation& /*pop*/) const = 0;
+        virtual double calculate_gvalue(const DiploidGeneticValueData data) const = 0;
 
         virtual void
         update(const DiploidPopulation& pop)
@@ -102,9 +100,7 @@ namespace fwdpy11
         virtual void
         operator()(DiploidGeneticValueData data) const
         {
-            data.offspring_metadata.get().g
-                = calculate_gvalue(data.offspring_metadata.get().label,
-                                   data.offspring_metadata.get(), data.pop.get());
+            data.offspring_metadata.get().g = calculate_gvalue(data);
             data.offspring_metadata.get().e = noise(DiploidGeneticValueNoiseData(data));
             data.offspring_metadata.get().w
                 = genetic_value_to_fitness(data.offspring_metadata.get());

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -102,14 +102,14 @@ namespace fwdpy11
         {
             data.offspring_metadata.get().g = calculate_gvalue(data);
             data.offspring_metadata.get().e = noise(DiploidGeneticValueNoiseData(data));
-            data.offspring_metadata.get().w
-                = genetic_value_to_fitness(data.offspring_metadata.get());
+            data.offspring_metadata.get().w = genetic_value_to_fitness(
+                DiploidGeneticValueToFitnessData(data, gvalues));
         }
 
         virtual double
-        genetic_value_to_fitness(const DiploidMetadata& metadata) const
+        genetic_value_to_fitness(const DiploidGeneticValueToFitnessData data) const
         {
-            return gv2w->operator()(metadata, gvalues);
+            return gv2w->operator()(data);
         }
 
         virtual double

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -105,8 +105,7 @@ namespace fwdpy11
             data.offspring_metadata.get().g
                 = calculate_gvalue(data.offspring_metadata.get().label,
                                    data.offspring_metadata.get(), data.pop.get());
-            data.offspring_metadata.get().e
-                = noise(data.rng.get(), data.offspring_metadata.get(), data.pop.get());
+            data.offspring_metadata.get().e = noise(DiploidGeneticValueNoiseData(data));
             data.offspring_metadata.get().w
                 = genetic_value_to_fitness(data.offspring_metadata.get());
         }
@@ -118,10 +117,9 @@ namespace fwdpy11
         }
 
         virtual double
-        noise(const GSLrng_t& rng, const DiploidMetadata& offspring_metadata,
-              const DiploidPopulation& pop) const
+        noise(const DiploidGeneticValueNoiseData data) const
         {
-            return noise_fxn->operator()(rng, offspring_metadata, pop);
+            return noise_fxn->operator()(data);
         }
 
         virtual pybind11::tuple

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
@@ -41,12 +41,12 @@ namespace fwdpy11
         }
 
         double
-        calculate_gvalue(const std::size_t diploid_index,
-                         const DiploidMetadata& /*metadata*/,
-                         const DiploidPopulation& pop) const
+        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
         {
             std::fill(begin(gvalues), end(gvalues), 0.0);
 
+            const auto & pop = data.pop.get();
+            const auto diploid_index = data.offspring_metadata.get().label;
             for (auto key :
                  pop.haploid_genomes[pop.diploids[diploid_index].first]
                      .smutations)

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
@@ -115,11 +115,11 @@ namespace fwdpy11
         }
 
         double
-        calculate_gvalue(const std::size_t diploid_index,
-                         const DiploidMetadata& metadata,
-                         const DiploidPopulation& pop) const override
+        calculate_gvalue(const DiploidGeneticValueData data) const override
         {
-            gvalues[0] = make_return_value(callback(gv, diploid_index, metadata, pop));
+            gvalues[0] = make_return_value(
+                callback(gv, data.offspring_metadata.get().label,
+                         data.offspring_metadata.get(), data.pop.get()));
             return gvalues[0];
         }
 

--- a/fwdpy11/headers/fwdpy11/util/array_proxy.hpp
+++ b/fwdpy11/headers/fwdpy11/util/array_proxy.hpp
@@ -1,0 +1,60 @@
+//
+// Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWPY11_UTIL_ARRAY_PROXY_HPP
+#define FWPY11_UTIL_ARRAY_PROXY_HPP
+
+#include <cstdint>
+#include <vector>
+#include <pybind11/pybind11.h>
+
+namespace fwdpy11
+{
+    template <typename T> struct array_proxy
+    {
+        T* data;
+        std::size_t size;
+        array_proxy() : data{nullptr}, size{0}
+        {
+        }
+
+        void
+        set(const std::vector<T>& v)
+        {
+            data = const_cast<T*>(v.data());
+            size = v.size();
+        }
+    };
+
+    template <typename T>
+    inline pybind11::buffer_info
+    as_buffer(const array_proxy<T>& self)
+    {
+        return pybind11::buffer_info(self.data, sizeof(T),
+                                     pybind11::format_descriptor<T>::format(), 1,
+                                     {self.size}, {sizeof(T)});
+    }
+
+    // fwdpy11._Uint32ArrayProxy
+    using uint32_array_proxy = array_proxy<std::uint32_t>;
+    // fwdpy11._FloatArrayProxy
+    using double_array_proxy = array_proxy<double>;
+}
+
+#endif

--- a/fwdpy11/src/_fwdpy11.cc
+++ b/fwdpy11/src/_fwdpy11.cc
@@ -31,6 +31,7 @@ void init_GSL(py::module &);
 void init_ts(py::module &);
 void init_evolution_functions(py::module &);
 void init_discrete_demography(py::module &m);
+void init_array_proxies(py::module &m);
 
 PYBIND11_MODULE(_fwdpy11, m)
 {
@@ -57,6 +58,7 @@ PYBIND11_MODULE(_fwdpy11, m)
     init_ts(m);
     init_evolution_functions(m);
     init_discrete_demography(m);
+    init_array_proxies(m);
 
     m.def(
         "pybind11_version",

--- a/fwdpy11/src/array_proxies/init.cc
+++ b/fwdpy11/src/array_proxies/init.cc
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <fwdpy11/util/array_proxy.hpp>
+
+namespace py = pybind11;
+
+void
+init_array_proxies(py::module& m)
+{
+    py::class_<fwdpy11::double_array_proxy>(m, "_FloatProxy", py::buffer_protocol())
+        .def_buffer(
+            [](const fwdpy11::double_array_proxy& self) { return as_buffer(self); });
+
+    py::class_<fwdpy11::uint32_array_proxy>(m, "_Uint32ArrayProxy",
+                                            py::buffer_protocol())
+        .def_buffer(
+            [](const fwdpy11::uint32_array_proxy& self) { return as_buffer(self); });
+}

--- a/fwdpy11/src/evolve_population/diploid_pop_fitness.cc
+++ b/fwdpy11/src/evolve_population/diploid_pop_fitness.cc
@@ -14,8 +14,12 @@ calculate_diploid_fitness(
     for (std::size_t i = 0; i < offspring_metadata.size(); ++i)
         {
             auto idx = deme_to_gvalue_map[offspring_metadata[i].deme];
-            gvalue_pointers[idx]->operator()(rng, offspring_metadata[i].label, pop,
-                                             offspring_metadata[i]);
+            //gvalue_pointers[idx]->operator()(rng, offspring_metadata[i].label, pop,
+            //                                 offspring_metadata[i]);
+            gvalue_pointers[idx]->operator()(fwdpy11::DiploidGeneticValueData(
+                rng, pop, pop.diploid_metadata[offspring_metadata[i].parents[0]],
+                pop.diploid_metadata[offspring_metadata[i].parents[1]], i,
+                offspring_metadata[i]));
             if (update_genotype_matrix == true)
                 {
                     new_diploid_gvalues.insert(end(new_diploid_gvalues),
@@ -45,7 +49,10 @@ calculate_diploid_fitness_genomes(
     double sum_parental_fitnesses = 0.0;
     for (std::size_t i = 0; i < pop.diploids.size(); ++i)
         {
-            genetic_value_fxn(rng, i, pop, offspring_metadata[i]);
+            genetic_value_fxn(fwdpy11::DiploidGeneticValueData(
+                rng, pop, pop.diploid_metadata[offspring_metadata[i].parents[0]],
+                pop.diploid_metadata[offspring_metadata[i].parents[1]], i,
+                offspring_metadata[i]));
             parental_fitnesses[i] = offspring_metadata[i].w;
             sum_parental_fitnesses += parental_fitnesses[i];
         }

--- a/fwdpy11/src/evolve_population/no_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/no_tree_sequences.cc
@@ -171,12 +171,12 @@ evolve_without_tree_sequences(
             handle_fixations(remove_selected_fixations, N_next, pop);
 
             pop.diploids.swap(offspring);
+            // TODO: deal with random effects
+            genetic_value_fxn.update(pop);
             lookup = calculate_diploid_fitness_genomes(
                 rng, pop, genetic_value_fxn, offspring_metadata);
             pop.diploid_metadata.swap(offspring_metadata);
             pop.N = N_next;
-            // TODO: deal with random effects
-            genetic_value_fxn.update(pop);
             recorder(pop); // The user may now analyze the pop'n
         }
 }

--- a/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
@@ -11,11 +11,9 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     GaussianNoise(const double s, const double m) : sd{ s }, mean{ m } {}
 
     double
-    operator()(const fwdpy11::GSLrng_t& rng,
-               const fwdpy11::DiploidMetadata& /*offspring_metadata*/,
-               const fwdpy11::DiploidPopulation& /*pop*/) const override
+    operator()(const fwdpy11::DiploidGeneticValueNoiseData data) const override
     {
-        return mean + gsl_ran_gaussian_ziggurat(rng.get(), sd);
+        return mean + gsl_ran_gaussian_ziggurat(data.rng.get().get(), sd);
     }
 
     void

--- a/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GeneticValueNoise.cc
@@ -30,15 +30,13 @@ class GeneticValueNoiseTrampoline : public fwdpy11::GeneticValueNoise
     }
 
     double
-    operator()(const fwdpy11::GSLrng_t& rng,
-               const fwdpy11::DiploidMetadata& offspring_metadata,
-               const fwdpy11::DiploidPopulation& pop) const override
+    operator()(const fwdpy11::DiploidGeneticValueNoiseData input_data) const override
     {
-        data.offspring_copy = offspring_metadata;
-        data.parent1_copy = pop.diploid_metadata[offspring_metadata.parents[0]];
-        data.parent2_copy = pop.diploid_metadata[offspring_metadata.parents[1]];
+        data.offspring_copy = input_data.offspring_metadata.get();
+        data.parent1_copy = input_data.parent1_metadata.get();
+        data.parent2_copy = input_data.parent2_metadata.get();
         PYBIND11_OVERLOAD_PURE_NAME(double, fwdpy11::GeneticValueNoise,
-                                    "__call__", operator(), rng, pydata);
+                                    "__call__", operator(), input_data.rng.get(), pydata);
     }
 
     void

--- a/fwdpy11/src/genetic_value_to_fitness/GeneticValueIsTrait.cc
+++ b/fwdpy11/src/genetic_value_to_fitness/GeneticValueIsTrait.cc
@@ -1,35 +1,13 @@
 #include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
+#include <fwdpy11/util/array_proxy.hpp>
 #include <fwdpy11/numpy/array.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
+#include "GeneticValueIsTraitData.hpp"
 
 namespace py = pybind11;
 
-struct genetic_values_buffer_proxy
-{
-    double* data;
-    std::size_t size;
-    genetic_values_buffer_proxy() : data{nullptr}, size{0}
-    {
-    }
-};
-
-struct GeneticValueIsTraitData
-{
-    fwdpy11::DiploidMetadata offspring_metadata_copy;
-    py::object offspring_metadata;
-    genetic_values_buffer_proxy buffer;
-    py::object genetic_values;
-
-    GeneticValueIsTraitData()
-        : offspring_metadata_copy{},
-          offspring_metadata{
-              py::cast<fwdpy11::DiploidMetadata*>(&offspring_metadata_copy)},
-          buffer{}, genetic_values{py::cast<genetic_values_buffer_proxy*>(&buffer)}
-    {
-    }
-};
 
 class GeneticValueIsTraitTrampoline : public fwdpy11::GeneticValueIsTrait
 // Trampoline class allowing custom
@@ -48,12 +26,11 @@ class GeneticValueIsTraitTrampoline : public fwdpy11::GeneticValueIsTrait
     }
 
     double
-    operator()(const fwdpy11::DiploidMetadata& metadata,
-               const std::vector<double>& genetic_values) const override
+    operator()(const fwdpy11::DiploidGeneticValueToFitnessData input_data) const override
     {
-        data.offspring_metadata_copy = metadata;
-        data.buffer.data = const_cast<double*>(genetic_values.data());
-        data.buffer.size = genetic_values.size();
+        data.offspring_metadata_copy = input_data.offspring_metadata.get();
+        data.buffer.data = const_cast<double*>(input_data.gvalues.get().data());
+        data.buffer.size = input_data.gvalues.get().size();
         PYBIND11_OVERLOAD_PURE_NAME(double, fwdpy11::GeneticValueIsTrait,
                                     "__call__", operator(), pydata);
     }
@@ -86,15 +63,6 @@ init_GeneticValueIsTrait(py::module& m)
         "ABC for functions mapping genetic values representing traits to "
         "fitness.")
         .def(py::init<std::size_t>(), py::arg("ndim") = 1);
-
-    py::class_<genetic_values_buffer_proxy>(m, "_GeneticValuesBufferProxy",
-                                            py::buffer_protocol())
-        .def_buffer([](const genetic_values_buffer_proxy& self) {
-            return py::buffer_info(self.data, sizeof(double),
-                                   py::format_descriptor<double>::format(), 1,
-                                   {self.size}, {sizeof(double)}
-                                   );
-        });
 
     py::class_<GeneticValueIsTraitData>(m, "PyGeneticValueIsTraitData")
         .def_readonly("offspring_metadata", &GeneticValueIsTraitData::offspring_metadata)

--- a/fwdpy11/src/genetic_value_to_fitness/GeneticValueIsTraitData.hpp
+++ b/fwdpy11/src/genetic_value_to_fitness/GeneticValueIsTraitData.hpp
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef FWPY11_GENETIC_VALUE_IS_TRAIT_DATA_HPP
+#define FWPY11_GENETIC_VALUE_IS_TRAIT_DATA_HPP
+
+#include <fwdpy11/util/array_proxy.hpp>
+#include <fwdpy11/types/Diploid.hpp>
+#include <pybind11/pybind11.h>
+
+using genetic_values_buffer_proxy = fwdpy11::double_array_proxy;
+
+struct GeneticValueIsTraitData
+{
+    fwdpy11::DiploidMetadata offspring_metadata_copy;
+    pybind11::object offspring_metadata;
+    genetic_values_buffer_proxy buffer;
+    pybind11::object genetic_values;
+
+    GeneticValueIsTraitData()
+        : offspring_metadata_copy{},
+          offspring_metadata{
+              pybind11::cast<fwdpy11::DiploidMetadata*>(&offspring_metadata_copy)},
+          buffer{}, genetic_values{pybind11::cast<genetic_values_buffer_proxy*>(&buffer)}
+    {
+    }
+};
+
+#endif

--- a/fwdpy11/src/genetic_values/DiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/DiploidGeneticValue.cc
@@ -11,38 +11,6 @@ init_DiploidGeneticValue(py::module& m)
         m, "DiploidGeneticValue",
         "ABC for genetic value calculations for diploid members of "
         ":class:`fwdpy11.DiploidPopulation`")
-        .def(
-            "__call__",
-            [](const fwdpy11::DiploidGeneticValue& gv, const std::size_t diploid_index,
-               const fwdpy11::DiploidPopulation& pop) {
-                return std::numeric_limits<double>::quiet_NaN();
-                //return gv.calculate_gvalue(pop.diploid_metadata[diploid_index].label,
-                //                           pop.diploid_metadata[diploid_index], pop);
-            },
-            R"delim(
-             :param diploid_index: The index of the individual to calculate.
-             :type diploid_index: int >= 0
-             :param pop: The population object containing the individual.
-             :type pop: :class:`fwdpy11.DiploidPopulation`
-             :return: The genetic value of an individual.
-             :rtype: float
-             )delim",
-            py::arg("diploid_index"), py::arg("pop"))
-        .def(
-            "fitness",
-            [](const fwdpy11::DiploidGeneticValue& gv, const std::size_t diploid_index,
-               const fwdpy11::DiploidPopulation& pop) {
-                return gv.genetic_value_to_fitness(pop.diploid_metadata[diploid_index]);
-            },
-            R"delim(
-        :param diploid_index: The index of the individual
-        :type diploid_index: int >= 0
-        :param pop: The population containing the individual
-        :type pop: :class:`fwdpy11.DiploidPopulation`
-        :return: The fitness of an individual.
-        :rtype: float
-        )delim",
-            py::arg("diploid_index"), py::arg("pop"))
         .def_property_readonly(
             "shape",
             [](const fwdpy11::DiploidGeneticValue& self) { return self.shape(); },

--- a/fwdpy11/src/genetic_values/DiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/DiploidGeneticValue.cc
@@ -15,8 +15,9 @@ init_DiploidGeneticValue(py::module& m)
             "__call__",
             [](const fwdpy11::DiploidGeneticValue& gv, const std::size_t diploid_index,
                const fwdpy11::DiploidPopulation& pop) {
-                return gv.calculate_gvalue(pop.diploid_metadata[diploid_index].label,
-                                           pop.diploid_metadata[diploid_index], pop);
+                return std::numeric_limits<double>::quiet_NaN();
+                //return gv.calculate_gvalue(pop.diploid_metadata[diploid_index].label,
+                //                           pop.diploid_metadata[diploid_index], pop);
             },
             R"delim(
              :param diploid_index: The index of the individual to calculate.

--- a/fwdpy11/src/genetic_values/GBR.cc
+++ b/fwdpy11/src/genetic_values/GBR.cc
@@ -89,12 +89,12 @@ namespace
         }
 
         double
-        calculate_gvalue(const std::size_t diploid_index,
-                         const fwdpy11::DiploidMetadata& /*metadata*/,
-                         const fwdpy11::DiploidPopulation& pop) const override
+        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
         {
-            deme = pop.diploid_metadata[diploid_index].deme;
-            gvalues[0] = f(diploid_index, pop);
+            deme = data.pop.get()
+                       .diploid_metadata[data.offspring_metadata.get().label]
+                       .deme;
+            gvalues[0] = f(data.offspring_metadata.get().label, data.pop.get());
             return gvalues[0];
         }
     };

--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -183,19 +183,29 @@ class PyDiploidGeneticValueTrampoline : public PyDiploidGeneticValue
     }
 
     double
-    calculate_gvalue(const std::size_t diploid_index,
-                     const fwdpy11::DiploidMetadata& diploid_metadata,
-                     const fwdpy11::DiploidPopulation& pop) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData input_data) const override
     {
-        data.metadata_proxy = diploid_metadata;
-        data.parent1_metadata_proxy = pop.diploid_metadata[diploid_metadata.parents[0]];
-        data.parent2_metadata_proxy = pop.diploid_metadata[diploid_metadata.parents[1]];
+        data.metadata_proxy = input_data.offspring_metadata.get();
+        data.parent1_metadata_proxy
+            = input_data.pop.get()
+                  .diploid_metadata[input_data.offspring_metadata.get().parents[0]];
+        data.parent2_metadata_proxy
+            = input_data.pop.get()
+                  .diploid_metadata[input_data.offspring_metadata.get().parents[1]];
         data.genome1_data.set_data(
-            pop.haploid_genomes[pop.diploids[diploid_index].first].smutations,
-            pop.mutations);
+            input_data.pop.get()
+                .haploid_genomes[input_data.pop.get()
+                                     .diploids[input_data.offspring_metadata.get().label]
+                                     .first]
+                .smutations,
+            input_data.pop.get().mutations);
         data.genome2_data.set_data(
-            pop.haploid_genomes[pop.diploids[diploid_index].second].smutations,
-            pop.mutations);
+            input_data.pop.get()
+                .haploid_genomes[input_data.pop.get()
+                                     .diploids[input_data.offspring_metadata.get().label]
+                                     .second]
+                .smutations,
+            input_data.pop.get().mutations);
         data.gvalues_proxy.data = gvalues.data();
         data.gvalues_proxy.size = gvalues.size();
         PYBIND11_OVERLOAD_PURE(double, PyDiploidGeneticValue, calculate_gvalue, data);

--- a/tests/custom_additive.cc
+++ b/tests/custom_additive.cc
@@ -5,21 +5,21 @@
 
 struct additive : public fwdpy11::DiploidGeneticValue
 {
-    additive() : fwdpy11::DiploidGeneticValue(1) {}
+    additive() : fwdpy11::DiploidGeneticValue(1)
+    {
+    }
 
     double
-    calculate_gvalue(const std::size_t diploid_index,
-                     const fwdpy11::DiploidMetadata& /*metadata*/,
-                     const fwdpy11::DiploidPopulation& pop) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
     {
+        const auto& pop = data.pop.get();
+        const auto diploid_index = data.offspring_metadata.get().label;
         double sum = 0;
-        for (auto m :
-             pop.haploid_genomes[pop.diploids[diploid_index].first].smutations)
+        for (auto m : pop.haploid_genomes[pop.diploids[diploid_index].first].smutations)
             {
                 sum += pop.mutations[m].s;
             }
-        for (auto m : pop.haploid_genomes[pop.diploids[diploid_index].second]
-                          .smutations)
+        for (auto m : pop.haploid_genomes[pop.diploids[diploid_index].second].smutations)
             {
                 sum += pop.mutations[m].s;
             }

--- a/tests/custom_stateless_genotype.cc
+++ b/tests/custom_stateless_genotype.cc
@@ -8,23 +8,20 @@ struct GeneralW : public fwdpy11::DiploidGeneticValue
 {
     fwdpp::site_dependent_genetic_value w;
 
-    GeneralW() : fwdpy11::DiploidGeneticValue{ 1 }, w{} {}
+    GeneralW() : fwdpy11::DiploidGeneticValue{1}, w{}
+    {
+    }
 
     inline double
-    calculate_gvalue(const std::size_t diploid_index,
-                     const fwdpy11::DiploidMetadata& /*metadata*/,
-                     const fwdpy11::DiploidPopulation& pop) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
     {
-        gvalues[0]
-            = std::max(0.0, w(
-                                pop.diploids[diploid_index],
-                                pop.haploid_genomes, pop.mutations,
-                                [](double& g, const fwdpy11::Mutation& m) {
-                                    g *= (1.0 + m.s);
-                                },
-                                [](double& g, const fwdpy11::Mutation& m) {
-                                    g *= (1.0 + m.h);
-                                }, 1.0));
+        gvalues[0] = std::max(
+            0.0,
+            w(
+                data.pop.get().diploids[data.offspring_metadata.get().label],
+                data.pop.get().haploid_genomes, data.pop.get().mutations,
+                [](double& g, const fwdpy11::Mutation& m) { g *= (1.0 + m.s); },
+                [](double& g, const fwdpy11::Mutation& m) { g *= (1.0 + m.h); }, 1.0));
         return gvalues[0];
     }
 

--- a/tests/inherit_noise.cc
+++ b/tests/inherit_noise.cc
@@ -22,17 +22,20 @@
 
 struct IneritedNoise : public fwdpy11::GeneticValueNoise
 {
+    std::uint32_t generation;
+
+    IneritedNoise() : GeneticValueNoise{}, generation{} {}
+
     double
-    operator()(const fwdpy11::GSLrng_t& /*rng*/,
-               const fwdpy11::DiploidMetadata& offspring_metadata,
-               const fwdpy11::DiploidPopulation& pop) const override
+    operator()(const fwdpy11::DiploidGeneticValueNoiseData data) const override
     {
-        return pop.diploid_metadata[offspring_metadata.parents[0]].e + pop.generation;
+        return data.parent1_metadata.get().e + generation;
     }
 
     void
-    update(const fwdpy11::DiploidPopulation& /*pop*/) override
+    update(const fwdpy11::DiploidPopulation& pop) override
     {
+        generation = pop.generation;
     }
 
     std::shared_ptr<fwdpy11::GeneticValueNoise>

--- a/tests/ll_snowdrift.cc
+++ b/tests/ll_snowdrift.cc
@@ -65,17 +65,18 @@ struct snowdrift : public fwdpy11::DiploidGeneticValue
     }
 
     double
-    genetic_value_to_fitness(const fwdpy11::DiploidMetadata &metadata) const override
+    genetic_value_to_fitness(
+        const fwdpy11::DiploidGeneticValueToFitnessData data) const override
     // This function converts genetic value to fitness.
     {
         double fitness = 0.0;
-        double zself = metadata.g;
+        double zself = data.offspring_metadata.get().g;
         auto N = phenotypes.size();
         for (std::size_t j = 0; j < N; ++j)
             {
                 // A record of which diploid we are
                 // processesing is the label field of the meta data.
-                if (metadata.label != j)
+                if (data.offspring_metadata.get().label != j)
                     {
                         double zpair = zself + phenotypes[j];
                         // Payoff function from Fig 1

--- a/tests/ll_snowdrift.cc
+++ b/tests/ll_snowdrift.cc
@@ -39,8 +39,8 @@ struct snowdrift : public fwdpy11::DiploidGeneticValue
 
     // This constructor is exposed to Python
     snowdrift(double b1_, double b2_, double c1_, double c2_)
-        : fwdpy11::DiploidGeneticValue{ 1 }, b1(b1_), b2(b2_), c1(c1_),
-          c2(c2_), phenotypes()
+        : fwdpy11::DiploidGeneticValue{1}, b1(b1_), b2(b2_), c1(c1_), c2(c2_),
+          phenotypes()
     {
     }
 
@@ -51,24 +51,21 @@ struct snowdrift : public fwdpy11::DiploidGeneticValue
     //initialize the phenotypes w/o extra copies.
     template <typename T>
     snowdrift(double b1_, double b2_, double c1_, double c2_, T &&p)
-        : fwdpy11::DiploidGeneticValue{ 1 }, b1(b1_), b2(b2_), c1(c1_),
-          c2(c2_), phenotypes(std::forward<T>(p))
+        : fwdpy11::DiploidGeneticValue{1}, b1(b1_), b2(b2_), c1(c1_), c2(c2_),
+          phenotypes(std::forward<T>(p))
     {
     }
 
     double
-    calculate_gvalue(const std::size_t diploid_index,
-                     const fwdpy11::DiploidMetadata& /*metadata*/,
-                     const fwdpy11::DiploidPopulation& /*pop*/) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
     // The call operator must return the genetic value of an individual
     {
-        gvalues[0] = phenotypes[diploid_index];
+        gvalues[0] = phenotypes[data.offspring_metadata.get().label];
         return gvalues[0];
     }
 
     double
-    genetic_value_to_fitness(
-        const fwdpy11::DiploidMetadata &metadata) const override
+    genetic_value_to_fitness(const fwdpy11::DiploidMetadata &metadata) const override
     // This function converts genetic value to fitness.
     {
         double fitness = 0.0;
@@ -120,7 +117,7 @@ PYBIND11_MODULE(ll_snowdrift, m)
 
     // Create a Python class based on our new type
     py::class_<snowdrift, fwdpy11::DiploidGeneticValue>(m, "_ll_DiploidSnowdrift")
-        .def(py::init<double, double, double, double>(), py::arg("b1"),
-             py::arg("b2"), py::arg("c1"), py::arg("c2"))
+        .def(py::init<double, double, double, double>(), py::arg("b1"), py::arg("b2"),
+             py::arg("c1"), py::arg("c2"))
         .def_readwrite("phenotypes", &snowdrift::phenotypes);
 }

--- a/tests/pyadditivegss.py
+++ b/tests/pyadditivegss.py
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2017-2020 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import math
+
+import fwdpy11
+
+
+class PyAdditiveGSS(fwdpy11.PyDiploidGeneticValue):
+    def __init__(self, opt, VS):
+        self.opt = opt
+        self.VS = VS
+        fwdpy11.PyDiploidGeneticValue.__init__(self, 1, None, None, False)
+
+    def genetic_value_to_fitness(self, data):
+        return math.e ** (
+            -((data.offspring_metadata.g + data.offspring_metadata.e - self.opt) ** 2)
+            / (2 * self.VS)
+        )
+
+    def calculate_gvalue(self, data):
+        s = 0.0
+        for g in data.genomes:
+            v = memoryview(g.effect_sizes)
+            for i in v:
+                s += i
+        memoryview(data.gvalues)[0] = s
+        return s

--- a/tests/test_genetic_values.py
+++ b/tests/test_genetic_values.py
@@ -164,28 +164,5 @@ class testGSS(unittest.TestCase):
         self.assertEqual(self.x.VS, 1.0)
 
 
-class testGSSandGSSmoConsistency(unittest.TestCase):
-    """
-    This tests that GSS and GSSmo have opt and VS
-    in the same order.  If that were not true,
-    fitness calculations would come out differently
-    and the test would fail.
-    """
-
-    @classmethod
-    def setUp(self):
-        self.a = fwdpy11.Additive(2.0, fwdpy11.GSS(0.0, 1.0))
-        self.b = fwdpy11.Additive(
-            2.0, fwdpy11.GSSmo([fwdpy11.Optimum(when=0, optimum=0.0, VS=1.0)])
-        )
-        self.pop = fwdpy11.DiploidPopulation(1000)
-
-    def testFitnesses(self):
-        wa = [self.a.fitness(i, self.pop) for i in range(self.pop.N)]
-        wb = [self.b.fitness(i, self.pop) for i in range(self.pop.N)]
-        for i, j in zip(wa, wb):
-            self.assertEqual(i, j)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_inherited_noise.py
+++ b/tests/test_inherited_noise.py
@@ -40,13 +40,13 @@ class TestInheritNoise(unittest.TestCase):
         params = fwdpy11.ModelParams(**self.pdict)
         fwdpy11.evolvets(self.rng, self.pop, params, 100)
         self.assertEqual(self.pop.generation, 3)
-        self.assertTrue(all([i.e == 6 for i in self.pop.diploid_metadata]) is True)
+        self.assertTrue(all([i.e == 6.0 for i in self.pop.diploid_metadata]) is True)
 
     def test_noise_values_without_tree_sequences(self):
         params = fwdpy11.ModelParams(**self.pdict)
         fwdpy11.evolve_genomes(self.rng, self.pop, params)
         self.assertEqual(self.pop.generation, 3)
-        self.assertTrue(all([i.e == 6 for i in self.pop.diploid_metadata]) is True)
+        self.assertTrue(all([i.e == 6.0 for i in self.pop.diploid_metadata]) is True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Motivated by #372, this PR creates single argument classes for the C++ back-ends representing genetic value types.  These classes simply hold `std::reference_wrapper` objects referring to simulation data.

- [x] Test runtime performance.  The wrapper classes should be very close to ZCAs.  Performance check on big Tennessen model simulation of a quantitative trait shows zero difference.
- [x] The wrapper classes passed to noise and gv2w need to hold a const reference to offspring metadata
- [x] Move GeneticValueIsTraitData to a separate header file for re-use.
- [x] Move genetic_values_buffer_proxy to a separate header file for re-use.  Should probably start an "array proxies" folder for this b/c it seems very useful.