### PR TITLE
Change "updating" API for DiploidGeneticValue

### DIFF
--- a/doc/pages/advancedtopics.rst
+++ b/doc/pages/advancedtopics.rst
@@ -710,17 +710,9 @@ Method requirements
 :class:`fwdpy11.PyDiploidGeneticValue` *does* provide a default ``update``
 function that updates the genetic-value-to-fitness-map and noise objects.
 
-If you define your own ``update`` function, it needs to have this form:
-
-.. code-block:: python
-
-       def update(self, pop: fwdpy11.DiploidPopulation) -> None:
-           # Update any data for this instance...
-           # ...
-           # ..., then make sure that the
-           # update members are called for the other
-           # objects:
-           self.update_members(pop)
+If your model can allow a no-op ``update`` function, you may apply
+the decorator
+:attr:`fwdpy11.custom_genetic_value_decorators.genetic_value_noise_default_clone`.
 
 The ``calculate_gvalue`` function is more complex because it has more
 responsibilities:

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -89,12 +89,7 @@ namespace fwdpy11
         // Callable from Python
         virtual double calculate_gvalue(const DiploidGeneticValueData data) const = 0;
 
-        virtual void
-        update(const DiploidPopulation& pop)
-        {
-            gv2w->update(pop);
-            noise_fxn->update(pop);
-        }
+        virtual void update(const DiploidPopulation& pop) = 0;
 
         // To be called from w/in a simulation
         virtual void

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
@@ -78,6 +78,11 @@ namespace fwdpy11
                 }
             return gvalues[focal_trait_index];
         }
+
+        void
+        update(const fwdpy11::DiploidPopulation& /*pop*/) override
+        {
+        }
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
@@ -123,6 +123,11 @@ namespace fwdpy11
             return gvalues[0];
         }
 
+        void
+        update(const fwdpy11::DiploidPopulation& /*pop*/) override
+        {
+        }
+
         double
         scaling() const
         {

--- a/fwdpy11/src/evolve_population/no_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/no_tree_sequences.cc
@@ -123,6 +123,8 @@ evolve_without_tree_sequences(
     // so we must call update(...) prior to calculating fitness,
     // else bad stuff like segfaults could happen.
     genetic_value_fxn.update(pop);
+    genetic_value_fxn.gv2w->update(pop);
+    genetic_value_fxn.noise_fxn->update(pop);
     std::vector<fwdpy11::DiploidMetadata> offspring_metadata(
         pop.diploid_metadata);
     auto lookup = calculate_diploid_fitness_genomes(
@@ -173,6 +175,8 @@ evolve_without_tree_sequences(
             pop.diploids.swap(offspring);
             // TODO: deal with random effects
             genetic_value_fxn.update(pop);
+            genetic_value_fxn.gv2w->update(pop);
+            genetic_value_fxn.noise_fxn->update(pop);
             lookup = calculate_diploid_fitness_genomes(
                 rng, pop, genetic_value_fxn, offspring_metadata);
             pop.diploid_metadata.swap(offspring_metadata);

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -270,6 +270,8 @@ evolve_with_tree_sequences(
     for (auto &i : genetics.gvalue)
         {
             i->update(pop);
+            i->gv2w->update(pop);
+            i->noise_fxn->update(pop);
         }
     std::vector<fwdpy11::DiploidMetadata> offspring_metadata(pop.diploid_metadata);
     std::vector<fwdpy11::DiploidGenotype> offspring;
@@ -399,6 +401,8 @@ evolve_with_tree_sequences(
             for (auto &i : genetics.gvalue)
                 {
                     i->update(pop);
+                    i->gv2w->update(pop);
+                    i->noise_fxn->update(pop);
                 }
             pop.diploid_metadata.swap(offspring_metadata);
             calculate_diploid_fitness(rng, pop, genetics.gvalue, deme_to_gvalue_map,

--- a/fwdpy11/src/genetic_values/GBR.cc
+++ b/fwdpy11/src/genetic_values/GBR.cc
@@ -97,6 +97,11 @@ namespace
             gvalues[0] = f(data.offspring_metadata.get().label, data.pop.get());
             return gvalues[0];
         }
+
+        void
+        update(const fwdpy11::DiploidPopulation& /*pop*/) override
+        {
+        }
     };
 }
 

--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -214,9 +214,7 @@ class PyDiploidGeneticValueTrampoline : public PyDiploidGeneticValue
     void
     update(const fwdpy11::DiploidPopulation& pop) override
     {
-        PYBIND11_OVERLOAD(void, PyDiploidGeneticValue, update, pop);
-        gv2w->update(pop);
-        noise_fxn->update(pop);
+        PYBIND11_OVERLOAD_PURE(void, PyDiploidGeneticValue, update, pop);
     }
 };
 
@@ -225,12 +223,7 @@ init_PyDiploidGeneticValue(py::module& m)
 {
     py::class_<PyDiploidGeneticValue, fwdpy11::DiploidGeneticValue,
                PyDiploidGeneticValueTrampoline>(m, "PyDiploidGeneticValue")
-        .def(py::init<std::size_t, py::object, py::object, bool>())
-        .def("update_members",
-             [](PyDiploidGeneticValue& self, const fwdpy11::DiploidPopulation& pop) {
-                 self.gv2w->update(pop);
-                 self.noise_fxn->update(pop);
-             });
+        .def(py::init<std::size_t, py::object, py::object, bool>());
 
     py::class_<PyDiploidGeneticValueData>(m, "PyDiploidGeneticValueData")
         .def_readwrite("offspring_metadata",

--- a/tests/pyadditive.py
+++ b/tests/pyadditive.py
@@ -20,8 +20,10 @@
 import numpy as np
 
 import fwdpy11
+import fwdpy11.custom_genetic_value_decorators
 
 
+@fwdpy11.custom_genetic_value_decorators.default_update
 class PyAdditive(fwdpy11.PyDiploidGeneticValue):
     def __init__(self, gvalue_to_fitness=None, noise=None):
         fwdpy11.PyDiploidGeneticValue.__init__(self, 1, gvalue_to_fitness, noise, False)

--- a/tests/pyadditivegss.py
+++ b/tests/pyadditivegss.py
@@ -20,8 +20,10 @@
 import math
 
 import fwdpy11
+import fwdpy11.custom_genetic_value_decorators
 
 
+@fwdpy11.custom_genetic_value_decorators.default_update
 class PyAdditiveGSS(fwdpy11.PyDiploidGeneticValue):
     def __init__(self, opt, VS):
         self.opt = opt


### PR DESCRIPTION
This PR makes a back-end change so that DiploidGeneticValue::update no longer calls the update function of the two nested dependency classes.  This change makes is simpler to explain how to create custom classes.