### PR TITLE
DiploidGeneticValue member functions are now non-const

### DIFF
--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -52,7 +52,7 @@ namespace fwdpy11
     /// Any deme/geography-specific details must be handled by the derived class.
     {
         std::size_t total_dim;
-        mutable std::vector<double> gvalues;
+        std::vector<double> gvalues;
         /// Classes deriving from this must call gv2w->update
         /// from their own update functions.
         std::shared_ptr<GeneticValueToFitnessMap> gv2w;
@@ -87,13 +87,13 @@ namespace fwdpy11
         DiploidGeneticValue& operator=(const DiploidGeneticValue&) = delete;
 
         // Callable from Python
-        virtual double calculate_gvalue(const DiploidGeneticValueData data) const = 0;
+        virtual double calculate_gvalue(const DiploidGeneticValueData data) = 0;
 
         virtual void update(const DiploidPopulation& pop) = 0;
 
         // To be called from w/in a simulation
         virtual void
-        operator()(DiploidGeneticValueData data) const
+        operator()(DiploidGeneticValueData data) 
         {
             data.offspring_metadata.get().g = calculate_gvalue(data);
             data.offspring_metadata.get().e = noise(DiploidGeneticValueNoiseData(data));
@@ -102,7 +102,7 @@ namespace fwdpy11
         }
 
         virtual double
-        genetic_value_to_fitness(const DiploidGeneticValueToFitnessData data) const
+        genetic_value_to_fitness(const DiploidGeneticValueToFitnessData data) 
         {
             return gv2w->operator()(data);
         }

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultivariateEffectsStrictAdditive.hpp
@@ -41,7 +41,7 @@ namespace fwdpy11
         }
 
         double
-        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
+        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) override
         {
             std::fill(begin(gvalues), end(gvalues), 0.0);
 

--- a/fwdpy11/headers/fwdpy11/genetic_values/dgvalue_pointer_vector.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/dgvalue_pointer_vector.hpp
@@ -38,7 +38,7 @@ namespace fwdpy11
     // to be passed as an argument to a C++ function.
     // Thus, we compromise with raw pointers stored in a vector.
     {
-        const std::vector<fwdpy11::DiploidGeneticValue *> genetic_values;
+        std::vector<fwdpy11::DiploidGeneticValue *> genetic_values;
 
         std::vector<fwdpy11::DiploidGeneticValue *>
         init_from_list(pybind11::list l)

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
@@ -115,7 +115,7 @@ namespace fwdpy11
         }
 
         double
-        calculate_gvalue(const DiploidGeneticValueData data) const override
+        calculate_gvalue(const DiploidGeneticValueData data) override
         {
             gvalues[0] = make_return_value(
                 callback(gv, data.offspring_metadata.get().label,

--- a/fwdpy11/src/evolve_population/diploid_pop_fitness.cc
+++ b/fwdpy11/src/evolve_population/diploid_pop_fitness.cc
@@ -3,7 +3,7 @@
 void
 calculate_diploid_fitness(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
-    const std::vector<fwdpy11::DiploidGeneticValue *> &gvalue_pointers,
+    std::vector<fwdpy11::DiploidGeneticValue *> &gvalue_pointers,
     const std::vector<std::size_t> &deme_to_gvalue_map,
     std::vector<fwdpy11::DiploidMetadata> &offspring_metadata,
     std::vector<double> &new_diploid_gvalues, const bool update_genotype_matrix)
@@ -41,7 +41,7 @@ calculate_diploid_fitness(
 fwdpp::gsl_ran_discrete_t_ptr
 calculate_diploid_fitness_genomes(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
-    const fwdpy11::DiploidGeneticValue &genetic_value_fxn,
+    fwdpy11::DiploidGeneticValue &genetic_value_fxn,
     std::vector<fwdpy11::DiploidMetadata> &offspring_metadata)
 {
     // Calculate parental fitnesses

--- a/fwdpy11/src/evolve_population/diploid_pop_fitness.hpp
+++ b/fwdpy11/src/evolve_population/diploid_pop_fitness.hpp
@@ -7,21 +7,20 @@
 
 // Changed in 0.6.0 to return void, as sims w/tree
 // sequences generate fitness lookups via DiscreteDemography
-void calculate_diploid_fitness(
-    const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
-    const std::vector<fwdpy11::DiploidGeneticValue *>
-        &gvalue_pointers,
-    const std::vector<std::size_t> &deme_to_gvalue_map,
-    std::vector<fwdpy11::DiploidMetadata> &offspring_metadata,
-    std::vector<double> &new_diploid_gvalues,
-    const bool update_genotype_matrix);
+void
+calculate_diploid_fitness(const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
+                          std::vector<fwdpy11::DiploidGeneticValue *> &gvalue_pointers,
+                          const std::vector<std::size_t> &deme_to_gvalue_map,
+                          std::vector<fwdpy11::DiploidMetadata> &offspring_metadata,
+                          std::vector<double> &new_diploid_gvalues,
+                          const bool update_genotype_matrix);
 
 // This overload was added in 0.6.0 as a temporary
 // hack b/c sims with tree sequences generate fitness
 // lookups via DiscreteDemography
 fwdpp::gsl_ran_discrete_t_ptr calculate_diploid_fitness_genomes(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
-    const fwdpy11::DiploidGeneticValue &genetic_value_fxn,
+    fwdpy11::DiploidGeneticValue &genetic_value_fxn,
     std::vector<fwdpy11::DiploidMetadata> &offspring_metadata);
 
 #endif

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -164,7 +164,7 @@ evolve_with_tree_sequences(
     // NOTE: gvalue_pointers is a change in 0.6.0,
     // and the object holds non-const bare pointers
     // to objects owned by Python.
-    const fwdpy11::dgvalue_pointer_vector_ &gvalue_pointers,
+    fwdpy11::dgvalue_pointer_vector_ &gvalue_pointers,
     fwdpy11::DiploidPopulation_sample_recorder recorder,
     std::function<bool(const fwdpy11::DiploidPopulation &, const bool)>
         &stopping_criteron,

--- a/fwdpy11/src/genetic_values/GBR.cc
+++ b/fwdpy11/src/genetic_values/GBR.cc
@@ -89,7 +89,7 @@ namespace
         }
 
         double
-        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
+        calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) override
         {
             deme = data.pop.get()
                        .diploid_metadata[data.offspring_metadata.get().label]

--- a/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
+++ b/fwdpy11/src/genetic_values/PyDiploidGeneticValue.cc
@@ -162,7 +162,7 @@ class PyDiploidGeneticValueTrampoline : public PyDiploidGeneticValue
     }
 
     double
-    calculate_gvalue(const fwdpy11::DiploidGeneticValueData input_data) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData input_data) override
     {
         data.metadata_proxy = input_data.offspring_metadata.get();
         data.parent1_metadata_proxy
@@ -192,7 +192,7 @@ class PyDiploidGeneticValueTrampoline : public PyDiploidGeneticValue
 
     double
     genetic_value_to_fitness(
-        const fwdpy11::DiploidGeneticValueToFitnessData input_data) const override
+        const fwdpy11::DiploidGeneticValueToFitnessData input_data) override
     // NOTE: see https://pybind11.readthedocs.io/en/stable/advanced/classes.html#extended-trampoline-class-functionality
     {
         pybind11::gil_scoped_acquire gil; // Acquire the GIL while in this scope.

--- a/tests/custom_additive.cc
+++ b/tests/custom_additive.cc
@@ -10,7 +10,7 @@ struct additive : public fwdpy11::DiploidGeneticValue
     }
 
     double
-    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) override
     {
         const auto& pop = data.pop.get();
         const auto diploid_index = data.offspring_metadata.get().label;

--- a/tests/custom_stateless_genotype.cc
+++ b/tests/custom_stateless_genotype.cc
@@ -13,7 +13,7 @@ struct GeneralW : public fwdpy11::DiploidGeneticValue
     }
 
     inline double
-    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) override
     {
         gvalues[0] = std::max(
             0.0,

--- a/tests/ll_snowdrift.cc
+++ b/tests/ll_snowdrift.cc
@@ -53,7 +53,7 @@ struct snowdrift : public fwdpy11::DiploidGeneticValue
     }
 
     double
-    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) const override
+    calculate_gvalue(const fwdpy11::DiploidGeneticValueData data) override
     // The call operator must return the genetic value of an individual
     {
         gvalues[0] = phenotypes[data.metadata_index];
@@ -62,7 +62,7 @@ struct snowdrift : public fwdpy11::DiploidGeneticValue
 
     double
     genetic_value_to_fitness(
-        const fwdpy11::DiploidGeneticValueToFitnessData data) const override
+        const fwdpy11::DiploidGeneticValueToFitnessData data) override
     // This function converts genetic value to fitness.
     {
         double zself = data.offspring_metadata.get().g;


### PR DESCRIPTION
This change allows us to get rid of the mutable hack for DiploidGeneticValue::gvalues.