### PR TITLE
Mark Python classes inheriting from C++ classes as "final". Closes #573.

### DIFF
--- a/fwdpy11/discrete_demography.py
+++ b/fwdpy11/discrete_demography.py
@@ -31,6 +31,7 @@ from .class_decorators import (attr_add_asblack, attr_class_pickle_with_super,
 _common_attr_attribs = {"frozen": True, "auto_attribs": True, "repr_ns": "fwdpy11"}
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -142,6 +143,7 @@ def copy_individuals(
     return MassMigration(when, source, destination, fraction, False, resets_growth_rate)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -183,6 +185,7 @@ class SetDemeSize(fwdpy11._fwdpy11._ll_SetDemeSize):
         )
 
 
+@typing.final
 @attr_class_to_from_dict
 @attr_add_asblack
 @attr_class_pickle_with_super
@@ -218,6 +221,7 @@ class SetExponentialGrowth(fwdpy11._fwdpy11._ll_SetExponentialGrowth):
         super(SetExponentialGrowth, self).__init__(self.when, self.deme, self.G)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -260,6 +264,7 @@ class SetSelfingRate(fwdpy11._fwdpy11._ll_SetSelfingRate):
         super(SetSelfingRate, self).__init__(**d)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -312,6 +317,7 @@ def _set_migration_rates_convert_deme(i: typing.Optional[int]) -> int:
     return int(i)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_to_from_dict
 @attr.s(eq=False, **_common_attr_attribs)
@@ -425,6 +431,7 @@ def _convert_migmatrix(o):
     return MigrationMatrix(o)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)

--- a/fwdpy11/genetic_map_unit.py
+++ b/fwdpy11/genetic_map_unit.py
@@ -17,6 +17,8 @@
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import typing
+
 import attr
 import numpy as np
 
@@ -28,6 +30,7 @@ from .class_decorators import (attr_add_asblack, attr_class_pickle_with_super,
 _common_attr_attribs = {"frozen": True, "auto_attribs": True, "repr_ns": "fwdpy11"}
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -71,6 +74,7 @@ class PoissonInterval(fwdpy11._fwdpy11._ll_PoissonInterval):
         super(PoissonInterval, self).__init__(self.beg, self.end, self.mean)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -119,6 +123,7 @@ class PoissonPoint(fwdpy11._fwdpy11._ll_PoissonPoint):
         super(PoissonPoint, self).__init__(**d)
 
 
+@typing.final
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
 @attr.s(**_common_attr_attribs)
@@ -157,6 +162,7 @@ class BinomialInterval(fwdpy11._fwdpy11._ll_BinomialInterval):
         super(BinomialInterval, self).__init__(self.beg, self.end, self.probability)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -199,6 +205,7 @@ class BinomialPoint(fwdpy11._fwdpy11._ll_BinomialPoint):
         super(BinomialPoint, self).__init__(self.position, self.probability)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict

--- a/fwdpy11/genetic_values.py
+++ b/fwdpy11/genetic_values.py
@@ -31,6 +31,7 @@ from .class_decorators import (attr_add_asblack, attr_class_pickle_with_super,
 _common_attr_attribs = {"frozen": True, "auto_attribs": True, "repr_ns": "fwdpy11"}
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -78,6 +79,7 @@ class Optimum(fwdpy11._fwdpy11._ll_Optimum):
         super(Optimum, self).__init__(self.optimum, self.VS, self.when)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -134,6 +136,7 @@ class PleiotropicOptima(fwdpy11._fwdpy11._ll_PleiotropicOptima):
         return optima_equal and VS_equal and when_equal
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
@@ -193,6 +196,7 @@ class GSS(fwdpy11._fwdpy11._ll_GSSmo):
             )
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
@@ -235,6 +239,7 @@ class GSSmo(fwdpy11._fwdpy11._ll_GSSmo):
         super(GSSmo, self).__init__(self.optima)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
@@ -301,6 +306,7 @@ class MultivariateGSS(fwdpy11._fwdpy11._ll_MultivariateGSSmo):
         return [PleiotropicOptima(optima=self.optima, VS=self.VS, when=0)]
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
@@ -339,6 +345,7 @@ class MultivariateGSSmo(fwdpy11._fwdpy11._ll_MultivariateGSSmo):
         super(MultivariateGSSmo, self).__init__(self.optima)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -357,6 +364,7 @@ class NoNoise(fwdpy11._fwdpy11._ll_NoNoise):
         super(NoNoise, self).__init__()
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -386,6 +394,7 @@ class GaussianNoise(fwdpy11._fwdpy11._ll_GaussianNoise):
         super(GaussianNoise, self).__init__(self.sd, self.mean)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
@@ -433,6 +442,7 @@ class Additive(fwdpy11._fwdpy11._ll_Additive):
         )
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
@@ -480,6 +490,7 @@ class Multiplicative(fwdpy11._fwdpy11._ll_Multiplicative):
         )
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
@@ -515,6 +526,7 @@ class GBR(fwdpy11._fwdpy11._ll_GBR):
         super(GBR, self).__init__(self.gvalue_to_fitness, self.noise)
 
 
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse

--- a/fwdpy11/regions.py
+++ b/fwdpy11/regions.py
@@ -83,6 +83,7 @@ _common_attr_attribs = {"frozen": True, "auto_attribs": True, "repr_ns": "fwdpy1
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -134,6 +135,7 @@ class Region(fwdpy11._fwdpy11._ll_Region):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -195,6 +197,7 @@ class ConstantS(fwdpy11._fwdpy11._ll_ConstantS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -258,6 +261,7 @@ class ExpS(fwdpy11._fwdpy11._ll_ExpS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -323,6 +327,7 @@ class GammaS(fwdpy11._fwdpy11._ll_GammaS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -384,6 +389,7 @@ class GaussianS(fwdpy11._fwdpy11._ll_GaussianS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -495,6 +501,7 @@ class LogNormalS(fwdpy11._fwdpy11._ll_LogNormalS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -560,6 +567,7 @@ class UniformS(fwdpy11._fwdpy11._ll_UniformS):
 
 
 @_add_deprecated_properties
+@typing.final
 @attr_add_asblack
 @attr_class_pickle_with_super
 @attr_class_to_from_dict
@@ -652,6 +660,7 @@ class MultivariateGaussianEffects(fwdpy11._fwdpy11._ll_MultivariateGaussianEffec
 
 
 @attr_add_asblack
+@typing.final
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
 @attr.s(eq=False, **_common_attr_attribs)


### PR DESCRIPTION
See #573