### PR TITLE
Update metadata handling when exporting to tskit

### DIFF
--- a/doc/pages/advancedtopics.rst
+++ b/doc/pages/advancedtopics.rst
@@ -40,19 +40,16 @@ A common set of idioms used by these examples are:
 Decoding metadata from :class:`tskit.TreeSequence`
 ---------------------------------------------------------------------
 
-`tskit` and `fwdpy11` treat metadata quite differently.  The former is much more general,
-while the latter gives you direct access to the data objects on the C++ side.
-The `tskit` approach is based on binary strings.  What `fwdpy11` does is encode strings that
-can be converted back to Python dictionaries.  For example, here is how one may process the
-individual metadata after dumping the tables to `tskit`:
+As of version 0.10.0, we make use of the metadata schema introduced in `tskit` 0.3.2.
+See `here <https://tskit.readthedocs.io/en/latest/tutorial.html#working-with-metadata>`_ for details.
 
 .. code-block:: python
 
    import tskit
 
-   individuals = ts.tables.individuals
-   md = tskit.unpack_bytes(individuals.metadata, individuals.metadata_offset)
-   first_individual = eval(md[0])
+   first_individual = ts.tables.individuals[0].metadata
+
+The data stored in `first_individual` will be a :class:`dict`.
 
 In order to distinguish "alive" from "dead" individuals (*e.g.*, those 
 preserved as ancient samples), we need to make use of flags found in
@@ -94,20 +91,9 @@ The mutation metadata follow the same general recipe:
 
 .. code-block:: python
 
-   mutations = ts.tables.mutations
-   sites = ts.tables.sites
-   md = tskit.unpack_bytes(mutations.metadata, mutations.metadata_offset)
+   first_mutations = ts.tables.mutations[0].metadata
 
-Here, ``md`` is a :class:`dict` whose key names are the same as the attributes of 
-:class`fwdpy11.Mutation`, with one exception. The `tskit` representation
-of the mutation record's the allele's *age* in generations while
-:attr:`fwdpy11.Mutation.g` is the generation when the mutation arose.
-The reason for this discrepancy is because ``fwdpy11`` thinks forward in time
-while ``tskit`` thinks backwards. The conversion to and from is trivial:
-
-.. code-block:: python
-
-   print(f"Origin to age = {pop.generation - m.g + 1}")
+The mutation's data will be represented as a :class:`dict`.
 
 .. _howlongtorun:
 

--- a/fwdpy11/_monkeypatch/_diploid_population.py
+++ b/fwdpy11/_monkeypatch/_diploid_population.py
@@ -146,6 +146,12 @@ def _dump_tables_to_tskit(self, parameters: typing.Optional[typing.Dict] = None)
         The provenance information is validated using
         :func:`tskit.validate_provenance`, which may
         raise an exception.
+
+    .. versionchanged:: 0.10.0
+
+        Use tskit metadata schema.
+        Mutation time is now stored in the tskit.MutationTable column.
+        Origin time of mutations is part of the metadata.
     """
     from fwdpy11 import pybind11_version, gsl_version
 

--- a/fwdpy11/_monkeypatch/_diploid_population.py
+++ b/fwdpy11/_monkeypatch/_diploid_population.py
@@ -18,11 +18,13 @@
 #
 
 import json
+import typing
+
+import numpy as np
+import tskit
 
 import fwdpy11.tskit_tools
 import fwdpy11.tskit_tools.metadata_schema
-import numpy as np
-import tskit
 
 
 def _alive_nodes(self):
@@ -127,7 +129,7 @@ def _initializeIndividualTable(self, tc):
     return individal_nodes
 
 
-def _dump_tables_to_tskit(self, parameters=None):
+def _dump_tables_to_tskit(self, parameters: typing.Optional[typing.Dict] = None):
     """
     Dump the population's TableCollection into
     an tskit TreeSequence

--- a/fwdpy11/_monkeypatch/_diploid_population.py
+++ b/fwdpy11/_monkeypatch/_diploid_population.py
@@ -98,13 +98,11 @@ def _generate_mutation_metadata(self):
 
 
 def _initializePopulationTable(node_view, tc):
-    population_metadata = []
+    tc.populations.metadata_schema = (
+        fwdpy11.tskit_tools.metadata_schema.PopulationMetadata
+    )
     for i in sorted(np.unique(node_view["deme"])):
-        md = "deme" + str(i)
-        population_metadata.append(md.encode("utf-8"))
-
-    pmd, pmdo = tskit.pack_bytes(population_metadata)
-    tc.populations.set_columns(metadata=pmd, metadata_offset=pmdo)
+        tc.populations.add_row(metadata={"name": "deme" + str(i)})
 
 
 def _initializeIndividualTable(self, tc):

--- a/fwdpy11/tskit_tools/metadata_schema.py
+++ b/fwdpy11/tskit_tools/metadata_schema.py
@@ -19,8 +19,9 @@
 import copy
 import typing
 
-import fwdpy11
 import tskit
+
+import fwdpy11
 
 IndividualDiploidMetadata = tskit.metadata.MetadataSchema(
     {
@@ -60,6 +61,14 @@ PopulationMetadata = tskit.metadata.MetadataSchema(
         "properties": {"name": {"type": "string"}},
     }
 )
+
+# NOTE: we could use JSON schema here and
+# have the array fields not included in "required".
+# However:
+# 1. That is much slower.
+# 2. This metadata contains floating point values.
+#    We don't want to lose precision in case anyone
+#    wants to try to recalculate diploid phenotypes/fitnesses
 
 MutationMetadata = tskit.metadata.MetadataSchema(
     {

--- a/fwdpy11/tskit_tools/metadata_schema.py
+++ b/fwdpy11/tskit_tools/metadata_schema.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2020 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+import typing
+
+import fwdpy11
+import tskit
+
+IndividualDiploidMetadata = tskit.metadata.MetadataSchema(
+    {
+        "codec": "struct",
+        "type": "object",
+        "properties": {
+            "g": {"type": "number", "binaryFormat": "d"},
+            "e": {"type": "number", "binaryFormat": "d"},
+            "w": {"type": "number", "binaryFormat": "d"},
+            "sex": {"type": "number", "binaryFormat": "i"},
+            "deme": {"type": "number", "binaryFormat": "i"},
+            "label": {"type": "number", "binaryFormat": "Q"},
+            "parents": {
+                "type": "array",
+                "items": {"type": "number", "binaryFormat": "Q"},
+                "arrayLengthFormat": "H",
+            },
+            "geography": {
+                "type": "array",
+                "items": {"type": "number", "binaryFormat": "d"},
+                "arrayLengthFormat": "H",
+            },
+            "nodes": {
+                "type": "array",
+                "items": {"type": "number", "binaryFormat": "i"},
+                "arrayLengthFormat": "H",
+            },
+        },
+    }
+)
+
+
+def generate_individual_metadata(
+    metadata: fwdpy11._fwdpy11.DiploidMetadata,
+) -> typing.Dict:
+    d = {
+        "g": metadata.g,
+        "e": metadata.e,
+        "w": metadata.w,
+        "geography": [i for i in metadata.geography],
+        "parents": [i for i in metadata.parents],
+        "nodes": [i for i in metadata.nodes],
+        "sex": metadata.sex,
+        "deme": metadata.deme,
+        "label": metadata.label,
+    }
+    return d

--- a/fwdpy11/tskit_tools/metadata_schema.py
+++ b/fwdpy11/tskit_tools/metadata_schema.py
@@ -51,6 +51,15 @@ IndividualDiploidMetadata = tskit.metadata.MetadataSchema(
     }
 )
 
+PopulationMetadata = tskit.metadata.MetadataSchema(
+    {
+        "codec": "json",
+        "type": "object",
+        "name": "Population metadata",
+        "properties": {"name": {"type": "string"}},
+    }
+)
+
 
 def generate_individual_metadata(
     metadata: fwdpy11._fwdpy11.DiploidMetadata,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ipython
 matplotlib
 seaborn
 msprime
-tskit==0.2.3
+tskit>=0.3.2
 setuptools_scm==1.11.1
 
 #below are for formatting, linting,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 PYBIND11_MIN_VERSION = "2.4.3"
-TSKIT_MIN_VERSION = "0.2.3"
+TSKIT_MIN_VERSION = "0.3.2"
 
 if sys.version_info[0] < 3:
     raise ValueError("Python 3 is required!")

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -269,36 +269,38 @@ class TestTreeSequencesNoAncientSamplesKeepFixations(unittest.TestCase):
 
         # Now, we make sure that the metadata can
         # be decoded
-        md = tskit.unpack_bytes(
-            dumped_ts.tables.individuals.metadata,
-            dumped_ts.tables.individuals.metadata_offset,
-        )
-        for i, j in zip(self.pop.diploid_metadata, md):
-            d = eval(j)
-            self.assertEqual(i.g, d["g"])
-            self.assertEqual(i.w, d["w"])
-            self.assertEqual(i.e, d["e"])
-            self.assertEqual(i.label, d["label"])
-            self.assertEqual(i.parents, d["parents"])
-            self.assertEqual(i.sex, d["sex"])
-            self.assertEqual(i.deme, d["deme"])
-            self.assertEqual(i.geography, d["geography"])
+        md = []
+        for i, j in enumerate(self.pop.diploid_metadata):
+            d = dumped_ts.tables.individuals[i].metadata
+            md.append(d)
+            self.assertEqual(j.g, d["g"])
+            self.assertEqual(j.w, d["w"])
+            self.assertEqual(j.e, d["e"])
+            self.assertEqual(j.label, d["label"])
+            self.assertEqual(j.sex, d["sex"])
+            self.assertEqual(j.deme, d["deme"])
+            for k, l in zip(j.parents, d["parents"]):
+                self.assertEqual(k, l)
+            for k, l in zip(j.geography, d["geography"]):
+                self.assertEqual(k, l)
 
         # Test that we can go backwards from node table to individuals
         samples = np.where(dumped_ts.tables.nodes.flags == tskit.NODE_IS_SAMPLE)[0]
         self.assertEqual(len(samples), 2 * self.pop.N)
         for i in samples[::2]:
             ind = i // 2
-            d = eval(md[ind])
+            d = md[ind]
             fwdpy11_md = self.pop.diploid_metadata[ind]
             self.assertEqual(fwdpy11_md.g, d["g"])
             self.assertEqual(fwdpy11_md.w, d["w"])
             self.assertEqual(fwdpy11_md.e, d["e"])
             self.assertEqual(fwdpy11_md.label, d["label"])
-            self.assertEqual(fwdpy11_md.parents, d["parents"])
             self.assertEqual(fwdpy11_md.sex, d["sex"])
             self.assertEqual(fwdpy11_md.deme, d["deme"])
-            self.assertEqual(fwdpy11_md.geography, d["geography"])
+            for k, l in zip(fwdpy11_md.parents, d["parents"]):
+                self.assertEqual(k, l)
+            for k, l in zip(fwdpy11_md.geography, d["geography"]):
+                self.assertEqual(k, l)
 
         md = tskit.unpack_bytes(
             dumped_ts.tables.mutations.metadata,

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -302,22 +302,16 @@ class TestTreeSequencesNoAncientSamplesKeepFixations(unittest.TestCase):
             for k, l in zip(fwdpy11_md.geography, d["geography"]):
                 self.assertEqual(k, l)
 
-        md = tskit.unpack_bytes(
-            dumped_ts.tables.mutations.metadata,
-            dumped_ts.tables.mutations.metadata_offset,
-        )
-        for i, j, k in zip(
-            self.pop.tables.mutations, dumped_ts.tables.mutations.site, md
-        ):
-            d = eval(k)
+        for idx in range(len(self.pop.tables.mutations)):
+            i = self.pop.tables.mutations[idx]
+            j = dumped_ts.tables.mutations[idx].site
+            d = dumped_ts.tables.mutations[idx].metadata
             self.assertEqual(i.key, d["key"])
             site = dumped_ts.tables.sites[j]
             m = self.pop.mutations[d["key"]]
             self.assertEqual(site.position, m.pos)
             self.assertEqual(d["s"], m.s)
             self.assertEqual(d["h"], m.h)
-            self.assertTrue(np.array_equal(np.array(d["esizes"]), m.esizes))
-            self.assertTrue(np.array_equal(np.array(d["heffects"]), m.heffects))
             self.assertEqual(d["label"], m.label)
             self.assertEqual(d["neutral"], m.neutral)
 


### PR DESCRIPTION
This PR updates the metadata encoding/decoding to use the new codec-based methods in tskit.

This changes the minimum tskit version to 0.3.2!