### PR TITLE
Add support for variable dominance.

### DIFF
--- a/cpptests/Makefile.am
+++ b/cpptests/Makefile.am
@@ -8,7 +8,8 @@ fwdpy11_cpp_tests_SOURCES=fwdpy11_cpp_tests.cc \
 						  test_lowlevel_discrete_demography_bad_models.cc \
 						  test_lowlevel_discrete_demography_objects.cc \
 						  discrete_demography_roundtrips.cc \
-						  discrete_demography_util.cc
+						  discrete_demography_util.cc \
+						  test_MutationDominance.cc
 
 AM_CPPFLAGS=-I../fwdpy11/headers -I../fwdpy11/headers/fwdpp 
 AM_CXXFLAGS=-W -Wall --coverage -DBOOST_TEST_DYN_LINK

--- a/cpptests/test_MutationDominance.cc
+++ b/cpptests/test_MutationDominance.cc
@@ -1,0 +1,108 @@
+#include <cstdint>
+#include <queue>
+#include <vector>
+#include <unordered_map>
+#include <boost/test/unit_test.hpp>
+#include <gsl/gsl_matrix.h>
+#include <fwdpy11/regions/ExpS.hpp>
+#include <fwdpy11/regions/mvDES.hpp>
+#include <fwdpy11/regions/LogNormalS.hpp>
+#include <fwdpy11/regions/MultivariateGaussianEffects.hpp>
+#include <fwdpp/simfunctions/recycling.hpp>
+#include <fwdpy11/regions/Region.hpp>
+#include <fwdpy11/regions/Sregion.hpp>
+#include <fwdpy11/rng.hpp>
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpy11/regions/MutationDominance.hpp>
+
+BOOST_AUTO_TEST_SUITE(test_MutationDominance)
+
+static fwdpy11::Region
+make_dummy_region()
+{
+    return fwdpy11::Region(0, 1, 1, true, 0);
+}
+
+static auto
+generate_mutation(const fwdpy11::Sregion &s, std::vector<fwdpy11::Mutation> &mutations)
+{
+    fwdpy11::GSLrng_t rng(42);
+    fwdpp::flagged_mutation_queue q(std::queue<std::size_t>{});
+    std::unordered_multimap<double, std::uint32_t> lookup_table;
+    return s(q, mutations, lookup_table, 0, rng);
+}
+
+BOOST_AUTO_TEST_CASE(test_FixedDominance_init_and_clone)
+{
+    fwdpy11::GSLrng_t rng(42);
+    fwdpy11::FixedDominance f(1.0);
+    BOOST_CHECK_EQUAL(f.generate_dominance(rng, 0.2135123), 1.);
+
+    auto fc = f.clone();
+    BOOST_CHECK_EQUAL(fc->generate_dominance(rng, 0.2135123), 1.);
+}
+
+BOOST_AUTO_TEST_CASE(test_FixedDominance_round_trip)
+{
+    fwdpy11::ExpS e(make_dummy_region(), 2, 1., fwdpy11::FixedDominance(0.25));
+    std::vector<fwdpy11::Mutation> mutations;
+    auto x = generate_mutation(e, mutations);
+    BOOST_CHECK_EQUAL(x, 0);
+    BOOST_CHECK_EQUAL(mutations[x].h, 0.25);
+}
+
+BOOST_AUTO_TEST_CASE(test_FixedDominance_round_trip_mvDES_vector_of_Sregion)
+{
+    std::vector<std::unique_ptr<fwdpy11::Sregion>> odist;
+    for (int i = 0; i < 3; ++i)
+        {
+            odist.emplace_back(std::unique_ptr<fwdpy11::Sregion>(new fwdpy11::ExpS(
+                make_dummy_region(), 2, 1., fwdpy11::FixedDominance(i))));
+        }
+    std::vector<double> vcov(9, 0.);
+    gsl_matrix_view vcov_view = gsl_matrix_view_array(vcov.data(), 3, 3);
+    gsl_matrix_set_identity(&vcov_view.matrix);
+    fwdpy11::mvDES mv(odist, std::vector<double>(3, 0.), vcov_view.matrix);
+    std::vector<fwdpy11::Mutation> mutations;
+    auto x = generate_mutation(mv, mutations);
+    BOOST_CHECK_EQUAL(x, 0);
+    for (int i = 0; i < 3; ++i)
+        {
+            BOOST_CHECK_EQUAL(mutations[x].heffects[i], static_cast<double>(i));
+        }
+}
+
+BOOST_AUTO_TEST_CASE(test_FixedDominance_round_trip_mvDES_LogNormalS)
+{
+    fwdpy11::LogNormalS l(make_dummy_region(), 1, fwdpy11::FixedDominance(1. / 8.));
+    std::vector<double> vcov(9, 0.);
+    gsl_matrix_view vcov_view = gsl_matrix_view_array(vcov.data(), 3, 3);
+    gsl_matrix_set_identity(&vcov_view.matrix);
+    fwdpy11::mvDES mv(l, std::vector<double>(3, 0.), vcov_view.matrix);
+    std::vector<fwdpy11::Mutation> mutations;
+    auto x = generate_mutation(mv, mutations);
+    BOOST_CHECK_EQUAL(x, 0);
+    for (int i = 0; i < 3; ++i)
+        {
+            BOOST_CHECK_EQUAL(mutations[x].heffects[i], 1. / 8.);
+        }
+}
+
+BOOST_AUTO_TEST_CASE(test_FixedDominance_round_trip_mvDES_MultivariateGaussian)
+{
+    std::vector<double> vcov(9, 0.);
+    gsl_matrix_view vcov_view = gsl_matrix_view_array(vcov.data(), 3, 3);
+    gsl_matrix_set_identity(&vcov_view.matrix);
+    fwdpy11::MultivariateGaussianEffects mvg(make_dummy_region(), 2., vcov_view.matrix,
+                                             1, fwdpy11::FixedDominance(1. / 6.));
+    fwdpy11::mvDES mv(mvg, std::vector<double>(3, 0.));
+    std::vector<fwdpy11::Mutation> mutations;
+    auto x = generate_mutation(mv, mutations);
+    BOOST_CHECK_EQUAL(x, 0);
+    for (int i = 0; i < 3; ++i)
+        {
+            BOOST_CHECK_EQUAL(mutations[x].heffects[i], 1. / 6.);
+        }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/fwdpy11/headers/fwdpy11/policies/mutation.hpp
+++ b/fwdpy11/headers/fwdpy11/policies/mutation.hpp
@@ -73,9 +73,11 @@ namespace fwdpy11
             {
                 pos = posmaker();
             }
+        auto esize = esize_maker();
+        auto dominance = hmaker(esize);
         auto idx = fwdpp::recycle_mutation_helper(recycling_bin, mutations,
-                                                  treat_as_neutral, pos, esize_maker(),
-                                                  hmaker(), generation, x);
+                                                  treat_as_neutral, pos, esize,
+                                                  dominance, generation, x);
         lookup.emplace(pos, idx);
         return idx;
     }
@@ -129,9 +131,11 @@ namespace fwdpy11
             {
                 pos = posmaker();
             }
+        auto esize = fixed_esize_maker();
+        auto fixed_dominance = fixed_hmaker(esize);
         auto idx = fwdpp::recycle_mutation_helper(
-            recycling_bin, mutations, treat_as_neutral, pos, fixed_esize_maker(),
-            fixed_hmaker(), generation, esizes(), dominance(), x);
+            recycling_bin, mutations, treat_as_neutral, pos, esize, fixed_dominance,
+            generation, esizes(), dominance(), x);
         lookup.emplace(pos, idx);
         return idx;
     }

--- a/fwdpy11/headers/fwdpy11/regions/ExpS.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/ExpS.hpp
@@ -5,59 +5,53 @@
 #include <stdexcept>
 #include <fwdpy11/policies/mutation.hpp>
 #include "Sregion.hpp"
+#include "MutationDominance.hpp"
 
 namespace fwdpy11
 {
-
     struct ExpS : public Sregion
     {
-        double mean, dominance;
+        double mean;
 
-        ExpS(const Region& r, double sc, double m, double h)
-            : Sregion(r, sc, 1), mean(m), dominance(h)
+        template <typename Dominance>
+        ExpS(const Region& r, double sc, double m, Dominance&& h)
+            : Sregion(r, sc, 1, std::forward<Dominance>(h)), mean(m)
         {
             if (!std::isfinite(mean))
                 {
                     throw std::invalid_argument("mean must be finite");
-                }
-            if (!std::isfinite(dominance))
-                {
-                    throw std::invalid_argument("dominance must be finite");
                 }
         }
 
         std::unique_ptr<Sregion>
         clone() const override
         {
-            return std::unique_ptr<ExpS>(new ExpS(*this));
+            return std::unique_ptr<ExpS>(
+                new ExpS(this->region, this->scaling, this->mean, *this->dominance));
         }
 
         std::uint32_t
-        operator()(
-            fwdpp::flagged_mutation_queue& recycling_bin,
-            std::vector<Mutation>& mutations,
-            std::unordered_multimap<double, std::uint32_t>& lookup_table,
-            const std::uint32_t generation, const GSLrng_t& rng) const override
+        operator()(fwdpp::flagged_mutation_queue& recycling_bin,
+                   std::vector<Mutation>& mutations,
+                   std::unordered_multimap<double, std::uint32_t>& lookup_table,
+                   const std::uint32_t generation, const GSLrng_t& rng) const override
         {
             return infsites_Mutation(
                 recycling_bin, mutations, lookup_table, false, generation,
                 [this, &rng]() { return region(rng); },
-                [this, &rng]() {
+                [&rng, this]() {
                     return gsl_ran_exponential(rng.get(), mean) / scaling;
                 },
-                [this]() { return dominance; }, this->label());
+                [this, &rng](const auto esize) {
+                    return dominance->generate_dominance(rng, esize);
+                },
+                this->label());
         }
 
         double
         from_mvnorm(const double /*deviate*/, const double P) const override
         {
             return gsl_cdf_exponential_Pinv(P, mean) / scaling;
-        }
-
-        std::vector<double>
-        get_dominance() const override
-        {
-            return { dominance };
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/regions/MutationDominance.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/MutationDominance.hpp
@@ -1,0 +1,65 @@
+#ifndef FWDPY11_MUTATION_DOMINANCE_HPP
+#define FWDPY11_MUTATION_DOMINANCE_HPP
+
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+#include <fwdpy11/rng.hpp>
+
+namespace fwdpy11
+{
+    struct MutationDominance
+    {
+        virtual ~MutationDominance() = default;
+        virtual double generate_dominance(const GSLrng_t& /*rng*/,
+                                          const double /*effect_size*/) const = 0;
+        virtual std::shared_ptr<MutationDominance> clone() const = 0;
+    };
+
+    struct FixedDominance : public MutationDominance
+    {
+        double dominance;
+        explicit FixedDominance(double d) : dominance{d}
+        {
+            if (!std::isfinite(dominance))
+                {
+                    throw std::invalid_argument("dominance values must be finite");
+                }
+        }
+
+        double
+        generate_dominance(const GSLrng_t& /*rng*/,
+                           const double /*effect_size*/) const override final
+        {
+            return dominance;
+        }
+
+        std::shared_ptr<MutationDominance>
+        clone() const override final
+        {
+            return std::make_shared<FixedDominance>(dominance);
+        }
+    };
+
+    inline std::shared_ptr<MutationDominance>
+    process_input_dominance(double dominance)
+    {
+        return std::make_shared<FixedDominance>(dominance);
+    }
+
+    // NOTE/FIXME we may not need both of these overloads:
+
+    inline std::shared_ptr<MutationDominance>
+    process_input_dominance(const MutationDominance& dominance)
+    {
+        return dominance.clone();
+    }
+
+    inline std::shared_ptr<MutationDominance>
+    process_input_dominance(const std::shared_ptr<MutationDominance>& dominance)
+    {
+        return dominance->clone();
+    }
+}
+
+#endif

--- a/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
@@ -82,10 +82,10 @@ namespace fwdpy11
             return dominance->generate_dominance(rng, esize);
         }
 
-        virtual pybind11::tuple
+        virtual std::vector<std::size_t>
         shape() const
         {
-            return pybind11::make_tuple(total_dim);
+            return {total_dim};
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
@@ -12,6 +12,7 @@
 #include <fwdpy11/rng.hpp>
 #include <gsl/gsl_cdf.h>
 #include "Region.hpp"
+#include "MutationDominance.hpp"
 
 namespace fwdpy11
 {
@@ -20,11 +21,14 @@ namespace fwdpy11
         Region region; // For returning positions
         double scaling;
         const std::size_t total_dim;
+        std::shared_ptr<MutationDominance> dominance;
 
         virtual ~Sregion() = default;
 
-        Sregion(const Region& r, double s, std::size_t dim)
-            : region(r), scaling(s), total_dim(dim)
+        template <typename Dominance>
+        Sregion(const Region& r, double s, std::size_t dim, Dominance&& h)
+            : region(r), scaling(s), total_dim(dim),
+              dominance(process_input_dominance(std::forward<Dominance>(h)))
         {
             if (!std::isfinite(scaling))
                 {
@@ -61,18 +65,23 @@ namespace fwdpy11
         }
 
         virtual std::unique_ptr<Sregion> clone() const = 0;
-        virtual std::uint32_t operator()(
-            fwdpp::flagged_mutation_queue& /*recycling_bin*/,
-            std::vector<Mutation>& /*mutations*/,
-            std::unordered_multimap<double, std::uint32_t>& /*lookup_table*/,
-            const std::uint32_t /*generation*/,
-            const GSLrng_t& /*rng*/) const = 0;
+        virtual std::uint32_t
+        operator()(fwdpp::flagged_mutation_queue& /*recycling_bin*/,
+                   std::vector<Mutation>& /*mutations*/,
+                   std::unordered_multimap<double, std::uint32_t>& /*lookup_table*/,
+                   const std::uint32_t /*generation*/,
+                   const GSLrng_t& /*rng*/) const = 0;
         // Added in 0.7.0.  We now require that these types
         // are able to return deviates from the relevant cdf_P
         // function.
         virtual double from_mvnorm(const double /*deviate*/,
                                    const double /*P*/) const = 0;
-        virtual std::vector<double> get_dominance() const = 0;
+        virtual double
+        generate_dominance(const GSLrng_t& rng, const double esize) const
+        {
+            return dominance->generate_dominance(rng, esize);
+        }
+
         virtual pybind11::tuple
         shape() const
         {

--- a/fwdpy11/headers/fwdpy11/regions/mvDES.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/mvDES.hpp
@@ -28,7 +28,6 @@
 #include "MutationDominance.hpp"
 #include "MultivariateGaussianEffects.hpp"
 #include <fwdpy11/policies/mutation.hpp>
-#include <fwdpy11/numpy/array.hpp>
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_linalg.h>

--- a/fwdpy11/src/regions/DiscreteDESD.cc
+++ b/fwdpy11/src/regions/DiscreteDESD.cc
@@ -34,8 +34,9 @@ class DiscreteDESD : public fwdpy11::Sregion
   public:
     DiscreteDESD(const fwdpy11::Region& r, const double sc, std::vector<double> esize_,
                  std::vector<double> h_, std::vector<double> w_)
-        : fwdpy11::Sregion(r, sc, 1), esize{std::move(esize_)}, h{std::move(h_)},
-          weight{std::move(w_)}, sh_lookup{init_lookup()}
+        : fwdpy11::Sregion(r, sc, 1, fwdpy11::process_input_dominance(0.)),
+          esize{std::move(esize_)}, h{std::move(h_)}, weight{std::move(w_)},
+          sh_lookup{init_lookup()}
     {
         if (esize.size() != h.size() || esize.size() != weight.size()
             || h.size() != weight.size())
@@ -63,7 +64,7 @@ class DiscreteDESD : public fwdpy11::Sregion
             recycling_bin, mutations, lookup_table, false, generation,
             [this, &rng]() { return region(rng); },
             [this, idx]() { return esize[idx] / scaling; },
-            [this, idx]() { return h[idx]; }, this->label());
+            [this, idx](const double esize) { return h[idx]; }, this->label());
     }
 
     double
@@ -73,10 +74,10 @@ class DiscreteDESD : public fwdpy11::Sregion
         return 1.;
     }
 
-    std::vector<double>
-    get_dominance() const override
+    double
+    generate_dominance(const fwdpy11::GSLrng_t& rng, const double esize) const override
     {
-        return {h};
+        return std::numeric_limits<double>::quiet_NaN();
     }
 };
 

--- a/fwdpy11/src/regions/Sregion.cc
+++ b/fwdpy11/src/regions/Sregion.cc
@@ -22,9 +22,11 @@ init_Sregion(py::module& m)
         .. versionchanged:: 0.8.0
 
             C++ version of class API minimized in favor of attrs.
+
+        .. versionchanged:: 0.13.0
+
+            Remove "dominance" property.
         )delim")
-        .def_property_readonly("dominance", &fwdpy11::Sregion::get_dominance,
-                               "Dominance values.  Added in 0.7.0")
         .def_property_readonly("shape", &fwdpy11::Sregion::shape,
                                "Return shape.  Added in 0.7.0");
 }

--- a/fwdpy11/src/regions/Sregion.cc
+++ b/fwdpy11/src/regions/Sregion.cc
@@ -27,7 +27,14 @@ init_Sregion(py::module& m)
 
             Remove "dominance" property.
         )delim")
-        .def_property_readonly("shape", &fwdpy11::Sregion::shape,
-                               "Return shape.  Added in 0.7.0");
+        .def_property_readonly(
+            "shape",
+            [](const fwdpy11::Sregion& s) {
+                auto shape = s.shape();
+                auto l = py::cast(shape);
+                auto t = l.cast<py::tuple>();
+                return t;
+            },
+            "Return shape.  Added in 0.7.0");
 }
 

--- a/fwdpy11/src/ts/infinite_sites.cc
+++ b/fwdpy11/src/ts/infinite_sites.cc
@@ -23,9 +23,10 @@ namespace
             return gsl_ran_flat(rng.get(), left, right);
         };
         const auto return_zero = []() { return 0.0; };
+        const auto return_zero_h = [](const double) { return 0.0; };
         auto key = fwdpy11::infsites_Mutation(
             recycling_bin, pop.mutations, pop.mut_lookup, true, generation, uniform,
-            return_zero, return_zero, 0);
+            return_zero, return_zero_h, 0);
         return fwdpp::ts::new_variant_record(
             pop.mutations[key].pos, fwdpp::ts::default_ancestral_state, key,
             pop.mutations[key].neutral, fwdpp::ts::default_derived_state);

--- a/tests/EsizeZero.cc
+++ b/tests/EsizeZero.cc
@@ -6,7 +6,8 @@ using namespace pybind11::literals;
 
 struct EsizeZero : public fwdpy11::Sregion
 {
-    EsizeZero(const fwdpy11::Region& r) : fwdpy11::Sregion(r, 1., 1)
+    EsizeZero(const fwdpy11::Region& r)
+        : fwdpy11::Sregion(r, 1., 1, fwdpy11::process_input_dominance(1.0))
     {
     }
 
@@ -22,10 +23,10 @@ struct EsizeZero : public fwdpy11::Sregion
         return 0.0;
     }
 
-    std::vector<double>
-    get_dominance() const override
+    double
+    generate_dominance(const fwdpy11::GSLrng_t&, const double) const override
     {
-        return {1.};
+        return 1.;
     }
 
     std::uint32_t
@@ -38,7 +39,7 @@ struct EsizeZero : public fwdpy11::Sregion
         return fwdpy11::infsites_Mutation(
             recycling_bin, mutations, lookup_table, false, generation,
             [this, &rng]() { return region(rng); }, []() { return 0.; },
-            []() { return 1.; }, this->label());
+            [](const double) { return 1.; }, this->label());
     }
 };
 

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -219,7 +219,6 @@ class Test_mvDES(unittest.TestCase):
         up = pickle.loads(p)
         self.assertTrue(np.array_equal(up.means, self.r.means))
         self.assertTrue(np.array_equal(up.matrix, np.identity(2)))
-        self.assertTrue(np.array_equal(up.dominance, self.r.dominance))
 
     def test_bad_init_1(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Notes for change log:

This removes the "dominance" property from all Sregion classes on the Python side.  That is fine, as it turns out to have been a hack introduced in 0.7.0 that we totally didn't need.