### PR TITLE
Make MassMigration C++ constructor consistent with other classes.

### DIFF
--- a/cpptests/test_discrete_demography_stable_sorting_of_events.cc
+++ b/cpptests/test_discrete_demography_stable_sorting_of_events.cc
@@ -19,10 +19,10 @@ struct demographic_event_stable_sorting_fixture
         fwdpy11::discrete_demography::DiscreteDemography::set_migration_rates_vector
             migration;
 
-        massmigs.emplace_back(5, 3, 5, 0, -1, 0.25, true, false, true);
-        massmigs.emplace_back(3, 2, 5, 0, -1, 0.25, true, false, true);
-        massmigs.emplace_back(4, 3, 4, 0, -1, 0.25, true, false, true);
-        massmigs.emplace_back(1, 2, 4, 0, -1, 0.25, true, false, true);
+        massmigs.emplace_back(5, 5, 3, 0, -1, 0.25, true, false, true);
+        massmigs.emplace_back(5, 3, 2, 0, -1, 0.25, true, false, true);
+        massmigs.emplace_back(4, 4, 3, 0, -1, 0.25, true, false, true);
+        massmigs.emplace_back(4, 1, 2, 0, -1, 0.25, true, false, true);
 
         growth.emplace_back(10, 1, 0.5);
         growth.emplace_back(10, 0, 0.25);

--- a/fwdpy11/headers/fwdpy11/discrete_demography/MassMigration.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/MassMigration.hpp
@@ -30,22 +30,20 @@ namespace fwdpy11
     {
         struct MassMigration
         {
-            std::int32_t source, destination; // Demes
             std::uint32_t when;               // when it happens
+            std::int32_t source, destination; // Demes
             std::uint32_t number;             // no. to move||copy
             std::int32_t sex;      // If event is sex-specific, this is the sex
             double fraction;       // fraction of deme to move||copy
             bool move_individuals; // If true, we move
-            bool
-                sex_specific; // If true, only apply to individuals with value sex
+            bool sex_specific;     // If true, only apply to individuals with value sex
             // If size is changed, but not growth rate, do we reset growth rate to zero?
             bool resets_growth_rate;
-            MassMigration(std::int32_t s, std::int32_t d, std::uint32_t w,
-                          std::uint32_t n, std::int32_t sx, double f, bool mv,
-                          bool ss, bool reset)
-                : source(s), destination(d), when(w), number(n), sex(sx),
-                  fraction(f), move_individuals(mv), sex_specific(ss),
-                  resets_growth_rate(reset)
+            MassMigration(std::uint32_t w, std::int32_t s, std::int32_t d,
+                          std::uint32_t n, std::int32_t sx, double f, bool mv, bool ss,
+                          bool reset)
+                : when(w), source(s), destination(d), number(n), sex(sx), fraction(f),
+                  move_individuals(mv), sex_specific(ss), resets_growth_rate(reset)
             {
                 if (!std::isfinite(fraction))
                     {
@@ -83,8 +81,7 @@ namespace fwdpy11
         inline bool
         operator==(const MassMigration& lhs, const MassMigration& rhs)
         {
-            return lhs.source == rhs.source
-                   && lhs.destination == rhs.destination
+            return lhs.source == rhs.source && lhs.destination == rhs.destination
                    && lhs.when == rhs.when && lhs.number == rhs.number
                    && lhs.fraction == rhs.fraction
                    && lhs.move_individuals == rhs.move_individuals

--- a/fwdpy11/src/discrete_demography/MassMigration.cc
+++ b/fwdpy11/src/discrete_demography/MassMigration.cc
@@ -30,7 +30,7 @@ init_MassMigration(py::module& m)
         .def(py::init([](std::uint32_t when, std::int32_t source,
                          std::int32_t destination, double fraction,
                          bool move_individuals, bool resets_growth_rate) {
-                 return ddemog::MassMigration(source, destination, when, 0, -1, fraction,
+                 return ddemog::MassMigration(when, source, destination, 0, -1, fraction,
                                               move_individuals, false,
                                               resets_growth_rate);
              }),


### PR DESCRIPTION
Fixes #602