### PR TITLE
Update minimum pybind11 version to 2.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
             sudo apt-get install libgsl0-dev libcunit1-dev libconfig-dev cmake libboost-test-dev autoconf
             pip install --user -r requirements.txt
             pip install --user twine
-            curl -L https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz > pybind11-2.4.3.tar.gz
-            tar xzf pybind11-2.4.3.tar.gz
+            curl -L https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz > pybind11-2.6.0.tar.gz
+            tar xzf pybind11-2.6.0.tar.gz
             # Skip running the pybind11 unit suite--not needed...
-            cd pybind11-2.4.3 && cmake . -DPYBIND11_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION -DPYBIND11_TEST=0 && sudo make install && pip install . --user && cd ..
+            cd pybind11-2.6.0 && cmake . -DPYBIND11_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION -DPYBIND11_TEST=0 && sudo make install && pip install . --user && cd ..
             # way to set path persistently https://circleci.com/docs/2.0/env-vars/#setting-path
             echo 'export PATH=/home/circleci/.local/bin:$PATH' >> $BASH_ENV
       - save_cache:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
     - python>=3.7
     - sphinx_rtd_theme
-    - pybind11>=2.4.3
+    - pybind11>=2.6.0
     - gsl
     - attrs
     - msprime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # As of 0.2.0, pybind11 
 # must not be installed via pip
-pybind11==2.4.3
+pybind11==2.6.0
 numpy
 sparse
 scipy

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import pybind11
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-PYBIND11_MIN_VERSION = "2.4.3"
+PYBIND11_MIN_VERSION = "2.6.0"
 TSKIT_MIN_VERSION = "0.3.2"
 
 if sys.version_info[0] < 3:


### PR DESCRIPTION
This allows us to have ``kwarg``-only C++ functions.