### PR TITLE
Fix sdist packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,12 @@ jobs:
             python setup.py sdist
             python setup.py check
             python -m twine check dist/*.tar.gz
-      # This is removed b/c the failures here are not reproducible on more up-to-date distros.
-      # We will revisit this via GH actions
-      # - run:
-      #     name: Install from the distribution tarball and build manual from distribution
-      #     command: |
-      #       python -m venv venv
-      #       source venv/bin/activate 
-      #       pip install --upgrade setuptools pip pybind11
-      #       pip install dist/*.tar.gz 
+      
+      - run:
+          name: Install from the distribution tarball and build manual from distribution
+          command: |
+            python -m venv venv
+            source venv/bin/activate 
+            pip install --upgrade setuptools pip pybind11
+            pip install dist/*.tar.gz 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,4 @@ include doc/Makefile
 recursive-include doc *.rst *.png
 include aclocal.m4
 recursive-include check_deps *
+exclude fwdpy11/headers/fwdpp


### PR DESCRIPTION
Some of Python's forbidden packaging secrets broke being able to pip install from an sdist.  The happened in #635.  This PR fixes it.