### PR TITLE
Fix 639 and 646

### DIFF
--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -82,7 +82,8 @@ set(EVOLVE_POPULATION_SOURCES src/evolve_population/init.cc
     src/evolve_population/no_stopping.cc
     src/evolve_population/remove_extinct_mutations.cc
     src/evolve_population/track_ancestral_counts.cc
-    src/evolve_population/remove_extinct_genomes.cc)
+    src/evolve_population/remove_extinct_genomes.cc
+    src/evolve_population/runtime_checks.cc)
 
 set(DISCRETE_DEMOGRAPHY_SOURCES src/discrete_demography/init.cc
     src/discrete_demography/MigrationMatrix.cc

--- a/fwdpy11/src/evolve_population/index_and_count_mutations.hpp
+++ b/fwdpy11/src/evolve_population/index_and_count_mutations.hpp
@@ -1,11 +1,11 @@
 #ifndef FWDPP_TSEVOLUTION_INDEX_AND_COUNT_HPP
 #define FWDPP_TSEVOLUTION_INDEX_AND_COUNT_HPP
 
-#include <vector>
-#include <cstdint>
 #include <fwdpy11/types/DiploidPopulation.hpp>
 
-void index_and_count_mutations(const bool suppress_edge_table_indexing,
+void index_and_count_mutations(bool suppress_edge_table_indexing,
+                               bool simulating_neutral_variants,
+                               bool reset_treeseqs_to_alive_nodes_after_simplification,
                                fwdpy11::DiploidPopulation& pop);
 
 #endif

--- a/fwdpy11/src/evolve_population/remove_extinct_mutations.cc
+++ b/fwdpy11/src/evolve_population/remove_extinct_mutations.cc
@@ -5,6 +5,7 @@
 #include <limits>
 #include <stdexcept>
 #include <fwdpy11/types/Population.hpp>
+#include "runtime_checks.hpp"
 
 namespace
 {
@@ -40,6 +41,7 @@ namespace
 void
 remove_extinct_mutations(fwdpy11::Population& pop)
 {
+    check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
     std::vector<fwdpp::uint_t> summed_counts(pop.mcounts);
     std::transform(begin(pop.mcounts_from_preserved_nodes),
                    end(pop.mcounts_from_preserved_nodes), begin(summed_counts),

--- a/fwdpy11/src/evolve_population/runtime_checks.cc
+++ b/fwdpy11/src/evolve_population/runtime_checks.cc
@@ -1,0 +1,30 @@
+#include <sstream>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+
+static std::string
+strip_unix_path(const std::string file)
+{
+    auto pos = file.find_last_of('/');
+    if (pos != std::string::npos)
+        {
+            return std::string(begin(file) + static_cast<std::ptrdiff_t>(pos) + 1,
+                               end(file));
+        }
+    return file;
+}
+
+void
+check_mutation_table_consistency_with_count_vectors(const fwdpy11::Population& pop,
+                                                    std::string file, int line)
+{
+    for (auto& mr : pop.tables->mutations)
+        {
+            if (pop.mcounts[mr.key] + pop.mcounts_from_preserved_nodes[mr.key] == 0)
+                {
+                    std::ostringstream msg;
+                    msg << "mutation table is inconsistent with count vectors: "
+                        << strip_unix_path(file) << ", line " << line;
+                    throw std::runtime_error(msg.str());
+                }
+        }
+}

--- a/fwdpy11/src/evolve_population/runtime_checks.hpp
+++ b/fwdpy11/src/evolve_population/runtime_checks.hpp
@@ -1,0 +1,6 @@
+#include <string>
+#include <fwdpy11/types/Population.hpp>
+
+void check_mutation_table_consistency_with_count_vectors(const fwdpy11::Population& pop,
+                                                         std::string file, int line);
+

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -68,24 +68,21 @@ apply_treseq_resetting_of_ancient_samples(
         }
 }
 
-template<typename SimplificationState>
+template <typename SimplificationState>
 std::pair<std::vector<fwdpp::ts::table_index_t>, std::vector<std::size_t>>
 simplification(
     bool preserve_selected_fixations, bool simulating_neutral_variants,
     bool suppress_edge_table_indexing,
     bool reset_treeseqs_to_alive_nodes_after_simplification,
     const fwdpy11::DiploidPopulation_temporal_sampler &post_simplification_recorder,
-    SimplificationState &simplifier_state, 
-    fwdpp::ts::edge_buffer & new_edge_buffer,
-    std::vector<fwdpp::ts::table_index_t> & alive_at_last_simplification,
+    SimplificationState &simplifier_state, fwdpp::ts::edge_buffer &new_edge_buffer,
+    std::vector<fwdpp::ts::table_index_t> &alive_at_last_simplification,
     fwdpy11::DiploidPopulation &pop)
 {
     auto simplification_rv = fwdpy11::simplify_tables(
-        pop, pop.mcounts_from_preserved_nodes,
-        alive_at_last_simplification,
-        *pop.tables, simplifier_state, new_edge_buffer,
-        preserve_selected_fixations, simulating_neutral_variants,
-        suppress_edge_table_indexing);
+        pop, pop.mcounts_from_preserved_nodes, alive_at_last_simplification, *pop.tables,
+        simplifier_state, new_edge_buffer, preserve_selected_fixations,
+        simulating_neutral_variants, suppress_edge_table_indexing);
     if (pop.mcounts.size() != pop.mcounts_from_preserved_nodes.size())
         {
             throw std::runtime_error("evolvets: count vector size mismatch after "
@@ -115,9 +112,9 @@ final_population_cleanup(
     index_and_count_mutations(suppress_edge_table_indexing, simulating_neutral_variants,
                               reset_treeseqs_to_alive_nodes_after_simplification, pop);
     check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
-    if (pop.generation == last_preserved_generation &&
-            !reset_treeseqs_to_alive_nodes_after_simplification &&
-            !simulating_neutral_variants)
+    if (pop.generation == last_preserved_generation
+        && !reset_treeseqs_to_alive_nodes_after_simplification
+        && !simulating_neutral_variants)
         {
             std::transform(begin(pop.mcounts_from_preserved_nodes),
                            end(pop.mcounts_from_preserved_nodes),
@@ -336,9 +333,11 @@ evolve_with_tree_sequences(
 
     fwdpp::ts::table_index_t next_index = pop.tables->nodes.size();
     bool simplified = false;
-    auto simplifier_state = 
-        std::make_unique<decltype(fwdpp::ts::make_simplifier_state(*pop.tables))>(fwdpp::ts::make_simplifier_state(*pop.tables));
-    auto new_edge_buffer = std::make_unique<fwdpp::ts::edge_buffer>(fwdpp::ts::edge_buffer{});
+    auto simplifier_state
+        = std::make_unique<decltype(fwdpp::ts::make_simplifier_state(*pop.tables))>(
+            fwdpp::ts::make_simplifier_state(*pop.tables));
+    auto new_edge_buffer
+        = std::make_unique<fwdpp::ts::edge_buffer>(fwdpp::ts::edge_buffer{});
     bool stopping_criteron_met = false;
     const bool simulating_neutral_variants = (mu_neutral > 0.0) ? true : false;
     std::pair<std::vector<fwdpp::ts::table_index_t>, std::vector<std::size_t>>
@@ -359,8 +358,8 @@ evolve_with_tree_sequences(
                                                 "the edge table is not empty");
                 }
             pop.tables->preserved_nodes.insert(end(pop.tables->preserved_nodes),
-                                              begin(pop.alive_nodes),
-                                              end(pop.alive_nodes));
+                                               begin(pop.alive_nodes),
+                                               end(pop.alive_nodes));
             pop.ancient_sample_metadata.insert(end(pop.ancient_sample_metadata),
                                                begin(pop.diploid_metadata),
                                                end(pop.diploid_metadata));
@@ -433,16 +432,16 @@ evolve_with_tree_sequences(
                         preserve_selected_fixations, simulating_neutral_variants,
                         suppress_edge_table_indexing,
                         reset_treeseqs_to_alive_nodes_after_simplification,
-                        post_simplification_recorder, *simplifier_state, *new_edge_buffer,
-                        alive_at_last_simplification, pop);
+                        post_simplification_recorder, *simplifier_state,
+                        *new_edge_buffer, alive_at_last_simplification, pop);
                     simplifier_state.reset(nullptr);
                     new_edge_buffer.reset(nullptr);
                     final_population_cleanup(
                         suppress_edge_table_indexing, preserve_selected_fixations,
                         remove_extinct_mutations_at_finish, simulating_neutral_variants,
                         reset_treeseqs_to_alive_nodes_after_simplification,
-                        last_preserved_generation,
-                        last_preserved_generation_counts, pop);
+                        last_preserved_generation, last_preserved_generation_counts,
+                        pop);
                     std::ostringstream o;
                     o << "extinction at time " << pop.generation;
                     throw ddemog::GlobalExtinction(o.str());
@@ -454,8 +453,8 @@ evolve_with_tree_sequences(
                         preserve_selected_fixations, simulating_neutral_variants,
                         suppress_edge_table_indexing,
                         reset_treeseqs_to_alive_nodes_after_simplification,
-                        post_simplification_recorder, *simplifier_state, *new_edge_buffer,
-                        alive_at_last_simplification, pop);
+                        post_simplification_recorder, *simplifier_state,
+                        *new_edge_buffer, alive_at_last_simplification, pop);
                     simplified = true;
                 }
             else
@@ -586,6 +585,13 @@ evolve_with_tree_sequences(
         });
     pop.tables->preserved_nodes.erase(itr, end(pop.tables->preserved_nodes));
     pop.alive_nodes.clear();
+    pop.ancient_sample_metadata.erase(
+        std::remove_if(begin(pop.ancient_sample_metadata),
+                       end(pop.ancient_sample_metadata),
+                       [&pop](const auto &md) {
+                           return pop.tables->nodes[md.nodes[0]].time == pop.generation;
+                       }),
+        end(pop.ancient_sample_metadata));
 
     if (!simplified)
         {
@@ -598,11 +604,11 @@ evolve_with_tree_sequences(
         }
     simplifier_state.reset(nullptr);
     new_edge_buffer.reset(nullptr);
-    final_population_cleanup(suppress_edge_table_indexing, preserve_selected_fixations,
-                             remove_extinct_mutations_at_finish, simulating_neutral_variants, 
-                             reset_treeseqs_to_alive_nodes_after_simplification,
-                             last_preserved_generation, last_preserved_generation_counts,
-                             pop);
+    final_population_cleanup(
+        suppress_edge_table_indexing, preserve_selected_fixations,
+        remove_extinct_mutations_at_finish, simulating_neutral_variants,
+        reset_treeseqs_to_alive_nodes_after_simplification, last_preserved_generation,
+        last_preserved_generation_counts, pop);
     ddemog::save_model_state(std::move(current_demographic_state), demography);
 }
 

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -601,6 +601,13 @@ evolve_with_tree_sequences(
                 reset_treeseqs_to_alive_nodes_after_simplification,
                 post_simplification_recorder, *simplifier_state, *new_edge_buffer,
                 alive_at_last_simplification, pop);
+            if (!preserve_selected_fixations)
+                {
+                    fwdpp::ts::remove_fixations_from_haploid_genomes(
+                        pop.haploid_genomes, pop.mutations, pop.mcounts,
+                        pop.mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
+                        preserve_selected_fixations);
+                }
         }
     simplifier_state.reset(nullptr);
     new_edge_buffer.reset(nullptr);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,26 @@ import pytest
 import fwdpy11
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def rng(request):
     try:
         seed = request.param.get("seed", None)
         return fwdpy11.GSLrng(seed)
-    except: # NOQA
+    except AttributeError:  # NOQA
         return fwdpy11.GSLrng(42)
+
+
+@pytest.fixture(scope="function")
+def pop(request):
+    popsize = request.param["N"]
+    genome_length = request.param["genome_length"]
+    return fwdpy11.DiploidPopulation(popsize, genome_length)
+
+
+@pytest.fixture(scope="function")
+def mslike_pop(request):
+    try:
+        N = request.param.get("N", None)
+        return fwdpy11.DiploidPopulation(N, 1.0)
+    except AttributeError:  # NOQA
+        return fwdpy11.DiploidPopulation(1000, 1.0)

--- a/tests/test_ancient_samples_with_neutral_mutations.py
+++ b/tests/test_ancient_samples_with_neutral_mutations.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import numpy as np
+import pytest
+
+import fwdpy11
+
+
+class CountSamplesPerTimePoint(object):
+    def __init__(self):
+        self.sample_timepoints = []
+        self.sample_sizes = []
+        self.timepoint_seen = {}
+
+    def __call__(self, pop):
+        # Get the most recent ancient samples
+        # and record their number.  We do this
+        # by a "brute-force" approach
+        for t, n, m in pop.sample_timepoints(False):
+            if t not in self.timepoint_seen:
+                self.timepoint_seen[t] = 1
+            else:
+                self.timepoint_seen[t] += 1
+            if t not in self.sample_timepoints:
+                self.sample_timepoints.append(t)
+                self.sample_sizes.append(len(n) // 2)
+
+            # simplify to each time point
+            tables, idmap = fwdpy11.simplify_tables(pop.tables, n)
+            for ni in n:
+                assert idmap[ni] != fwdpy11.NULL_NODE
+                assert tables.nodes[idmap[ni]].time == t
+
+
+@pytest.fixture(
+    scope="function",
+    params=[
+        {"nregions": [], "rates": (0.0, 0.025, None)},
+        {
+            "nregions": [fwdpy11.Region(0.0, 1.0, 1.0)],
+            "rates": (0.025, 0.025, None),
+        },
+    ],
+)
+def pdict(request):
+    """
+    Build models w/ and w/o neutral mutations.
+    """
+    pd = {
+        "nregions": request.param["nregions"],
+        "sregions": [fwdpy11.ExpS(beg=0, end=1, weight=1, mean=0.2)],
+        "recregions": [fwdpy11.PoissonInterval(0, 1, 1e-2)],
+        "gvalue": [fwdpy11.Multiplicative(2.0)],
+        "rates": request.param["rates"],
+        "demography": fwdpy11.DiscreteDemography(),
+    }
+    return pd
+
+
+def make_counter():
+    return lambda: CountSamplesPerTimePoint()
+
+
+def make_none():
+    return lambda: None
+
+
+@pytest.fixture(scope="function", params=[make_counter, make_none])
+def resetter(request):
+    """
+    Generate a value for post_simplification_recorder
+    """
+    return request.param()()
+
+
+@pytest.fixture(params=[5, 10, 25, 33, 50, 73, 100, 101])
+def simlen(request):
+    return request.param
+
+
+@pytest.fixture(params=[1, 2, 5, 10, 33])
+def simplification_inteval(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def prune_selected(request):
+    return request.param
+
+
+@pytest.mark.parametrize("rng", [{"seed": 101 * 45 * 110 * 210}], indirect=True)
+@pytest.mark.parametrize(
+    "mslike_pop", [{"N": 50}, {"N": 100}, {"N": 200}], indirect=True
+)
+def test_ancient_samples_and_neutral_mutations(
+    pdict, simlen, simplification_inteval, prune_selected, rng, mslike_pop, resetter
+):
+    """
+    The test involving neutral mutations test GitHub issue 639 and 646
+    """
+    ancient_sample_recorder = fwdpy11.RandomAncientSamples(
+        seed=42, samplesize=10, timepoints=[i for i in range(1, simlen + 1)]
+    )
+    pdict["simlen"] = simlen
+    pdict["prune_selected"] = prune_selected
+    params = fwdpy11.ModelParams(**pdict)
+    fwdpy11.evolvets(
+        rng,
+        mslike_pop,
+        params,
+        simplification_inteval,
+        recorder=ancient_sample_recorder,
+        post_simplification_recorder=resetter,
+    )
+
+    if resetter is not None:
+        assert len(mslike_pop.tables.preserved_nodes) == 0
+        assert len(mslike_pop.ancient_sample_metadata) == 0
+
+        # FIXME: check that the number of sampled time points is correct?
+        for _, j in resetter.timepoint_seen.items():
+            assert j == 1
+
+        assert all([i == 10 for i in resetter.sample_sizes]) is True
+    else:
+        assert (
+            len(mslike_pop.tables.preserved_nodes)
+            == len([i for i in range(1, params.simlen)]) * 10 * 2
+        )
+        assert (
+            len(mslike_pop.ancient_sample_metadata)
+            == len([i for i in range(1, params.simlen)]) * 10
+        )
+
+    ti = fwdpy11.TreeIterator(
+        mslike_pop.tables, mslike_pop.alive_nodes, update_samples=True
+    )
+    for t in ti:
+        for m in t.mutations():
+            s = t.samples_below(m.node)
+            if len(s) == 0:
+                assert mslike_pop.mcounts_ancient_samples[m.key] > 0
+            else:
+                assert len(s) == mslike_pop.mcounts[m.key]
+                if prune_selected is True and len(s) == 2 * mslike_pop.N:
+                    assert mslike_pop.mcounts_ancient_samples[m.key] > 0

--- a/tests/test_ancient_samples_with_neutral_mutations.py
+++ b/tests/test_ancient_samples_with_neutral_mutations.py
@@ -34,6 +34,7 @@ class CountSamplesPerTimePoint(object):
         # and record their number.  We do this
         # by a "brute-force" approach
         for t, n, m in pop.sample_timepoints(False):
+            assert t != pop.generation
             if t not in self.timepoint_seen:
                 self.timepoint_seen[t] = 1
             else:

--- a/tests/test_tree_sequences_with_neutral_mutations.py
+++ b/tests/test_tree_sequences_with_neutral_mutations.py
@@ -143,5 +143,34 @@ class TestNeutralMutRegions(unittest.TestCase):
         self.assertTrue(all([i < 0.25 or i >= 0.5 for i in pos]))
 
 
+def test_trigger_final_simplification_with_fixations_to_remove():
+    """
+    MRE that triggers an exception that would hit after many of the
+    changes in PR647 were in place.  Commit 06a8a41 avoids the exception.
+    """
+    burnin = 10
+    N = 133
+    pdict = {
+        # Add a region for neutral mutations:
+        "nregions": [fwdpy11.Region(0, 1, 1)],
+        "sregions": [fwdpy11.ExpS(beg=0, end=1, weight=1, mean=0.2)],
+        "recregions": [fwdpy11.PoissonInterval(0, 1, 1e-2)],
+        "gvalue": [fwdpy11.Multiplicative(2.0)],
+        "rates": (1e-3, 1e-3, None),
+        "simlen": burnin * N,
+        "prune_selected": True,
+    }
+    params = fwdpy11.ModelParams(**pdict)
+    pop = fwdpy11.DiploidPopulation(N, 1.0)
+    rng = fwdpy11.GSLrng(54321)
+
+    fwdpy11.evolvets(
+        rng,
+        pop,
+        params,
+        37,
+        suppress_table_indexing=False,
+    )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
WIP to fix #639 and #646

- [x] Decide on input parameter validation

To follow up on in a later PR:

1. Neutral mutations w/frequency tracking should error out if not simplifying every generation.