### PR TITLE
Add check on container sizes at end of final_population_cleanup.

### DIFF
--- a/fwdpy11/src/evolve_population/index_and_count_mutations.cc
+++ b/fwdpy11/src/evolve_population/index_and_count_mutations.cc
@@ -11,7 +11,8 @@ index_and_count_mutations(bool suppress_edge_table_indexing,
                           fwdpy11::DiploidPopulation& pop)
 {
     pop.mcounts_from_preserved_nodes.resize(pop.mutations.size(), 0);
-    if (!suppress_edge_table_indexing && !simulating_neutral_variants)
+    if (!suppress_edge_table_indexing && !simulating_neutral_variants
+        && !reset_treeseqs_to_alive_nodes_after_simplification)
         {
             return;
         }

--- a/fwdpy11/src/evolve_population/with_tree_sequences.cc
+++ b/fwdpy11/src/evolve_population/with_tree_sequences.cc
@@ -157,6 +157,12 @@ final_population_cleanup(
             remove_extinct_mutations(pop);
         }
     remove_extinct_genomes(pop);
+    if (pop.mutations.size() != pop.mcounts.size()
+        || pop.mutations.size() != pop.mcounts_from_preserved_nodes.size())
+        {
+            throw std::runtime_error("mutation container size does not equal mutation "
+                                     "count container size(s)");
+        }
 }
 
 void


### PR DESCRIPTION
It appears that #647 left an issue.  The final sizes of mutations/mcounts, etc., can get out of sync. Let's fix that...