### PR TITLE
Remove TableCollection.preserved_nodes

### DIFF
--- a/fwdpy11/_monkeypatch/_diploid_population.py
+++ b/fwdpy11/_monkeypatch/_diploid_population.py
@@ -222,7 +222,7 @@ def _dump_tables_to_tskit(self, parameters: typing.Optional[typing.Dict] = None)
         individual[k] = v
     flags = [1] * 2 * self.N + [0] * (len(node_view) - 2 * self.N)
     # Bug fixed in 0.3.1: add preserved nodes to samples list
-    for i in self.tables.preserved_nodes:
+    for i in np.array(self.ancient_sample_metadata, copy=False)["nodes"].flatten():
         flags[i] = 1
     tc.nodes.set_columns(
         flags=flags,
@@ -266,8 +266,32 @@ def _deme_sizes(self, as_dict=False):
     return {i: j for i, j in zip(deme_sizes[0], deme_sizes[1])}
 
 
+def _preserved_nodes(self):
+    """
+    Return an array of nodes associated with preserved/ancient samples.
+
+    :rtype: :class:`np.ndarray`
+
+    .. versionadded:: 0.13.0
+    """
+    return np.array(self.ancient_sample_metadata, copy=False)["nodes"].flatten()
+
+
+def _ancient_sample_nodes(self):
+    """
+    Return an array of nodes associated with preserved/ancient samples.
+
+    Alias for :attr:`fwdpy11.DiploidPopulation.preserved_nodes`.
+
+    .. versionadded:: 0.13.0
+    """
+    return self.preserved_nodes
+
+
 def _patch_diploid_population(d):
     d.alive_nodes = property(_alive_nodes)
     d.sample_timepoints = _traverse_sample_timepoints
     d.dump_tables_to_tskit = _dump_tables_to_tskit
     d.deme_sizes = _deme_sizes
+    d.preserved_nodes = property(_preserved_nodes)
+    d.ancient_sample_nodes = property(_ancient_sample_nodes)

--- a/fwdpy11/_monkeypatch/_table_collection.py
+++ b/fwdpy11/_monkeypatch/_table_collection.py
@@ -278,5 +278,12 @@ def _fs(
     return fs
 
 
+def _preserved_nodes(self):
+    raise AttributeError(
+        "TableCollection.preserved_nodes was removed in 0.13.0 and is now an attribute of DiploidPopulation"
+    )
+
+
 def _patch_table_collection(t):
     t.fs = _fs
+    t.preserved_nodes = property(_preserved_nodes)

--- a/fwdpy11/headers/fwdpy11/serialization.hpp
+++ b/fwdpy11/headers/fwdpy11/serialization.hpp
@@ -181,8 +181,10 @@ namespace fwdpy11
                         std::vector<fwdpp::ts::table_index_t> samples(2 * pop.N);
                         std::iota(samples.begin(), samples.end(), 0);
                         fwdpp::ts::count_mutations(*pop.tables, pop.mutations, samples,
-                                                   pop.mcounts,
-                                                   pop.mcounts_from_preserved_nodes);
+                                                   pop.mcounts);
+                        pop.mcounts_from_preserved_nodes.resize(pop.mutations.size());
+                        std::fill(begin(pop.mcounts_from_preserved_nodes),
+                                  end(pop.mcounts_from_preserved_nodes), 0);
                     }
                 if (version > 2)
                     {

--- a/fwdpy11/headers/fwdpy11/types/Population.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Population.hpp
@@ -163,6 +163,7 @@ namespace fwdpy11
 
         virtual std::size_t ancient_sample_metadata_size() const = 0;
         virtual void fill_alive_nodes() = 0;
+        virtual void fill_preserved_nodes() = 0;
     };
 }
 

--- a/fwdpy11/src/evolve_population/index_and_count_mutations.cc
+++ b/fwdpy11/src/evolve_population/index_and_count_mutations.cc
@@ -16,12 +16,14 @@ index_and_count_mutations(bool suppress_edge_table_indexing,
         {
             return;
         }
-    if (pop.tables->preserved_nodes.empty() || simulating_neutral_variants)
+    if (pop.ancient_sample_metadata.empty() || simulating_neutral_variants)
         {
             pop.tables->build_indexes();
             pop.fill_alive_nodes();
+            pop.fill_preserved_nodes();
             fwdpp::ts::count_mutations(*pop.tables, pop.mutations, pop.alive_nodes,
-                                       pop.mcounts, pop.mcounts_from_preserved_nodes);
+                                       pop.preserved_sample_nodes, pop.mcounts,
+                                       pop.mcounts_from_preserved_nodes);
         }
     else
         {

--- a/fwdpy11/src/fwdpp_types/TableCollection.cc
+++ b/fwdpy11/src/fwdpp_types/TableCollection.cc
@@ -18,7 +18,6 @@ init_ts_TableCollection(py::module& m)
     // A table_collection will not be user-constructible.  Rather,
     // they will be members of the Population classes.
     // TODO: work out conversion to msprime format
-    // TODO: allow preserved_nodes to be cleared
     // TODO: allow access to the "right" member functions
     py::class_<fwdpp::ts::std_table_collection,
                std::shared_ptr<fwdpp::ts::std_table_collection>>(
@@ -39,9 +38,6 @@ init_ts_TableCollection(py::module& m)
         .def_readonly("output_right", &fwdpp::ts::std_table_collection::output_right,
                       "Index vector describing when nodes leave trees.")
         .def("build_indexes", &fwdpp::ts::std_table_collection::build_indexes)
-        .def_readonly("preserved_nodes",
-                      &fwdpp::ts::std_table_collection::preserved_nodes,
-                      "List of nodes corresponding to ancient samples.")
         .def_property_readonly("genome_length",
                                &fwdpp::ts::std_table_collection::genome_length,
                                "Return the genome/sequence length.")
@@ -54,8 +50,7 @@ init_ts_TableCollection(py::module& m)
                                       fwdpy11::vector_to_list(tables.nodes),
                                       fwdpy11::vector_to_list(tables.edges),
                                       fwdpy11::vector_to_list(tables.mutations),
-                                      fwdpy11::vector_to_list(tables.sites),
-                                      fwdpy11::vector_to_list(tables.preserved_nodes));
+                                      fwdpy11::vector_to_list(tables.sites));
             },
             [](py::tuple t) {
                 auto length = t[0].cast<double>();
@@ -69,9 +64,6 @@ init_ts_TableCollection(py::module& m)
                     t[3].cast<py::list>());
                 tables.sites = fwdpy11::list_to_vector<
                     fwdpp::ts::std_table_collection::site_table>(t[4].cast<py::list>());
-                tables.preserved_nodes = fwdpy11::list_to_vector<decltype(
-                    fwdpp::ts::std_table_collection::preserved_nodes)>(
-                    t[5].cast<py::list>());
                 tables.build_indexes();
                 return tables;
             }));

--- a/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
+++ b/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
@@ -206,7 +206,6 @@ init_DiploidPopulation(py::module& m)
                     {
                         dump(s, f);
                     }
-                dump(self.tables->preserved_nodes, f);
                 dump(self.genetic_value_matrix, f);
                 dump(self.ancient_sample_genetic_value_matrix, f);
             },
@@ -320,9 +319,6 @@ init_DiploidPopulation(py::module& m)
                         rv.tables->sites.push_back(
                             load(f).cast<fwdpp::ts::site>());
                     }
-
-                rv.tables->preserved_nodes
-                    = load(f).cast<decltype(rv.tables->preserved_nodes)>();
                 rv.tables->build_indexes();
                 rv.rebuild_mutation_lookup(false);
                 rv.genetic_value_matrix

--- a/fwdpy11/src/ts/VariantIterator.cc
+++ b/fwdpy11/src/ts/VariantIterator.cc
@@ -1,7 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
-#include <fwdpy11/types/Population.hpp>
+#include <fwdpy11/types/DiploidPopulation.hpp>
 #include <fwdpy11/numpy/array.hpp>
 #include <fwdpp/ts/std_table_collection.hpp>
 #include <fwdpp/ts/site_visitor.hpp>
@@ -173,7 +173,7 @@ init_variant_iterator(py::module& m)
 
                  No longer requires a :class:`fwdpy11.MutationVector`.
             )delim")
-        .def(py::init([](const fwdpy11::Population& pop,
+        .def(py::init([](const fwdpy11::DiploidPopulation& pop,
                          const bool include_preserved, double begin,
                          double end, bool include_neutral_variants,
                          bool include_selected_variants) {
@@ -181,9 +181,11 @@ init_variant_iterator(py::module& m)
                  std::iota(samples.begin(), samples.end(), 0);
                  if (include_preserved)
                      {
-                         samples.insert(samples.end(),
-                                        pop.tables->preserved_nodes.begin(),
-                                        pop.tables->preserved_nodes.end());
+                         for(auto & md : pop.ancient_sample_metadata)
+                         {
+                            samples.push_back(md.nodes[0]);
+                            samples.push_back(md.nodes[1]);
+                         }
                      }
                  return VariantIterator(*pop.tables, samples, begin, end,
                                         include_neutral_variants,

--- a/fwdpy11/src/ts/infinite_sites.cc
+++ b/fwdpy11/src/ts/infinite_sites.cc
@@ -55,6 +55,7 @@ init_infinite_sites(py::module& m)
                           recycling_bin, pop, rng, left, right, generation);
                   };
             pop.fill_alive_nodes();
+            pop.fill_preserved_nodes();
             auto nmuts = fwdpp::ts::mutate_tables(
                 rng, apply_mutations, *pop.tables, pop.alive_nodes, mu);
             if (nmuts == 0)
@@ -62,8 +63,10 @@ init_infinite_sites(py::module& m)
                     return nmuts;
                 }
             fwdpp::ts::count_mutations(*pop.tables, pop.mutations,
-                                       pop.alive_nodes, pop.mcounts,
-                                       pop.mcounts_from_preserved_nodes);
+                                       pop.alive_nodes, pop.preserved_sample_nodes,
+                                       pop.mcounts, pop.mcounts_from_preserved_nodes);
+            pop.alive_nodes.clear();
+            pop.preserved_sample_nodes.clear();
             return nmuts;
         },
         py::arg("rng"), py::arg("pop"), py::arg("mu"));

--- a/fwdpy11/src/ts/simplify.cc
+++ b/fwdpy11/src/ts/simplify.cc
@@ -37,9 +37,6 @@ simplify(const fwdpy11::Population& pop,
             throw std::invalid_argument("invalid sample list");
         }
     auto t(*pop.tables);
-    // NOTE: If the user wants to keep ancient samples,
-    // they must pass them in to the samples list
-    t.preserved_nodes.clear();
     fwdpp::ts::table_simplifier<fwdpp::ts::std_table_collection> simplifier{};
     auto rv = simplifier.simplify(t, samples);
     t.build_indexes();
@@ -64,7 +61,7 @@ init_simplify_functions(py::module& m)
             Note that the samples argument is agnostic with respect to the time of
             the nodes in the input tables. Thus, you may do things like simplify
             to a set of "currently-alive" nodes plus some or all ancient samples by
-            including some node IDs from :attr:`fwdpy11.TableCollection.preserved_nodes`.
+            including some node IDs from :attr:`fwdpy11.DiploidPopulation.ancient_sample_metadata`.
             
             If the input contains ancient samples, and you wish to include them in the output,
             then you need to include their IDs in the samples argument.
@@ -95,7 +92,6 @@ init_simplify_functions(py::module& m)
         [](const fwdpp::ts::std_table_collection& tables,
            const std::vector<fwdpp::ts::table_index_t>& samples) -> py::tuple {
             auto t(tables);
-            t.preserved_nodes.clear();
             fwdpp::ts::table_simplifier<fwdpp::ts::std_table_collection> simplifier{};
             auto rv = simplifier.simplify(t, samples);
             t.build_indexes();

--- a/tests/test_ancient_samples_with_neutral_mutations.py
+++ b/tests/test_ancient_samples_with_neutral_mutations.py
@@ -132,7 +132,6 @@ def test_ancient_samples_and_neutral_mutations(
     )
 
     if resetter is not None:
-        assert len(mslike_pop.tables.preserved_nodes) == 0
         assert len(mslike_pop.ancient_sample_metadata) == 0
 
         # FIXME: check that the number of sampled time points is correct?
@@ -141,10 +140,6 @@ def test_ancient_samples_and_neutral_mutations(
 
         assert all([i == 10 for i in resetter.sample_sizes]) is True
     else:
-        assert (
-            len(mslike_pop.tables.preserved_nodes)
-            == len([i for i in range(1, params.simlen)]) * 10 * 2
-        )
         assert (
             len(mslike_pop.ancient_sample_metadata)
             == len([i for i in range(1, params.simlen)]) * 10

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -136,8 +136,8 @@ def mcounts_comparison_details(pop, counts, ts):
 
 
 def mcounts_comparison(pop, ts):
-    if len(pop.tables.preserved_nodes) > 0:
-        ts2 = ts.simplify(pop.tables.preserved_nodes)
+    if len(pop.preserved_nodes) > 0:
+        ts2 = ts.simplify(pop.preserved_nodes)
         c = mcounts_comparison_details(pop, pop.mcounts_ancient_samples, ts2)
         if c is not True:
             return c
@@ -552,7 +552,7 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
         self.assertTrue(self.pop.mut_lookup == up.mut_lookup)
 
     def test_count_mutations_preserved_samples(self):
-        mc = fwdpy11.count_mutations(self.pop, self.pop.tables.preserved_nodes)
+        mc = fwdpy11.count_mutations(self.pop, self.pop.preserved_nodes)
         pmc = np.array(self.pop.mcounts_ancient_samples)
         self.assertTrue(np.array_equal(mc, pmc))
 
@@ -564,7 +564,7 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
 
     def test_VariantIteratorFromPreservedSamples(self):
         n = np.array(self.pop.tables.nodes)
-        pn = np.array(self.pop.tables.preserved_nodes)
+        pn = np.array(self.pop.preserved_nodes)
         at = n["time"][pn]
         for u in np.unique(at):
             n = pn[np.where(at == u)[0]]
@@ -575,7 +575,7 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
                 self.assertNotEqual(k.key, np.iinfo(np.uint64).max)
 
     def test_mcounts_from_ancient_samples(self):
-        vi = fwdpy11.VariantIterator(self.pop.tables, self.pop.tables.preserved_nodes)
+        vi = fwdpy11.VariantIterator(self.pop.tables, self.pop.preserved_nodes)
         for v in vi:
             k = v.records[0]
             self.assertEqual(self.pop.mcounts_ancient_samples[k.key], v.genotypes.sum())
@@ -585,7 +585,7 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
         amd = np.array(self.pop.ancient_sample_metadata, copy=False)
         n = np.array(self.pop.tables.nodes)
         at = n["time"][amd["nodes"][:, 0]]
-        pn = np.array(self.pop.tables.preserved_nodes)
+        pn = np.array(self.pop.preserved_nodes)
         self.assertEqual(2 * len(amd), len(pn))
         # j contains (time, nodes, metadata).  The metadata
         # also contain nodes
@@ -610,9 +610,9 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
                 self.assertEqual(amd["parents"][k][1], l.parents[1])
 
             # Extract out the nodes from preserved_nodes
-            idx = np.where(n["time"][self.pop.tables.preserved_nodes] == i)[0]
+            idx = np.where(n["time"][self.pop.preserved_nodes] == i)[0]
             self.assertTrue(
-                np.array_equal(np.array(self.pop.tables.preserved_nodes)[idx], j[1])
+                np.array_equal(np.array(self.pop.preserved_nodes)[idx], j[1])
             )
 
     def test_binary_round_trip(self):
@@ -1222,7 +1222,7 @@ class TestTreeSequenceResettingDuringTimeSeriesAnalysis(unittest.TestCase):
                 self.timepoint_seen = {}
 
             def __call__(self, pop):
-                assert len(pop.tables.preserved_nodes) // 2 == len(
+                assert len(pop.preserved_nodes) // 2 == len(
                     pop.ancient_sample_metadata
                 )
                 # Get the most recent ancient samples
@@ -1277,7 +1277,7 @@ class TestTreeSequenceResettingDuringTimeSeriesAnalysis(unittest.TestCase):
         )
 
     def test_no_preserved_nodes(self):
-        self.assertEqual(len(self.pop.tables.preserved_nodes), 0)
+        self.assertEqual(len(self.pop.preserved_nodes), 0)
 
     def test_no_ancient_sample_metadata(self):
         self.assertEqual(len(self.pop.ancient_sample_metadata), 0)
@@ -1367,7 +1367,7 @@ class TestRecapitation(unittest.TestCase):
 
     def test_ancient_sample_records(self):
         self.assertEqual(len(self.pop.ancient_sample_metadata), self.pop.N)
-        self.assertEqual(len(self.pop.tables.preserved_nodes), 2 * self.pop.N)
+        self.assertEqual(len(self.pop.ancient_sample_nodes), 2 * self.pop.N)
 
     def test_ancient_sample_times(self):
         nodes = np.array(self.pop.tables.nodes, copy=False)


### PR DESCRIPTION
This PR does a few things:

1. Update the fwdpp submodule
2. The updated submodule removes `preserved_nodes` from the table collection, on the grounds that it violated the ORP from this class.
3. Update the C++ back-end to reflect API changes.
4. Update Python types and tests to reflect API changes.