### PR TITLE
Add Python classes modeling variable dominance

### DIFF
--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -27,6 +27,7 @@
   - file: short_vignettes/genetics_vignettes_intro
   - file: short_vignettes/geneticmaps_vignette
   - file: short_vignettes/des_vignette
+  - file: short_vignettes/mutationdominance_vignette
   - file: short_vignettes/neutralmuts_vignette
   - file: short_vignettes/gvalues_fitness
   - file: short_vignettes/gvalues_traits

--- a/doc/pages/regiontypes.md
+++ b/doc/pages/regiontypes.md
@@ -82,4 +82,25 @@
     This class inherits from :class:`fwdpy11.GeneticMapUnit`
 ```
 
+```{eval-rst}
+.. autoclass:: fwdpy11.MutationDominance
+    
+    See :ref:`here <mutationdominance_vignette>` for details.
+
+.. autoclass:: fwdpy11.FixedDominance
+    
+    See :ref:`here <mutationdominance_vignette>` for details.
+
+.. autoclass:: fwdpy11.UniformDominance
+    
+    See :ref:`here <mutationdominance_vignette>` for details.
+
+.. autoclass:: fwdpy11.ExponentialDominance
+    
+    See :ref:`here <mutationdominance_vignette>` for details.
+
+.. autoclass:: fwdpy11.LargeEffectExponentiallyRecessive
+    
+    See :ref:`here <mutationdominance_vignette>` for details.
+```
 

--- a/doc/short_vignettes/mutationdominance_vignette.md
+++ b/doc/short_vignettes/mutationdominance_vignette.md
@@ -1,0 +1,88 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+(mutationdominance_vignette)=
+
+# Mutations with variable dominance
+
+:::{versionadded} 0.13.0
+:::
+
+The heterozygous effect of a mutation does not need to be constant.
+You may use instances of classes derived from {class}`fwdpy11.MutationDominance` to assign functions to generate the dominance of mutations.
+
+The available classes are:
+
+* {class}`fwdpy11.FixedDominance`
+  This class is equivalent to passing in a {class}`float` to the `h` `kwarg`.
+  See {ref}`here <des_vignette>`
+* {class}`fwdpy11.ExponentialDominance`
+* {class}`fwdpy11.UniformDominance`
+* {class}`fwdpy11.LargeEffectExponentiallyRecessive`
+
+## Example
+
+```{code-cell}
+import fwdpy11
+
+des = fwdpy11.GaussianS(beg=0, end=1, weight=1, sd=0.1,
+    h=fwdpy11.LargeEffectExponentiallyRecessive(k=5.0))
+```
+
+If we apply this `des` object to a model of a quantitative trait evolving to a sudden "optimum shift", then we see that the larger effect variants present at the end of the simulation to indeed have smaller dominance coefficients.
+
+```{code-cell} python
+---
+tags: ['hide-input']
+---
+pop = fwdpy11.DiploidPopulation(500, 1.0)
+
+rng = fwdpy11.GSLrng(54321)
+
+GSSmo = fwdpy11.GSSmo(
+    [
+        fwdpy11.Optimum(when=0, optimum=0.0, VS=1.0),
+        fwdpy11.Optimum(when=10 * pop.N, optimum=1.0, VS=1.0),
+    ]
+)
+
+rho = 1000.
+
+p = {
+    "nregions": [],
+    "gvalue": fwdpy11.Additive(2.0, GSSmo),
+    "sregions": [des],
+    "recregions": [fwdpy11.PoissonInterval(0, 1., rho / float(4 * pop.N))],
+    "rates": (0.0, 1e-3, None),
+    "prune_selected": False,
+    "demography": fwdpy11.DiscreteDemography(),
+    "simlen": 10 * pop.N + 200,
+}
+params = fwdpy11.ModelParams(**p)
+
+fwdpy11.evolvets(rng, pop, params, 100, suppress_table_indexing=True)
+```
+
+```{code-cell}
+---
+tags: ['hide-input']
+---
+import matplotlib.pyplot as plt
+esize = [pop.mutations[m.key].s for m in pop.tables.mutations]
+h = [pop.mutations[m.key].h for m in pop.tables.mutations]
+
+f, ax = plt.subplots()
+ax.scatter(esize, h)
+ax.set_xlabel("Effect size of mutation on trait")
+ax.set_ylabel("Dominance")
+plt.show();
+```

--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -50,6 +50,12 @@ from .genetic_map_unit import (
     BinomialPoint,
     FixedCrossovers,
 )
+from .mutation_dominance import ( # NOQA
+    FixedDominance,
+    UniformDominance,
+    ExponentialDominance,
+    LargeEffectExponentiallyRecessive,
+)
 from .genetic_values import (  # NOQA
     PleiotropicOptima,
     Optimum,

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
@@ -10,10 +10,13 @@ namespace fwdpy11
     struct LargeEffectExponentiallyRecessive : public MutationDominance
     {
         const double k;
+        const double scaling;
 
-        explicit LargeEffectExponentiallyRecessive(double k) : MutationDominance{}, k{k}
+        explicit LargeEffectExponentiallyRecessive(double k, double scaling)
+            : MutationDominance{}, k{k}, scaling{scaling}
         {
             fwdpp::validators::isfinite(k, "k must be finite");
+            fwdpp::validators::isfinite(scaling, "scaling must be finite");
             fwdpp::validators::is_positive(k, "k must be > 0.0");
         }
 
@@ -21,7 +24,7 @@ namespace fwdpy11
         generate_dominance(const GSLrng_t& rng,
                            const double effect_size) const override final
         {
-            return std::exp(-k * std::abs(effect_size));
+            return scaling * std::exp(-k * std::abs(effect_size));
         }
 
         std::shared_ptr<MutationDominance>

--- a/fwdpy11/mutation_dominance.py
+++ b/fwdpy11/mutation_dominance.py
@@ -1,0 +1,122 @@
+#
+# Copyright(C) 2021 Kevin Thornton < krthornt @uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software : you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.If not, see < http: //www.gnu.org/licenses/>.
+#
+
+import attr
+
+import fwdpy11._fwdpy11
+
+from .class_decorators import (attr_add_asblack, attr_class_pickle_with_super,
+                               attr_class_to_from_dict)
+
+_common_attr_attribs = {"frozen": True, "auto_attribs": True, "repr_ns": "fwdpy11"}
+
+
+@attr_add_asblack
+@attr_class_pickle_with_super
+@attr_class_to_from_dict
+@attr.s(**_common_attr_attribs)
+class FixedDominance(fwdpy11._fwdpy11._ll_FixedDominance):
+    """
+    Fixed heterozygous effects.
+
+    :param h: The heterozygous effect of a mutation, or "dominance".
+    :type h: float
+
+    .. versionadded:: 0.14.0
+    """
+
+    h: float = attr.ib(validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super(FixedDominance, self).__init__(self.h)
+
+
+@attr_add_asblack
+@attr_class_pickle_with_super
+@attr_class_to_from_dict
+@attr.s(**_common_attr_attribs)
+class ExponentialDominance(fwdpy11._fwdpy11._ll_ExponentialDominance):
+    """
+    Exponential distribution of heterozygous effects.
+
+    :param m: The mean of the distribution.
+    :type m: float
+
+    .. versionadded:: 0.14.0
+    """
+
+    m: float = attr.ib(validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super(ExponentialDominance, self).__init__(self.m)
+
+
+@attr_add_asblack
+@attr_class_pickle_with_super
+@attr_class_to_from_dict
+@attr.s(**_common_attr_attribs)
+class UniformDominance(fwdpy11._fwdpy11._ll_UniformDominance):
+    """
+    Uniform distribution of heterozygous effects.
+
+    :param lo: The lower bound of the range
+    :type lo: float
+    :param hi: The upper bound of the range
+    :type hi: float
+
+    .. versionadded:: 0.14.0
+    """
+
+    lo: float = attr.ib(validator=attr.validators.instance_of(float))
+    hi: float = attr.ib(validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super(UniformDominance, self).__init__(self.lo, self.hi)
+
+
+@attr_add_asblack
+@attr_class_pickle_with_super
+@attr_class_to_from_dict
+@attr.s(**_common_attr_attribs)
+class LargeEffectExponentiallyRecessive(
+    fwdpy11._fwdpy11._ll_LargeEffectExponentiallyRecessive
+):
+    """
+    Large effect mutations are more recessive according to
+    the function :math:`y \\times e^{-k|s|}`, where :math:`s` is the
+    effect size and :math:`y` is a "scaling" parameter.
+
+    :param k: The "tuning" parameter.
+    :type k: float
+    :type scaling: Scaling parameter
+    :type scaling: float
+
+    .. versionadded:: 0.14.0
+    """
+
+    k: float = attr.ib(validator=attr.validators.instance_of(float))
+    scaling: float = attr.ib(validator=attr.validators.instance_of(float), default=1.0)
+
+    @k.validator
+    def _k_positive(self, attribute, value):
+        if value <= 0.0:
+            raise ValueError(f"{attribute} must be > 0.0")
+
+    def __attrs_post_init__(self):
+        super(LargeEffectExponentiallyRecessive, self).__init__(self.k, self.scaling)

--- a/fwdpy11/regions.py
+++ b/fwdpy11/regions.py
@@ -156,7 +156,7 @@ class ConstantS(fwdpy11._fwdpy11._ll_ConstantS):
     :param s: the selection coefficient
     :type s: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to (end-beg)*weight
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -217,7 +217,7 @@ class ExpS(fwdpy11._fwdpy11._ll_ExpS):
     :param mean: the mean selection coefficient
     :type s: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to (end-beg)*weight
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -282,7 +282,7 @@ class GammaS(fwdpy11._fwdpy11._ll_GammaS):
     :param shape: the shape parameter of the distribution
     :type shape: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to (end-beg)*weight
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -345,7 +345,7 @@ class GaussianS(fwdpy11._fwdpy11._ll_GaussianS):
     :param sd: standard deviation of effect sizes
     :type sd: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to (end-beg)*weight
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -408,7 +408,7 @@ class LogNormalS(fwdpy11._fwdpy11._ll_LogNormalS):
     :param sigma: the sigma parameter
     :type sigma: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to(end-beg)*weight
     :type Constructor: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -473,7 +473,7 @@ class LogNormalS(fwdpy11._fwdpy11._ll_LogNormalS):
         :param weight: the weight to assign
         :type weight: float
         :param h: the dominance
-        :type h: float
+        :type h: typing.Union[float, fwdpy11.MutationDominance]
         :param coupled: if True, the weight is converted to(end-beg)*weight
         :type coupled: bool
         :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -519,7 +519,7 @@ class UniformS(fwdpy11._fwdpy11._ll_UniformS):
     :param hi: upper bound on s
     :type hi: float
     :param h: the dominance
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: if True, the weight is converted to (end-beg)*weight
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.
@@ -587,7 +587,7 @@ class MultivariateGaussianEffects(fwdpy11._fwdpy11._ll_MultivariateGaussianEffec
     :param fixed_effect: Fixed effect size. Defaults to 0.0.
     :type fixed_effect: float
     :param h: Dominance. Defaults to 1.0
-    :type h: float
+    :type h: typing.Union[float, fwdpy11.MutationDominance]
     :param coupled: Specify if weight is function of end-beg or not. Defaults to True
     :type coupled: bool
     :param label: Fill :attr:`fwdpy11.Mutation.label` with this value.

--- a/fwdpy11/regions.py
+++ b/fwdpy11/regions.py
@@ -137,7 +137,7 @@ class Region(fwdpy11._fwdpy11._ll_Region):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class ConstantS(fwdpy11._fwdpy11._ll_ConstantS):
     """
@@ -198,7 +198,7 @@ class ConstantS(fwdpy11._fwdpy11._ll_ConstantS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class ExpS(fwdpy11._fwdpy11._ll_ExpS):
     """
@@ -261,7 +261,7 @@ class ExpS(fwdpy11._fwdpy11._ll_ExpS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class GammaS(fwdpy11._fwdpy11._ll_GammaS):
     """
@@ -326,7 +326,7 @@ class GammaS(fwdpy11._fwdpy11._ll_GammaS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class GaussianS(fwdpy11._fwdpy11._ll_GaussianS):
     """
@@ -387,7 +387,7 @@ class GaussianS(fwdpy11._fwdpy11._ll_GaussianS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class LogNormalS(fwdpy11._fwdpy11._ll_LogNormalS):
     """
@@ -498,7 +498,7 @@ class LogNormalS(fwdpy11._fwdpy11._ll_LogNormalS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(**_common_attr_attribs)
 class UniformS(fwdpy11._fwdpy11._ll_UniformS):
     """
@@ -563,7 +563,7 @@ class UniformS(fwdpy11._fwdpy11._ll_UniformS):
 @_add_deprecated_properties
 @attr_add_asblack
 @attr_class_pickle_with_super
-@attr_class_to_from_dict
+@attr_class_to_from_dict_no_recurse
 @attr.s(eq=False, **_common_attr_attribs)
 class MultivariateGaussianEffects(fwdpy11._fwdpy11._ll_MultivariateGaussianEffects):
     """

--- a/fwdpy11/src/mutation_dominance/MutationDominance.cc
+++ b/fwdpy11/src/mutation_dominance/MutationDominance.cc
@@ -18,14 +18,14 @@ init_MutationDominance(py::module& m)
 
     py::class_<fwdpy11::FixedDominance, fwdpy11::MutationDominance>(m,
                                                                     "_ll_FixedDominance")
-        .def(py::init<double>());
+        .def(py::init<double>(), py::arg("h"));
     py::class_<fwdpy11::ExponentialDominance, fwdpy11::MutationDominance>(
         m, "_ll_ExponentialDominance")
-        .def(py::init<double>());
+        .def(py::init<double>(), py::arg("m"));
     py::class_<fwdpy11::UniformDominance, fwdpy11::MutationDominance>(
         m, "_ll_UniformDominance")
-        .def(py::init<double, double>());
+        .def(py::init<double, double>(), py::arg("lo"), py::arg("hi"));
     py::class_<fwdpy11::LargeEffectExponentiallyRecessive, fwdpy11::MutationDominance>(
         m, "_ll_LargeEffectExponentiallyRecessive")
-        .def(py::init<double>());
+        .def(py::init<double, double>(), py::arg("k"), py::arg("scaling"));
 }

--- a/fwdpy11/src/mutation_dominance/MutationDominance.cc
+++ b/fwdpy11/src/mutation_dominance/MutationDominance.cc
@@ -16,11 +16,16 @@ init_MutationDominance(py::module& m)
             .. versionadded:: 0.13.0
             )delim");
 
-    py::class_<fwdpy11::FixedDominance>(m, "_ll_FixedDominance").def(py::init<double>());
-    py::class_<fwdpy11::ExponentialDominance>(m, "_ll_ExponentialDominance")
+    py::class_<fwdpy11::FixedDominance, fwdpy11::MutationDominance>(m,
+                                                                    "_ll_FixedDominance")
         .def(py::init<double>());
-    py::class_<fwdpy11::UniformDominance>(m, "_ll_UniformDominance")
+    py::class_<fwdpy11::ExponentialDominance, fwdpy11::MutationDominance>(
+        m, "_ll_ExponentialDominance")
+        .def(py::init<double>());
+    py::class_<fwdpy11::UniformDominance, fwdpy11::MutationDominance>(
+        m, "_ll_UniformDominance")
         .def(py::init<double, double>());
-    py::class_<fwdpy11::LargeEffectExponentiallyRecessive>(m, "_ll_LargeEffectExponentiallyRecessive")
+    py::class_<fwdpy11::LargeEffectExponentiallyRecessive, fwdpy11::MutationDominance>(
+        m, "_ll_LargeEffectExponentiallyRecessive")
         .def(py::init<double>());
 }

--- a/fwdpy11/src/regions/ConstantS.cc
+++ b/fwdpy11/src/regions/ConstantS.cc
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/ConstantS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -13,8 +14,16 @@ init_ConstantS(py::module& m)
                      fwdpy11::Region(beg, end, weight, coupled, label), scaling, s, h);
              }),
              py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("s"),
-             py::arg("h"), py::arg("coupled"), py::arg("label"),
-             py::arg("scaling"))
+             py::arg("h"), py::arg("coupled"), py::arg("label"), py::arg("scaling"))
+        .def_readonly("esize", &fwdpy11::ConstantS::esize)
+        .def(py::init([](double beg, double end, double weight, double s,
+                         const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label, double scaling) {
+                 return fwdpy11::ConstantS(
+                     fwdpy11::Region(beg, end, weight, coupled, label), scaling, s, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("s"),
+             py::arg("h"), py::arg("coupled"), py::arg("label"), py::arg("scaling"))
         .def_readonly("esize", &fwdpy11::ConstantS::esize);
 }
 

--- a/fwdpy11/src/regions/ExpS.cc
+++ b/fwdpy11/src/regions/ExpS.cc
@@ -1,18 +1,27 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/ExpS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
 void
 init_ExpS(py::module& m)
 {
-    py::class_<fwdpy11::ExpS, fwdpy11::Sregion>(m, "_ll_ExpS" )
-        .def(py::init([](double beg, double end, double weight, double mean, double h,
-                         bool coupled, std::uint16_t label, double scaling) {
+    py::class_<fwdpy11::ExpS, fwdpy11::Sregion>(m, "_ll_ExpS")
+        .def(py::init([](double beg, double end, double weight, double mean,
+                         const double h, bool coupled, std::uint16_t label,
+                         double scaling) {
+                 return fwdpy11::ExpS(fwdpy11::Region(beg, end, weight, coupled, label),
+                                      scaling, mean, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("mean"),
+             py::arg("h"), py::arg("coupled"), py::arg("label"), py::arg("scaling"))
+        .def(py::init([](double beg, double end, double weight, double mean,
+                         const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label, double scaling) {
                  return fwdpy11::ExpS(fwdpy11::Region(beg, end, weight, coupled, label),
                                       scaling, mean, h);
              }),
              py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("mean"),
              py::arg("h"), py::arg("coupled"), py::arg("label"), py::arg("scaling"));
 }
-

--- a/fwdpy11/src/regions/GammaS.cc
+++ b/fwdpy11/src/regions/GammaS.cc
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/GammaS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -14,6 +15,16 @@ init_GammaS(py::module& m)
                                        scaling, mean, shape, h);
             }),
             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("mean"),
-            py::arg("shape_parameter"), py::arg("h"), py::arg("coupled"), py::arg("label"),
-            py::arg("scaling"));
+            py::arg("shape_parameter"), py::arg("h"), py::arg("coupled"),
+            py::arg("label"), py::arg("scaling"))
+        .def(py::init([](double beg, double end, double weight, double mean,
+                         double shape, const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label, double scaling) {
+                 return fwdpy11::GammaS(
+                     fwdpy11::Region(beg, end, weight, coupled, label), scaling, mean,
+                     shape, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("mean"),
+             py::arg("shape_parameter"), py::arg("h"), py::arg("coupled"),
+             py::arg("label"), py::arg("scaling"));
 }

--- a/fwdpy11/src/regions/GaussianS.cc
+++ b/fwdpy11/src/regions/GaussianS.cc
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/GaussianS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -9,6 +10,14 @@ init_GaussianS(py::module& m)
     py::class_<fwdpy11::GaussianS, fwdpy11::Sregion>(m, "_ll_GaussianS")
         .def(py::init([](double beg, double end, double weight, double sd, double h,
                          bool coupled, std::uint16_t label, double scaling) {
+                 return fwdpy11::GaussianS(
+                     fwdpy11::Region(beg, end, weight, coupled, label), scaling, sd, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("sd"),
+             py::arg("h"), py::arg("coupled"), py::arg("label"), py::arg("scaling"))
+        .def(py::init([](double beg, double end, double weight, double sd,
+                         const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label, double scaling) {
                  return fwdpy11::GaussianS(
                      fwdpy11::Region(beg, end, weight, coupled, label), scaling, sd, h);
              }),

--- a/fwdpy11/src/regions/LogNormalS.cc
+++ b/fwdpy11/src/regions/LogNormalS.cc
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/LogNormalS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -10,6 +11,21 @@ init_LogNormalS(py::module& m)
         .def(py::init([](double beg, double end, double weight, py::object zeta,
                          py::object sigma, double h, bool coupled, std::uint16_t label,
                          double scaling) {
+                 if (zeta.is_none() == false && sigma.is_none() == false)
+                     {
+                         return fwdpy11::LogNormalS(
+                             fwdpy11::Region(beg, end, weight, coupled, label), scaling,
+                             zeta.cast<double>(), sigma.cast<double>(), h);
+                     }
+                 return fwdpy11 ::LogNormalS(
+                     fwdpy11::Region(beg, end, weight, coupled, label), scaling, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("zeta"),
+             py::arg("sigma"), py::arg("h"), py::arg("coupled"), py::arg("label"),
+             py::arg("scaling"))
+        .def(py::init([](double beg, double end, double weight, py::object zeta,
+                         py::object sigma, const fwdpy11::MutationDominance& h,
+                         bool coupled, std::uint16_t label, double scaling) {
                  if (zeta.is_none() == false && sigma.is_none() == false)
                      {
                          return fwdpy11::LogNormalS(

--- a/fwdpy11/src/regions/MultivariateGaussianEffects.cc
+++ b/fwdpy11/src/regions/MultivariateGaussianEffects.cc
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <fwdpy11/regions/MultivariateGaussianEffects.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -24,6 +25,23 @@ init_MultivariateGaussianEffects(py::module& m)
                      fixed_effect, h);
              }),
              py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("cov_matrix"),
-             py::arg("fixed_effect"), py::arg("h"),
-             py::arg("coupled"), py::arg("label"));
+             py::arg("fixed_effect"), py::arg("h"), py::arg("coupled"), py::arg("label"))
+        .def(py::init([](double beg, double end, double weight,
+                         py::array_t<double> cov_matrix, double fixed_effect,
+                         const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label) {
+                 auto r = cov_matrix.unchecked<2>();
+                 if (r.shape(0) != r.shape(1))
+                     {
+                         throw std::invalid_argument("input matrix is not square");
+                     }
+                 gsl_matrix_const_view v
+                     = gsl_matrix_const_view_array(r.data(0, 0), r.shape(0), r.shape(1));
+                 return fwdpy11::MultivariateGaussianEffects(
+                     fwdpy11::Region(beg, end, weight, coupled, label), 1.0, v.matrix,
+                     fixed_effect, h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("cov_matrix"),
+             py::arg("fixed_effect"), py::arg("h"), py::arg("coupled"),
+             py::arg("label"));
 }

--- a/fwdpy11/src/regions/UniformS.cc
+++ b/fwdpy11/src/regions/UniformS.cc
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <fwdpy11/regions/UniformS.hpp>
+#include <fwdpy11/mutation_dominance/MutationDominance.hpp>
 
 namespace py = pybind11;
 
@@ -9,6 +10,16 @@ init_UniformS(py::module& m)
     py::class_<fwdpy11::UniformS, fwdpy11::Sregion>(m, "_ll_UniformS")
         .def(py::init([](double beg, double end, double weight, double lo, double hi,
                          double h, bool coupled, std::uint16_t label, double scaling) {
+                 return fwdpy11::UniformS(
+                     fwdpy11::Region(beg, end, weight, coupled, label), scaling, lo, hi,
+                     h);
+             }),
+             py::arg("beg"), py::arg("end"), py::arg("weight"), py::arg("lo"),
+             py::arg("hi"), py::arg("h"), py::arg("coupled"), py::arg("label"),
+             py::arg("scaling"))
+        .def(py::init([](double beg, double end, double weight, double lo, double hi,
+                         const fwdpy11::MutationDominance& h, bool coupled,
+                         std::uint16_t label, double scaling) {
                  return fwdpy11::UniformS(
                      fwdpy11::Region(beg, end, weight, coupled, label), scaling, lo, hi,
                      h);

--- a/tests/test_mutation_dominance.py
+++ b/tests/test_mutation_dominance.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+import pickle
+
+import fwdpy11
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    "t", [(fwdpy11.FixedDominance, "h"), (fwdpy11.ExponentialDominance, "m")]
+)
+@pytest.mark.parametrize("x", [1.0, -0.25])
+def test_single_param_construction(t, x):
+    _ = t[0](x)
+    kwargs = {t[1]: x}
+    _ = t[0](**kwargs)
+
+
+@pytest.mark.parametrize(
+    "t", [(fwdpy11.FixedDominance, "h"), (fwdpy11.ExponentialDominance, "m")]
+)
+@pytest.mark.parametrize("x", [np.nan, np.inf])
+def test_single_param_bad_construction(t, x):
+    with pytest.raises(ValueError):
+        _ = t[0](x)
+    with pytest.raises(ValueError):
+        kwargs = {t[1]: x}
+        _ = t[0](**kwargs)
+
+
+@pytest.mark.parametrize("x", [(0.0, 1.0), (-0.25, 1.0), (-1.0, 0.0), (-1.0, -1 / 3)])
+def test_UniformDominance_construction(x):
+    _ = fwdpy11.UniformDominance(lo=x[0], hi=x[1])
+    _ = fwdpy11.UniformDominance(x[0], x[1])
+
+
+@pytest.mark.parametrize(
+    "x", [(np.inf, 1.0), (np.nan, 1.0), (1.0, np.inf), (np.nan, 1.0), (1.0, 0.0)]
+)
+def test_UniformDominance_bad_construction(x):
+    with pytest.raises(ValueError):
+        _ = fwdpy11.UniformDominance(lo=x[0], hi=x[1])
+
+
+@pytest.mark.parametrize("k", [1e-3, 1.0, 10.0])
+def test_LargeEffectExponentiallyRecessive_construction(k):
+    _ = fwdpy11.LargeEffectExponentiallyRecessive(k)
+    _ = fwdpy11.LargeEffectExponentiallyRecessive(k=k)
+
+
+@pytest.mark.parametrize("k", [-1e-3, np.nan, np.inf])
+def test_LargeEffectExponentiallyRecessive_bad_construction(k):
+    with pytest.raises(ValueError):
+        _ = fwdpy11.LargeEffectExponentiallyRecessive(k)
+    with pytest.raises(ValueError):
+        _ = fwdpy11.LargeEffectExponentiallyRecessive(k=k)
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        fwdpy11.FixedDominance(h=0.667),
+        fwdpy11.ExponentialDominance(m=-0.23),
+        fwdpy11.LargeEffectExponentiallyRecessive(k=1.0),
+        fwdpy11.LargeEffectExponentiallyRecessive(k=1.0, scaling=1.),
+        fwdpy11.UniformDominance(lo=-2 / 3, hi=2 / 3),
+    ],
+)
+def test_pickling(x):
+    p = pickle.dumps(x, -1)
+    up = pickle.loads(p)
+    assert up == x
+
+
+@pytest.mark.parametrize(
+    "des",
+    [
+        (fwdpy11.ExpS, {"mean": -0.2}),
+        (fwdpy11.ConstantS, {"s": -0.2}),
+        (fwdpy11.GammaS, {"mean": 1, "shape_parameter": 1}),
+        (fwdpy11.GaussianS, {"sd": 1}),
+        (fwdpy11.LogNormalS, {"zeta": 1, "sigma": 1}),
+        (fwdpy11.UniformS, {"lo": -0.1, "hi": -1e-3}),
+        (fwdpy11.MultivariateGaussianEffects, {"cov_matrix": np.identity(2)}),
+    ],
+)
+@pytest.mark.parametrize(
+    "h",
+    [
+        fwdpy11.FixedDominance(h=0.667),
+        fwdpy11.ExponentialDominance(m=-0.23),
+        fwdpy11.LargeEffectExponentiallyRecessive(k=1.0),
+        fwdpy11.LargeEffectExponentiallyRecessive(k=1.0, scaling=0.5),
+        fwdpy11.UniformDominance(lo=-2 / 3, hi=2 / 3),
+    ],
+)
+def test_build_DES_objects(des, h):
+    x = des[0](beg=0, end=1, weight=1, h=h, **des[1])
+    p = pickle.dumps(x)
+    up = pickle.loads(p)
+    assert x == up


### PR DESCRIPTION
This PR adds Python classes exposing the low-level classes added in #630 to the public interface.

- [x] The low-level C++ DES/"Sregion" classes need their "init" methods changes to take a polymorphic reference to the MutationDominance base class.
- [x] The existing Python DES/"Sregion" classes need to have their "init" methods detect `float` vs not input and properly init the super class.
- [x] The typing hints for those Python DES/"Sregion" classes need updating, too.
- [x] Add Python classes for all the current MutationDominace types
- [x] Python tests
- [x] Vignette