### PR TITLE
Audit C++ code with clang-tidy.

### DIFF
--- a/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_noise/GeneticValueNoise.hpp
@@ -31,6 +31,11 @@ namespace fwdpy11
     ///ABC for random effects on trait values
     {
         virtual ~GeneticValueNoise() = default;
+        GeneticValueNoise() = default;
+        GeneticValueNoise(const GeneticValueNoise &) = delete;
+        GeneticValueNoise(GeneticValueNoise &&) = default;
+        GeneticValueNoise& operator=(GeneticValueNoise &&) = default;
+        GeneticValueNoise& operator=(const GeneticValueNoise &) = delete;
         virtual double
         operator()(const DiploidGeneticValueNoiseData /*data*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GSSmo.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GSSmo.hpp
@@ -74,7 +74,7 @@ namespace fwdpy11
         std::shared_ptr<GeneticValueToFitnessMap>
         clone() const override
         {
-            return std::make_shared<GSSmo>(*this);
+            return std::make_shared<GSSmo>(optima);
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp
@@ -31,6 +31,11 @@ namespace fwdpy11
             : GeneticValueToFitnessMap(ndim, maps_to_fitness(false))
         {
         }
+        virtual ~GeneticValueIsTrait() = default;
+        GeneticValueIsTrait(const GeneticValueIsTrait&) = delete;
+        GeneticValueIsTrait(GeneticValueIsTrait&&) = default;
+        GeneticValueIsTrait& operator=(const GeneticValueIsTrait&) = delete;
+        GeneticValueIsTrait& operator=(GeneticValueIsTrait&&) = default;
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueToFitnessMap.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/GeneticValueToFitnessMap.hpp
@@ -38,12 +38,18 @@ namespace fwdpy11
     struct GeneticValueToFitnessMap
     {
         std::size_t total_dim;
-        const bool isfitness;
+        bool isfitness;
         explicit GeneticValueToFitnessMap(std::size_t ndim, const maps_to_fitness& m)
             : total_dim{ndim}, isfitness{m.get()}
         {
         }
+
         virtual ~GeneticValueToFitnessMap() = default;
+        GeneticValueToFitnessMap(const GeneticValueToFitnessMap&)=delete;
+        GeneticValueToFitnessMap(GeneticValueToFitnessMap&&)=default;
+        GeneticValueToFitnessMap& operator=(const GeneticValueToFitnessMap&)=delete;
+        GeneticValueToFitnessMap& operator=(GeneticValueToFitnessMap&&)=default;
+
         virtual double
         operator()(const DiploidGeneticValueToFitnessData /*data*/) const = 0;
         virtual void update(const DiploidPopulation& /*pop*/) = 0;

--- a/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/MultivariateGSSmo.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_value_to_fitness/MultivariateGSSmo.hpp
@@ -84,7 +84,7 @@ namespace fwdpy11
         std::shared_ptr<GeneticValueToFitnessMap>
         clone() const override
         {
-            return std::make_shared<MultivariateGSSmo>(*this);
+            return std::make_shared<MultivariateGSSmo>(optima);
         }
 
         template <typename poptype>

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidGeneticValue.hpp
@@ -73,6 +73,7 @@ namespace fwdpy11
         DiploidGeneticValue(const DiploidGeneticValue&) = delete;
         DiploidGeneticValue(DiploidGeneticValue&&) = default;
         DiploidGeneticValue& operator=(const DiploidGeneticValue&) = delete;
+        DiploidGeneticValue& operator=(DiploidGeneticValue&&) = default;
 
         virtual double calculate_gvalue(const DiploidGeneticValueData data) = 0;
 

--- a/fwdpy11/headers/fwdpy11/gsl/gsl_error_handler_wrapper.hpp
+++ b/fwdpy11/headers/fwdpy11/gsl/gsl_error_handler_wrapper.hpp
@@ -64,9 +64,14 @@ namespace fwdpy11
         gsl_scoped_convert_error_to_exception(
             const gsl_scoped_convert_error_to_exception&)
             = delete;
+        gsl_scoped_convert_error_to_exception(gsl_scoped_convert_error_to_exception&&)
+            = default;
         gsl_scoped_convert_error_to_exception&
         operator=(const gsl_scoped_convert_error_to_exception&)
             = delete;
+        gsl_scoped_convert_error_to_exception&
+        operator=(gsl_scoped_convert_error_to_exception&&)
+            = default;
     };
 
     struct gsl_scoped_disable_error_handler_wrapper
@@ -85,9 +90,16 @@ namespace fwdpy11
         gsl_scoped_disable_error_handler_wrapper(
             const gsl_scoped_disable_error_handler_wrapper&)
             = delete;
+        gsl_scoped_disable_error_handler_wrapper(
+            gsl_scoped_disable_error_handler_wrapper&&)
+            = default;
+
         gsl_scoped_disable_error_handler_wrapper&
         operator=(const gsl_scoped_disable_error_handler_wrapper&)
             = delete;
+        gsl_scoped_disable_error_handler_wrapper&
+        operator=(gsl_scoped_disable_error_handler_wrapper&&)
+            = default;
     };
 } // namespace fwdpy11
 

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/ExponentialDominance.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/ExponentialDominance.hpp
@@ -26,7 +26,7 @@ namespace fwdpy11
         std::shared_ptr<MutationDominance>
         clone() const override final
         {
-            return std::make_shared<ExponentialDominance>(*this);
+            return std::make_shared<ExponentialDominance>(mean);
         }
     };
 }

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
@@ -30,7 +30,7 @@ namespace fwdpy11
         std::shared_ptr<MutationDominance>
         clone() const override final
         {
-            return std::make_shared<LargeEffectExponentiallyRecessive>(*this);
+            return std::make_shared<LargeEffectExponentiallyRecessive>(k, scaling);
         }
     };
 }

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/MutationDominance.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/MutationDominance.hpp
@@ -12,6 +12,11 @@ namespace fwdpy11
     struct MutationDominance
     {
         virtual ~MutationDominance() = default;
+        MutationDominance() = default;
+        MutationDominance(const MutationDominance&) = delete;
+        MutationDominance(MutationDominance&&) = default;
+        MutationDominance& operator=(const MutationDominance&) = delete;
+        MutationDominance& operator=(MutationDominance&&) = default;
         virtual double generate_dominance(const GSLrng_t& /*rng*/,
                                           const double /*effect_size*/) const = 0;
         virtual std::shared_ptr<MutationDominance> clone() const = 0;

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/UniformDominance.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/UniformDominance.hpp
@@ -32,7 +32,7 @@ namespace fwdpy11
         std::shared_ptr<MutationDominance>
         clone() const override final
         {
-            return std::make_shared<UniformDominance>(*this);
+            return std::make_shared<UniformDominance>(lo, hi);
         }
     };
 }

--- a/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/GeneticMapUnit.hpp
@@ -49,6 +49,12 @@ namespace fwdpy11
             : ll_map_unit(std::move(input)), discrete_(discrete)
         {
         }
+        GeneticMapUnit(GeneticMapUnit&&)=default;
+
+        GeneticMapUnit(const GeneticMapUnit &) = delete;
+        GeneticMapUnit& operator=(const GeneticMapUnit &) = delete;
+        GeneticMapUnit& operator=(GeneticMapUnit &&) = default;
+
 
         ll_ptr_t
         ll_clone() const

--- a/fwdpy11/headers/fwdpy11/regions/LogNormalS.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/LogNormalS.hpp
@@ -46,7 +46,13 @@ namespace fwdpy11
         std::unique_ptr<Sregion>
         clone() const override
         {
-            return std::unique_ptr<LogNormalS>(new LogNormalS(*this));
+            if (std::isfinite(zeta))
+                {
+                    return std::unique_ptr<LogNormalS>(
+                        new LogNormalS(region, scaling, zeta, sigma, dominance));
+                }
+            return std::unique_ptr<LogNormalS>(
+                new LogNormalS(region, scaling, dominance));
         }
 
         std::uint32_t

--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -16,6 +16,11 @@ namespace fwdpy11
     struct GeneticMap
     {
         virtual ~GeneticMap() = default;
+        GeneticMap() = default;
+        GeneticMap(const GeneticMap&) = delete;
+        GeneticMap(GeneticMap&&) = default;
+        GeneticMap& operator=(const GeneticMap&)=delete;
+        GeneticMap& operator=(GeneticMap&&)=default;
         virtual std::vector<double> operator()(const GSLrng_t& rng) const = 0;
     };
 

--- a/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
@@ -20,7 +20,7 @@ namespace fwdpy11
     {
         Region region; // For returning positions
         double scaling;
-        const std::size_t total_dim;
+        std::size_t total_dim;
         std::shared_ptr<MutationDominance> dominance;
 
         virtual ~Sregion() = default;
@@ -39,6 +39,11 @@ namespace fwdpy11
                     throw std::invalid_argument("invalid dimension parameter");
                 }
         }
+
+        Sregion(const Sregion&) = delete;
+        Sregion(Sregion&&) = default;
+        Sregion& operator=(const Sregion&) = delete;
+        Sregion& operator=(Sregion&&) = default;
 
         inline double
         beg() const

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -157,7 +157,7 @@ namespace fwdpy11
         }
 
         void
-        fill_preserved_nodes()
+        fill_preserved_nodes() override
         {
             fill_sample_nodes_from_metadata(preserved_sample_nodes,
                                             ancient_sample_metadata);

--- a/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
+++ b/fwdpy11/src/genetic_value_noise/GaussianNoise.cc
@@ -24,7 +24,7 @@ struct GaussianNoise : public fwdpy11::GeneticValueNoise
     std::shared_ptr<fwdpy11::GeneticValueNoise>
     clone() const override
     {
-        return std::make_shared<GaussianNoise>(*this);
+        return std::make_shared<GaussianNoise>(sd, mean);
     }
 };
 

--- a/tests/EsizeZero.cc
+++ b/tests/EsizeZero.cc
@@ -14,7 +14,7 @@ struct EsizeZero : public fwdpy11::Sregion
     std::unique_ptr<fwdpy11::Sregion>
     clone() const override
     {
-        return std::unique_ptr<EsizeZero>(new EsizeZero(*this));
+        return std::unique_ptr<EsizeZero>(new EsizeZero(this->region));
     }
 
     double

--- a/tests/inherit_noise.cc
+++ b/tests/inherit_noise.cc
@@ -50,7 +50,7 @@ struct IneritedNoise : public fwdpy11::GeneticValueNoise
         return pybind11::bytes("IneritedNoise");
     }
 
-    static inline const IneritedNoise
+    static inline IneritedNoise
     unpickle(pybind11::object& o)
     {
         auto s = o.cast<std::string>();


### PR DESCRIPTION
Audit all C++ .cc files in the Python package with clang-tidy.

Example shell script for doing this:

```sh
#!/bin/bash

for i in $(find fwdpy11/src/ -name '*.cc')
do
    n=`basename $i .cc`
    echo $i
    clang-tidy $i -checks="cppcoreguidelines-special-member-functions" -header-filter=fwdpy11 -export-fixes=fixes/$n.yaml -- -I/usr/include/python3.8d -I./fwdpy11/headers/fwdpp -I./fwdpy11/headers -I$HOME/.local/include
done
```

Example processing of output:

```
grep define fixes/*|cut -d":" -f 3|sort | uniq
         'class ''DiploidGeneticValue'' defines a default destructor, a copy constructor, a copy assignment operator and a move constructor but does not define a move assignment operator'
         'class ''GeneticMap'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
         'class ''GeneticMapUnit'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
         'class ''GeneticValueNoise'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
         'class ''GeneticValueToFitnessMap'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
         'class ''gsl_scoped_convert_error_to_exception'' defines a non-default destructor, a copy constructor and a copy assignment operator but does not define a move constructor or a move assignment operator'
         'class ''gsl_scoped_disable_error_handler_wrapper'' defines a non-default destructor, a copy constructor and a copy assignment operator but does not define a move constructor or a move assignment operator'
         'class ''MutationDominance'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
         'class ''Sregion'' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator'
```