### PR TITLE
evolvets back end no longer depends on pybind11.

### DIFF
--- a/cpptests/Makefile.am
+++ b/cpptests/Makefile.am
@@ -9,9 +9,19 @@ fwdpy11_cpp_tests_SOURCES=fwdpy11_cpp_tests.cc \
 						  test_lowlevel_discrete_demography_objects.cc \
 						  discrete_demography_roundtrips.cc \
 						  discrete_demography_util.cc \
-						  test_MutationDominance.cc
+						  test_MutationDominance.cc \
+						  ../fwdpy11/src/evolve_population/evolvets.cc \
+						  ../fwdpy11/src/evolve_population/util.cc \
+						  ../fwdpy11/src/evolve_population/remove_extinct_genomes.cc \
+						  ../fwdpy11/src/evolve_population/remove_extinct_mutations.cc \
+						  ../fwdpy11/src/evolve_population/diploid_pop_fitness.cc \
+						  ../fwdpy11/src/evolve_population/runtime_checks.cc \
+						  ../fwdpy11/src/evolve_population/track_mutation_counts.cc \
+						  ../fwdpy11/src/evolve_population/track_ancestral_counts.cc \
+						  ../fwdpy11/src/evolve_population/index_and_count_mutations.cc \
+						  ../fwdpy11/src/evolve_population/cleanup_metadata.cc
 
-AM_CPPFLAGS=-I../fwdpy11/headers -I../fwdpy11/headers/fwdpp 
+AM_CPPFLAGS=-I../fwdpy11/headers -I../fwdpy11/headers/fwdpp -I../fwdpy11/src/evolve_population
 AM_CXXFLAGS=-W -Wall --coverage -DBOOST_TEST_DYN_LINK
 
 AM_LIBS=-lboost_unit_test_framework
@@ -25,6 +35,9 @@ clean-local:
 	find . -name '*.gcov' | xargs rm -f
 	find . -name '*.gcda' | xargs rm -f
 	find . -name '*.gcno' | xargs rm -f
+	find ../fwdpy11/src -name '*.gcov' | xargs rm -f
+	find ../fwdpy11/src -name '*.gcda' | xargs rm -f
+	find ../fwdpy11/src -name '*.gcno' | xargs rm -f
 	rm -f *.info
 	rm -rf fwdpy11_coverage
 

--- a/cpptests/configure.ac
+++ b/cpptests/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([fwdpy11_cpp_tests], 0.0)
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_PROG_CC
 AC_PROG_CXX
 AC_LANG(C++)

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -73,7 +73,8 @@ set(TS_SOURCES src/ts/init.cc src/ts/TreeIterator.cc src/ts/VariantIterator.cc
     src/ts/node_traversal.cc)
 
 set(EVOLVE_POPULATION_SOURCES src/evolve_population/init.cc
-    src/evolve_population/with_tree_sequences.cc
+    src/evolve_population/_evolvets.cc
+    src/evolve_population/evolvets.cc
     src/evolve_population/util.cc
     src/evolve_population/cleanup_metadata.cc
     src/evolve_population/diploid_pop_fitness.cc

--- a/fwdpy11/src/evolve_population/_evolvets.cc
+++ b/fwdpy11/src/evolve_population/_evolvets.cc
@@ -1,0 +1,33 @@
+// Wright-Fisher simulation for a fwdpy11::DiploidPopulation with
+// tree sequences.
+//
+// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include "evolvets.hpp"
+#include <fwdpy11/discrete_demography/simulation/demographic_model_state.hpp>
+
+namespace py = pybind11;
+
+void
+init_evolve_with_tree_sequences(py::module &m)
+{
+    m.def("evolve_with_tree_sequences", &evolve_with_tree_sequences);
+}

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -1,48 +1,13 @@
-// Wright-Fisher simulation for a fwdpy11::DiploidPopulation with
-// tree sequences.
-//
-// Copyright (C) 2017 Kevin Thornton <krthornt@uci.edu>
-//
-// This file is part of fwdpy11.
-//
-// fwdpy11 is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// fwdpy11 is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
-//
-
-#include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-#include <pybind11/stl.h>
-#include <functional>
-#include <cmath>
-#include <stdexcept>
 #include <fwdpp/simparams.hpp>
 #include <fwdpp/ts/simplify_tables.hpp>
 #include <fwdpp/ts/simplify_tables_output.hpp>
 #include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/recording/edge_buffer.hpp>
 #include <fwdpp/ts/make_simplifier_state.hpp>
-#include <fwdpy11/rng.hpp>
-#include <fwdpy11/types/DiploidPopulation.hpp>
-#include <fwdpy11/genetic_values/dgvalue_pointer_vector.hpp>
+#include <fwdpp/ts/recycling.hpp>
+#include <fwdpy11/gsl/gsl_error_handler_wrapper.hpp>
 #include <fwdpy11/evolvets/evolve_generation_ts.hpp>
 #include <fwdpy11/evolvets/simplify_tables.hpp>
-#include <fwdpy11/evolvets/sample_recorder_types.hpp>
-#include <fwdpy11/regions/MutationRegions.hpp>
-#include <fwdpy11/regions/RecombinationRegions.hpp>
-#include <fwdpy11/discrete_demography/DiscreteDemography.hpp>
-#include <fwdpy11/gsl/gsl_error_handler_wrapper.hpp>
-#include <fwdpy11/samplers.hpp>
-#include <fwdpp/ts/recycling.hpp>
 #include "util.hpp"
 #include "diploid_pop_fitness.hpp"
 #include "index_and_count_mutations.hpp"
@@ -53,7 +18,8 @@
 #include "remove_extinct_genomes.hpp"
 #include "runtime_checks.hpp"
 
-namespace py = pybind11;
+#include "evolvets.hpp"
+
 namespace ddemog = fwdpy11::discrete_demography;
 
 void
@@ -647,8 +613,3 @@ evolve_with_tree_sequences(
     ddemog::save_model_state(std::move(current_demographic_state), demography);
 }
 
-void
-init_evolve_with_tree_sequences(py::module &m)
-{
-    m.def("evolve_with_tree_sequences", &evolve_with_tree_sequences);
-}

--- a/fwdpy11/src/evolve_population/evolvets.hpp
+++ b/fwdpy11/src/evolve_population/evolvets.hpp
@@ -1,0 +1,34 @@
+#include <functional>
+#include <cmath>
+#include <stdexcept>
+#include <fwdpy11/rng.hpp>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+#include <fwdpy11/genetic_values/dgvalue_pointer_vector.hpp>
+#include <fwdpy11/evolvets/sample_recorder_types.hpp>
+#include <fwdpy11/regions/MutationRegions.hpp>
+#include <fwdpy11/regions/RecombinationRegions.hpp>
+#include <fwdpy11/discrete_demography/DiscreteDemography.hpp>
+#include <fwdpy11/gsl/gsl_error_handler_wrapper.hpp>
+#include <fwdpy11/samplers.hpp>
+
+void evolve_with_tree_sequences(
+    const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
+    fwdpy11::SampleRecorder &sr, const unsigned simplification_interval,
+    fwdpy11::discrete_demography::DiscreteDemography &demography,
+    const std::uint32_t simlen, const double mu_neutral, const double mu_selected,
+    const fwdpy11::MutationRegions &mmodel, const fwdpy11::GeneticMap &rmodel,
+    // NOTE: gvalue_pointers is a change in 0.6.0,
+    // and the object holds non-const bare pointers
+    // to objects owned by Python.
+    fwdpy11::dgvalue_pointer_vector_ &gvalue_pointers,
+    fwdpy11::DiploidPopulation_sample_recorder recorder,
+    std::function<bool(const fwdpy11::DiploidPopulation &, const bool)>
+        &stopping_criteron,
+    // NOTE: this is the complement of what a user will input, which is "prune_selected"
+    const bool preserve_selected_fixations, const bool suppress_edge_table_indexing,
+    bool record_genotype_matrix, const bool track_mutation_counts_during_sim,
+    const bool remove_extinct_mutations_at_finish,
+    const bool reset_treeseqs_to_alive_nodes_after_simplification,
+    const bool preserve_first_generation,
+    const fwdpy11::DiploidPopulation_temporal_sampler &post_simplification_recorder);
+


### PR DESCRIPTION
Separate the C++ back end from the generation of the Python function.