### PR TITLE
Make local wheel building more robust

### DIFF
--- a/deployment/linux_wheels/build_and_audit.sh
+++ b/deployment/linux_wheels/build_and_audit.sh
@@ -5,7 +5,7 @@ do
     rm -rf build
     PYPATH=/opt/python/${py}
     PYBIN=${PYPATH}/bin/python 
-    ${PYBIN} -m pip install --no-cache -r requirements.txt
+    ${PYBIN} -m pip install --no-cache-dir -r requirements.txt
     PATH=${PYPATH}:$PATH ${PYBIN} setup.py build_ext -i
     PATH=${PYPATH}:$PATH ${PYBIN} setup.py bdist_wheel
 done

--- a/deployment/linux_wheels/install_wheels_run_tests.sh
+++ b/deployment/linux_wheels/install_wheels_run_tests.sh
@@ -15,9 +15,9 @@ do
     ${PYBIN} -m venv test-${py}
     source test-${py}/bin/activate
     which pip
-    pip install --upgrade --no-cache pip wheel
-    pip install fwdpy11 --only-binary fwdpy11 -f ../dist/wheelhouse
-    pip install --no-cache msprime pytest pytest-xdist
+    pip install --upgrade --no-cache-dir pip wheel
+    pip install fwdpy11 --pre --only-binary fwdpy11 -f ../dist/wheelhouse
+    pip install --no-cache-dir msprime pytest pytest-xdist
     python -m pytest tests -n 4
     deactivate
     rm -rf test-${py}


### PR DESCRIPTION
The current work flow will fail tests because pip will pull a stable wheel from pypi instead of the local wheel when the local wheel is not a stable release.  This PR fixes that behavior.