### PR TITLE
Add check that population is simulating

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,13 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## Next release
+
+C++ back-end
+
+* A population can now be checked that it is- or is not- being simulated.
+  {pr}`762`
+
 ## 0.15.1
 
 Point release

--- a/fwdpy11/_types/population_mixin.py
+++ b/fwdpy11/_types/population_mixin.py
@@ -50,6 +50,10 @@ class PopulationMixin(object):
         return self._generation  # type: ignore
 
     @property
+    def _is_simulating(self) -> bool:
+        return self.is_simulating  # type: ignore
+
+    @property
     def genetic_values(self) -> np.ndarray:
         """
         Return the genetic values as a readonly 2d numpy.ndarray.

--- a/fwdpy11/headers/fwdpy11/types/Population.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Population.hpp
@@ -58,6 +58,7 @@ namespace fwdpy11
 
         fwdpp::uint_t N;
         fwdpp::uint_t generation;
+        bool is_simulating;
 
         std::shared_ptr<fwdpp::ts::std_table_collection> tables;
         std::vector<fwdpp::ts::table_index_t> alive_nodes, preserved_sample_nodes;
@@ -69,7 +70,7 @@ namespace fwdpy11
         std::vector<double> genetic_value_matrix, ancient_sample_genetic_value_matrix;
 
         Population(fwdpp::uint_t N_, const double L)
-            : fwdpp_base{N_}, N{N_}, generation{0},
+            : fwdpp_base{N_}, N{N_}, generation{0}, is_simulating{false},
               tables(init_tables(N_, L)), alive_nodes{}, preserved_sample_nodes{},
               genetic_value_matrix{}, ancient_sample_genetic_value_matrix{}
         {

--- a/fwdpy11/src/fwdpy11_types/PopulationBase.cc
+++ b/fwdpy11/src/fwdpy11_types/PopulationBase.cc
@@ -60,6 +60,7 @@ init_PopulationBase(py::module& m)
     py::class_<fwdpy11::Population>(m, "PopulationBase")
         .def_readonly("_N", &fwdpy11::Population::N)
         .def_readonly("_generation", &fwdpy11::Population::generation)
+        .def_readonly("_is_simulating", &fwdpy11::Population::is_simulating)
         .def_readonly("_mutations", &fwdpy11::Population::mutations)
         .def_property_readonly("_mutations_ndarray",
                                [](const fwdpy11::Population& self) {

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -40,6 +40,7 @@ class Recorder(object):
         self.data = []
 
     def __call__(self, pop, recorder):
+        assert pop._is_simulating is True
         if len(self.timepoints) > 0:
             if self.timepoints[0] == pop.generation:
                 s = np.random.choice(pop.N, self.samplesize, replace=False)
@@ -561,7 +562,9 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
         self.params, self.rng, self.pop = set_up_quant_trait_model(3.0)
         self.stimes = [i for i in range(1, 101)]
         self.recorder = Recorder(42, 10, self.stimes)
+        assert self.pop._is_simulating is False
         fwdpy11.evolvets(self.rng, self.pop, self.params, 100, self.recorder)
+        assert self.pop._is_simulating is False
         assert (
             max(self.pop.mcounts) == 2 * self.pop.N
         ), "Nothing fixed, so test case is not helpful"


### PR DESCRIPTION
We may not want some functions to be applicable to populations mid-simulation.  This PR adds the ability to do a runtime check that a pop is or is not in the middle of a simulation.