### PR TITLE
Add functions to add mutations to populations.

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -12,6 +12,11 @@ Bug fixes
   {pr}`766`
   {issue}`765`
 
+New features
+
+* Add {func}`fwdpy11.DiploidPopulation.add_mutation`.
+* Add {class}`fwdpy11.NewMutationData`.
+
 C++ back-end
 
 * A population can now be checked that it is- or is not- being simulated.

--- a/doc/pages/types.md
+++ b/doc/pages/types.md
@@ -325,6 +325,9 @@ print(fwdpy11.NOGROWTH)
 
     .. autoattribute:: __init__
 
+.. autoclass:: fwdpy11.NewMutationData
+   :members:
+
 ```
 
 

--- a/fwdpy11/CMakeLists.txt
+++ b/fwdpy11/CMakeLists.txt
@@ -101,6 +101,10 @@ set (ARRAY_PROXY_SOURCES src/array_proxies/init.cc)
 set (MUTATION_DOMINANCE_SOURCES src/mutation_dominance/init.cc
      src/mutation_dominance/MutationDominance.cc)
 
+set (FUNCTION_SOURCES src/functions/init.cc
+     src/functions/add_mutation.cc
+     src/functions/_add_mutation.cc)
+
 set(ALL_SOURCES ${FWDPP_TYPES_SOURCES}
     ${FWDPY11_TYPES_SOURCES}
     ${REGION_SOURCES}
@@ -112,7 +116,8 @@ set(ALL_SOURCES ${FWDPP_TYPES_SOURCES}
     ${EVOLVE_POPULATION_SOURCES}
     ${DISCRETE_DEMOGRAPHY_SOURCES}
     ${ARRAY_PROXY_SOURCES}
-    ${MUTATION_DOMINANCE_SOURCES})
+    ${MUTATION_DOMINANCE_SOURCES}
+    ${FUNCTION_SOURCES})
 
 set(LTO_OPTIONS)
 if(ENABLE_PROFILING OR DISABLE_LTO)

--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -75,6 +75,7 @@ from ._types import (
     DiploidPopulation,
     TreeIterator,
     VariantIterator,
+    NewMutationData,
 )  # NOQA
 from ._types.demography_debugger import DemographyDebugger  # NOQA
 from ._types.model_params import ModelParams, MutationAndRecombinationRates  # NOQA

--- a/fwdpy11/_types/__init__.py
+++ b/fwdpy11/_types/__init__.py
@@ -27,3 +27,4 @@ from .data_matrix import DataMatrix  # NOQA
 from .data_matrix_iterator import DataMatrixIterator  # NOQA
 from .diploid_population import DiploidPopulation  # NOQA
 from .model_params import ModelParams  # NOQA
+from .new_mutation_data import NewMutationData  # NOQA

--- a/fwdpy11/_types/new_mutation_data.py
+++ b/fwdpy11/_types/new_mutation_data.py
@@ -1,0 +1,50 @@
+import typing
+
+import attr
+
+from .._fwdpy11 import ll_NewMutationData
+
+
+@attr.s(auto_attribs=True, frozen=True, repr_ns="fwdpy11", kw_only=True)
+class NewMutationData(ll_NewMutationData):
+    """
+    Data object for :func:`fwdpy11.DiploidPopulation.add_mutation`
+
+    .. versionadded:: 0.16.0
+
+    This class has the following attributes, whose names
+    are also `kwargs` for intitialization.  The attribute names
+    also determine the order of positional arguments:
+
+    :param effect_size: The fixed/univariate effect size.
+                        Will fill in :attr:`fwdpy11.Mutation.s`
+    :type effect_size: float
+    :param dominance: Heterozygous effect of the mutation.
+                      Will fill in :attr:`fwdpy11.Mutation.h`
+    :type dominance: float
+    :param esizes: Data to fill :attr:`fwdpy11.Mutation.esizes`.
+                   Default is `None`.
+    :type esizes: list[float]
+    :param heffects: Data to fill :attr:`fwdpy11.Mutation.heffects`.
+                     Default is `None`.
+    :type heffects: list[float]
+    :param label: Data for :attr:`fwdpy11.Mutation.label`.
+                  Default is 0.
+    :type label: int
+    """
+
+    effect_size: float
+    dominance: float
+    esizes: typing.Optional[typing.List[float]] = None
+    heffects: typing.Optional[typing.List[float]] = None
+    label: int = 0
+
+    def __attrs_post_init__(self):
+        if self.esizes is None and self.heffects is None:
+            super(NewMutationData, self).__init__(
+                self.effect_size, self.dominance, [], [], self.label
+            )
+        else:
+            super(NewMutationData, self).__init__(
+                self.effect_size, self.dominance, self.esizes, self.heffects, self.label
+            )

--- a/fwdpy11/src/_fwdpy11.cc
+++ b/fwdpy11/src/_fwdpy11.cc
@@ -22,6 +22,7 @@ void init_ts(py::module &);
 void init_evolution_functions(py::module &);
 void init_discrete_demography(py::module &m);
 void init_array_proxies(py::module &m);
+void initialize_functions(py::module & m);
 
 PYBIND11_MODULE(_fwdpy11, m)
 {
@@ -37,6 +38,7 @@ PYBIND11_MODULE(_fwdpy11, m)
     init_evolution_functions(m);
     init_discrete_demography(m);
     init_array_proxies(m);
+    initialize_functions(m);
 
     py::register_exception<fwdpy11::GSLError>(m, "GSLError");
 

--- a/fwdpy11/src/functions/_add_mutation.cc
+++ b/fwdpy11/src/functions/_add_mutation.cc
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "add_mutation.hpp"
+
+namespace py = pybind11;
+
+void
+init_add_mutation(py::module& m)
+{
+    m.def("_add_mutation", &add_mutation);
+
+    py::class_<new_mutation_data>(m, "ll_NewMutationData")
+        .def(py::init<double, double, std::vector<double>, std::vector<double>,
+                      decltype(fwdpy11::Mutation::xtra)>());
+}
+

--- a/fwdpy11/src/functions/add_mutation.cc
+++ b/fwdpy11/src/functions/add_mutation.cc
@@ -1,0 +1,343 @@
+//
+// Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <stdexcept>
+#include <algorithm>
+#include <fwdpy11/rng.hpp>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+#include <fwdpy11/policies/mutation.hpp>
+#include <fwdpp/ts/marginal_tree_functions/nodes.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
+#include <fwdpp/ts/marginal_tree_functions/samples.hpp>
+#include <fwdpp/ts/tree_visitor.hpp>
+#include <fwdpp/mutate_recombine.hpp>
+#include <gsl/gsl_randist.h>
+
+#include "add_mutation.hpp"
+
+new_mutation_data::new_mutation_data(double e, double h, std::vector<double> esizes,
+                                     std::vector<double> heffects,
+                                     decltype(fwdpy11::Mutation::xtra) l)
+    : effect_size{e}, dominance{h}, esizes{std::move(esizes)},
+      heffects{std::move(heffects)}, label{l}
+{
+    if (e == 0.0
+        && std::all_of(begin(esizes), end(esizes), [](double d) { return d == 0.0; }))
+        {
+            throw std::invalid_argument("new mutation must have non-zero effect size");
+        }
+    if (!std::isfinite(e) || std::any_of(begin(esizes), end(esizes), [](double d) {
+            return !std::isfinite(d);
+        }))
+        {
+            throw std::invalid_argument("all effect size values must be finite");
+        }
+    if (!std::isfinite(dominance)
+        || std::any_of(begin(heffects), end(heffects),
+                       [](double d) { return !std::isfinite(d); }))
+        {
+            throw std::invalid_argument("dominance values must all be finite");
+        }
+    if (esizes.size() != heffects.size())
+        {
+            throw std::invalid_argument(
+                "effect size and dominance vectors must have the same length");
+        }
+}
+
+namespace
+{
+    struct candidate_node_map
+    {
+        double left, right;
+        // The candidate node and its parent id
+        fwdpp::ts::table_index_t node, parent;
+        // The sample nodes below node
+        std::vector<fwdpp::ts::table_index_t> descendants;
+
+        candidate_node_map(double l, double r, fwdpp::ts::table_index_t n,
+                           fwdpp::ts::table_index_t p,
+                           std::vector<fwdpp::ts::table_index_t> d)
+            : left{l}, right{r}, node{n}, parent{p}, descendants{std::move(d)}
+        {
+        }
+    };
+
+    std::vector<candidate_node_map>
+    generate_canidate_list(const double left, const double right,
+                           const unsigned ndescendants,
+                           const fwdpp::ts::table_index_t deme,
+                           const fwdpy11::DiploidPopulation& pop)
+    {
+        std::vector<fwdpp::ts::table_index_t> samples;
+        for (auto& dip : pop.diploid_metadata)
+            {
+                for (auto i : dip.nodes)
+                    {
+                        samples.push_back(i);
+                    }
+            }
+
+        auto tv = fwdpp::ts::tree_visitor<fwdpp::ts::std_table_collection>(
+            *pop.tables, samples, fwdpp::ts::update_samples_list(true));
+
+        std::vector<candidate_node_map> candidates;
+
+        while (tv())
+            {
+                auto& tree = tv.tree();
+                if (tree.left < right && tree.right >= left)
+                    {
+                        fwdpp::ts::node_iterator ni(tree, fwdpp::ts::nodes_preorder());
+                        auto n = ni();
+                        while (n != fwdpp::ts::NULL_INDEX)
+                            {
+                                if (tree.leaf_counts[n]
+                                    == static_cast<fwdpp::ts::table_index_t>(
+                                        ndescendants))
+                                    {
+                                        // Then this is a node in this tree
+                                        // that is a candidate for mutation
+                                        // placement
+                                        std::vector<fwdpp::ts::table_index_t>
+                                            descendants;
+                                        fwdpp::ts::samples_iterator si(
+                                            tree, n,
+                                            fwdpp::ts::convert_sample_index_to_nodes(
+                                                true));
+                                        auto s = si();
+                                        while (s != fwdpp::ts::NULL_INDEX)
+                                            {
+                                                descendants.push_back(s);
+                                                s = si();
+                                            }
+                                        if (deme < 0
+                                            || (deme >= 0
+                                                && std::all_of(
+                                                    begin(descendants), end(descendants),
+                                                    [&pop,
+                                                     deme](fwdpp::ts::table_index_t i) {
+                                                        return pop.tables->nodes[i].deme
+                                                               == deme;
+                                                    })))
+                                            {
+                                                candidates.emplace_back(
+                                                    std::max(tree.left, left),
+                                                    std::min(tree.right, right), n,
+                                                    tree.parents[n],
+                                                    std::move(descendants));
+                                            }
+                                    }
+                                n = ni();
+                            }
+                    }
+                if (tree.left >= right)
+                    {
+                        break;
+                    }
+            }
+        return candidates;
+    }
+}
+
+std::size_t
+add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right,
+             const fwdpp::ts::table_index_t ndescendants,
+             const fwdpp::ts::table_index_t deme, const new_mutation_data& data,
+             fwdpy11::DiploidPopulation& pop)
+{
+    // TODO: tables must be indexed!
+    if (pop.is_simulating)
+        {
+            throw std::runtime_error(
+                "mutations cannot be added to a population during simulation");
+        }
+    if (right <= left)
+        {
+            throw std::invalid_argument("right must be > left");
+        }
+    if (left < 0.0 || left >= pop.tables->genome_length())
+        {
+            throw std::invalid_argument("left must be 0 <= x < genome length");
+        }
+    if (right <= 0. || right > pop.tables->genome_length())
+        {
+            throw std::invalid_argument("right must be 0 < x <= genome length");
+        }
+    if (!std::isfinite(right) || !std::isfinite(left))
+        {
+            throw std::invalid_argument("left and right must both be finite");
+        }
+    if (pop.tables->edges.empty())
+        {
+            throw std::invalid_argument(
+                "a population must have ancestry in order to add mutations");
+        }
+    if (ndescendants < 1)
+        {
+            throw std::invalid_argument("number of descendants must be >= 1");
+        }
+    if (deme >= 0)
+        {
+            bool found = false;
+            for (auto& dip : pop.diploid_metadata)
+                {
+                    if (dip.deme == deme)
+                        {
+                            found = true;
+                            break;
+                        }
+                }
+            if (!found)
+                {
+                    throw std::invalid_argument(
+                        "no alive individuals have the desired deme id");
+                }
+        }
+
+    std::size_t new_mutation_key = std::numeric_limits<std::size_t>::max();
+    auto candidates = generate_canidate_list(left, right, ndescendants, deme, pop);
+
+    if (candidates.empty())
+        {
+            return new_mutation_key;
+        }
+
+    // Randomly choose a candidate
+    std::size_t candidate
+        = static_cast<std::size_t>(gsl_ran_flat(rng.get(), 0, candidates.size()));
+
+    auto candidate_data = std::move(candidates[candidate]);
+    // TODO: what to do if candidates.empty() == true?
+
+    // NOTE: can we do all of what we need using existing
+    // mutate/recombine functions?  Gotta check the back-end.
+
+    // The new variant gets a derived state of 1
+    auto empty = fwdpp::empty_mutation_queue();
+    new_mutation_key = fwdpy11::infsites_Mutation(
+        empty, pop.mutations, pop.mut_lookup, false,
+        // The new mutation's origin time == the node time
+        static_cast<fwdpy11::mutation_origin_time>(
+            pop.tables->nodes[candidate_data.node].time),
+        // The lambdas will simply transfer input parameters to the new object.
+        [&rng, &candidate_data]() {
+            return gsl_ran_flat(rng.get(), candidate_data.left, candidate_data.right);
+        },
+        [&data]() { return data.effect_size; },
+        [&data](double) { return data.dominance; }, [&data]() { return data.esizes; },
+        [&data]() { return data.heffects; }, data.label);
+
+    pop.mcounts.push_back(ndescendants);
+    if (pop.mutations.size() != pop.mcounts.size())
+        {
+            throw std::runtime_error("mutations.size() != mcounts.size()");
+        }
+
+    // Update the tables
+    // 0 = ancestral_state
+    auto site_id = pop.tables->emplace_back_site(pop.mutations[new_mutation_key].pos,
+                                                 static_cast<std::int8_t>(0));
+
+    pop.tables->emplace_back_mutation(candidate_data.node, new_mutation_key, site_id,
+                                      static_cast<std::int8_t>(1), false);
+    fwdpp::ts::sort_mutation_table_and_rebuild_site_table(*pop.tables);
+
+    // Now, we update individual haploid genomes
+    std::vector<std::size_t> nodes_to_haploid_genome(
+        pop.tables->nodes.size(), std::numeric_limits<std::size_t>::max());
+    std::vector<std::pair<std::size_t, int>> nodes_to_individuals(
+        pop.tables->nodes.size(),
+        std::make_pair(std::numeric_limits<std::size_t>::max(), -1));
+
+    for (std::size_t i = 0; i < pop.diploid_metadata.size(); ++i)
+        {
+            auto node0 = pop.diploid_metadata[i].nodes[0];
+            auto node1 = pop.diploid_metadata[i].nodes[1];
+            nodes_to_haploid_genome[node0] = pop.diploids[i].first;
+            nodes_to_individuals[node0] = std::make_pair(i, 0);
+            nodes_to_haploid_genome[node1] = pop.diploids[i].second;
+            nodes_to_individuals[node1] = std::make_pair(i, 1);
+        }
+
+    for (auto n : candidate_data.descendants)
+        {
+            if (nodes_to_haploid_genome[static_cast<std::size_t>(n)]
+                == std::numeric_limits<std::size_t>::max())
+                {
+                    throw std::runtime_error("bad node to genome mapping");
+                }
+            if (deme >= 0)
+                {
+                    if (pop.tables->nodes[n].deme != deme)
+                        {
+                            throw std::runtime_error("unexpected descendant deme");
+                        }
+                }
+            if (pop.haploid_genomes[nodes_to_haploid_genome[n]].n == 0)
+                {
+                    throw std::runtime_error(
+                        "attempting to mutate an extinct haploid_genome");
+                }
+            fwdpp::haploid_genome new_genome(1);
+            auto itr = std::upper_bound(
+                begin(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
+                end(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
+                new_mutation_key, [&pop](const auto new_key, const auto key) {
+                    return pop.mutations[new_key].pos < pop.mutations[key].pos;
+                });
+            std::copy(begin(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
+                      itr, std::back_inserter(new_genome.smutations));
+            new_genome.smutations.push_back(new_mutation_key);
+            std::copy(itr,
+                      end(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
+                      std::back_inserter(new_genome.smutations));
+
+            // decrement the original genome count
+            pop.haploid_genomes[nodes_to_haploid_genome[n]].n--;
+
+            auto ind = nodes_to_individuals[n];
+            if (ind.first == std::numeric_limits<std::size_t>::max())
+                {
+                    throw std::runtime_error("bad node to individual mapping");
+                }
+            // Add the new genome to the pop
+            if (new_genome.smutations.empty())
+                {
+                    throw std::runtime_error("new genome is empty");
+                }
+            pop.haploid_genomes.emplace_back(std::move(new_genome));
+            if (ind.second == 0)
+                {
+                    pop.diploids[ind.first].first = pop.haploid_genomes.size() - 1;
+                }
+            else if (ind.second == 1)
+                {
+                    pop.diploids[ind.first].second = pop.haploid_genomes.size() - 1;
+                }
+            else
+                {
+                    throw std::runtime_error("bad reference to diploid genome");
+                }
+        }
+
+    return new_mutation_key;
+}

--- a/fwdpy11/src/functions/add_mutation.hpp
+++ b/fwdpy11/src/functions/add_mutation.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <vector>
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpy11/types/DiploidPopulation.hpp>
+#include <fwdpy11/rng.hpp>
+
+struct new_mutation_data
+{
+    double effect_size, dominance;
+    std::vector<double> esizes, heffects;
+    decltype(fwdpy11::Mutation::xtra) label;
+
+    new_mutation_data(double e, double h, std::vector<double> esizes,
+                      std::vector<double> heffects, decltype(fwdpy11::Mutation::xtra) l);
+};
+
+std::size_t add_mutation(const fwdpy11::GSLrng_t& rng, const double left,
+                         const double right, const fwdpp::ts::table_index_t ndescendants,
+                         const fwdpp::ts::table_index_t deme,
+                         const new_mutation_data& data, fwdpy11::DiploidPopulation& pop);

--- a/fwdpy11/src/functions/init.cc
+++ b/fwdpy11/src/functions/init.cc
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+//
+// This file is part of fwdpy11.
+//
+// fwdpy11 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// fwdpy11 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void init_add_mutation(py::module &);
+
+void initialize_functions(py::module & m)
+{
+    init_add_mutation(m);
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,3 +93,23 @@ migrations:
 - {demes: [CEU, CHB], rate: 9.6e-5}
 """
     return demes.loads(yaml)
+
+
+@pytest.fixture
+def small_split_model():
+    yaml = """
+description: Two deme model.
+time_units: generations
+demes:
+- name: ancestral
+  description: ancestral deme
+  epochs:
+  - {start_size: 100}
+- name: deme1
+  description: child deme
+  start_time: 100
+  epochs:
+  - {start_size: 100}
+  ancestors: [ancestral]
+"""
+    return demes.loads(yaml)

--- a/tests/test_add_mutation.py
+++ b/tests/test_add_mutation.py
@@ -1,0 +1,258 @@
+#
+# Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import fwdpy11
+import msprime
+import numpy as np
+import pytest
+
+
+# NOTE: this is copied from test/test_tree_sequences.py
+# FIXME: this should be a more general fixture?
+@pytest.fixture
+def set_up_quant_trait_model(simlen=1.0):
+    # TODO add neutral variants
+    N = 1000
+    demography = fwdpy11.DiscreteDemography()
+    rho = 2.0
+    # theta = 100.
+    # nreps = 500
+    # mu = theta/(4*N)
+    r = rho / (4 * N)
+    Opt = fwdpy11.Optimum
+    GSSmo = fwdpy11.GSSmo(
+        [Opt(when=0, optimum=0.0, VS=1.0), Opt(when=N, optimum=1.0, VS=1.0)]
+    )
+    a = fwdpy11.Additive(2.0, GSSmo)
+    p = {
+        "nregions": [],
+        "sregions": [fwdpy11.GaussianS(0, 1, 1, 0.25)],
+        "recregions": [fwdpy11.Region(0, 1, 1)],
+        "rates": (0.0, 0.025, r),
+        "gvalue": a,
+        "prune_selected": False,
+        "demography": demography,
+        "simlen": np.rint(simlen * N).astype(int),
+    }
+    params = fwdpy11.ModelParams(**p)
+    rng = fwdpy11.GSLrng(101 * 45 * 110 * 210)
+    pop = fwdpy11.DiploidPopulation(N, 1.0)
+    return params, rng, pop
+
+
+def test_new_mutation_data_bad_construction():
+    with pytest.raises(ValueError):
+        # Mutation is neutral
+        fwdpy11.NewMutationData(effect_size=0.0, dominance=1.0)
+
+    with pytest.raises(ValueError):
+        fwdpy11.NewMutationData(
+            effect_size=np.nan,
+            dominance=1.0,
+        )
+
+    with pytest.raises(ValueError):
+        fwdpy11.NewMutationData(
+            effect_size=-1e-3,
+            dominance=np.nan,
+        )
+
+    with pytest.raises(ValueError):
+        fwdpy11.NewMutationData(
+            effect_size=0.0,  # 0
+            dominance=np.nan,
+            esizes=[0.0] * 4,  # all 0
+            heffects=[0.5] * 4,
+        )
+
+    with pytest.raises(ValueError):
+        fwdpy11.NewMutationData(
+            effect_size=1e-3,
+            dominance=np.nan,
+            esizes=[0.0] * 4,  # length 4
+            heffects=[0.5] * 5,  # length 5
+        )
+
+
+@pytest.mark.parametrize("ndescendants", [1, 2, 3, 4, 5, 10])
+def test_add_mutation_in_single_deme(ndescendants):
+    ts = msprime.sim_ancestry(
+        50, population_size=50, sequence_length=10, random_seed=612534
+    )
+    pop = fwdpy11.DiploidPopulation.create_from_tskit(ts)
+    data = fwdpy11.NewMutationData(effect_size=-1e-3, dominance=1.0)
+    rng = fwdpy11.GSLrng(42)
+    key = pop.add_mutation(rng, ndescendants=ndescendants, data=data)
+    # Skip over cases where ndescendants could not be satisfied
+    if key is not None:
+        assert key == 0
+        assert pop.mcounts[key] == ndescendants
+
+        count = 0
+        for d in pop.diploids:
+            for i in [d.first, d.second]:
+                assert i >= 0
+                assert i < len(pop.haploid_genomes)
+                for k in pop.haploid_genomes[i].smutations:
+                    if k == key:
+                        count += 1
+        assert count == pop.mcounts[key]
+
+
+@pytest.mark.parametrize("ndescendants", [1, 2, 3, 4, 5, 10])
+@pytest.mark.parametrize("deme", [0, 1])
+def test_add_mutation_in_two_deme_model(deme, ndescendants, small_split_model):
+    demog = msprime.Demography.from_demes(small_split_model)
+    ts = msprime.sim_ancestry(
+        samples={0: 50, 1: 50},
+        random_seed=654321,
+        sequence_length=1.0,
+        demography=demog,
+        recombination_rate=1,
+        discrete_genome=False,
+    )
+    pop = fwdpy11.DiploidPopulation.create_from_tskit(ts)
+    data = fwdpy11.NewMutationData(effect_size=-1e-3, dominance=1.0)
+    rng = fwdpy11.GSLrng(42)
+    key = pop.add_mutation(rng, ndescendants=ndescendants, deme=deme, data=data)
+    # Skip over cases where ndescendants could not be satisfied
+    if key is not None:
+        assert key == 0
+        assert pop.mcounts[key] == ndescendants
+
+        count = 0
+        for di, d in enumerate(pop.diploids):
+            for i in [d.first, d.second]:
+                assert i >= 0
+                assert i < len(pop.haploid_genomes)
+                for k in pop.haploid_genomes[i].smutations:
+                    if k == key:
+                        assert pop.diploid_metadata[di].deme == deme
+                        count += 1
+        assert count == pop.mcounts[key]
+
+
+@pytest.mark.parametrize("ndescendants", [3, 4, 5, 10])
+@pytest.mark.parametrize("deme", [0, 1])
+@pytest.mark.parametrize("window", [(0.3, 0.6), (0.7, 0.88)])
+@pytest.mark.parametrize("msprime_seed", [654321, 12345, 111, 222])
+@pytest.mark.parametrize("fwdpy11_seed", [123451])
+def test_add_mutation_in_two_deme_model_windows(
+    deme, ndescendants, small_split_model, window, msprime_seed, fwdpy11_seed
+):
+    demog = msprime.Demography.from_demes(small_split_model)
+    ts = msprime.sim_ancestry(
+        samples={0: 50, 1: 50},
+        random_seed=msprime_seed,
+        sequence_length=1.0,
+        demography=demog,
+        recombination_rate=1,
+        discrete_genome=False,
+    )
+    pop = fwdpy11.DiploidPopulation.create_from_tskit(ts)
+    data = fwdpy11.NewMutationData(effect_size=-1e-3, dominance=1.0)
+    rng = fwdpy11.GSLrng(fwdpy11_seed)
+    key = pop.add_mutation(
+        rng, window=window, ndescendants=ndescendants, deme=deme, data=data
+    )
+    # Skip over cases where ndescendants could not be satisfied
+    if key is not None:
+        assert key == 0
+        assert pop.mcounts[key] == ndescendants
+
+        pos = pop.mutations[key].pos
+        assert pos >= window[0]
+        assert pos < window[1]
+
+        count = 0
+        for di, d in enumerate(pop.diploids):
+            for i in [d.first, d.second]:
+                assert i >= 0
+                assert i < len(pop.haploid_genomes)
+                for k in pop.haploid_genomes[i].smutations:
+                    if k == key:
+                        assert pop.diploid_metadata[di].deme == deme
+                        count += 1
+        assert count == pop.mcounts[key]
+
+
+@pytest.mark.parametrize("ndescendants", [1])
+@pytest.mark.parametrize("deme", [0])
+def test_add_mutation_in_bad_window(deme, ndescendants, small_split_model):
+    demog = msprime.Demography.from_demes(small_split_model)
+    ts = msprime.sim_ancestry(
+        samples={0: 50, 1: 50},
+        random_seed=654321,
+        sequence_length=1.0,
+        demography=demog,
+        recombination_rate=1,
+        discrete_genome=False,
+    )
+    pop = fwdpy11.DiploidPopulation.create_from_tskit(ts)
+    data = fwdpy11.NewMutationData(effect_size=0.3, dominance=1.0)
+    rng = fwdpy11.GSLrng(1234)
+    with pytest.raises(ValueError):
+        pop.add_mutation(
+            rng, window=(-1, pop.tables.genome_length), ndescendants=1, data=data
+        )
+
+
+def test_adding_to_evolved_pop(set_up_quant_trait_model):
+    params, rng, pop = set_up_quant_trait_model
+    fwdpy11.evolvets(rng, pop, params, simplification_interval=100)
+    assert len(pop.tables.mutations) > 0
+    data = fwdpy11.NewMutationData(effect_size=0.3, dominance=1.0)
+    key = pop.add_mutation(rng, ndescendants=1, data=data)
+    assert key is not None
+    assert pop.mcounts[key] == 1
+    count = 0
+    for d in pop.diploids:
+        for i in [d.first, d.second]:
+            assert i >= 0
+            assert i < len(pop.haploid_genomes)
+            for k in pop.haploid_genomes[i].smutations:
+                if k == key:
+                    count += 1
+    assert count == pop.mcounts[key]
+
+
+def test_attempting_to_add_during_a_simulation(set_up_quant_trait_model):
+    params, rng, pop = set_up_quant_trait_model
+
+    class InvalidRecorder(object):
+        def __init__(self):
+            self.rng = fwdpy11.GSLrng(101)
+            self.data = fwdpy11.NewMutationData(effect_size=0.3, dominance=1.0)
+
+        def __call__(self, pop, sampler):
+            if pop.generation > 5:
+                pop.add_mutation(self.rng, data=self.data)
+
+    with pytest.raises(RuntimeError):
+        fwdpy11.evolvets(
+            rng, pop, params, simplification_interval=100, recorder=InvalidRecorder()
+        )
+
+
+def test_attempt_to_add_to_pop_without_ancestry():
+    rng = fwdpy11.GSLrng(42)
+    pop = fwdpy11.DiploidPopulation(100, 1.0)
+    data = fwdpy11.NewMutationData(effect_size=0.3, dominance=1.0)
+    with pytest.raises(ValueError):
+        pop.add_mutation(rng, ndescendants=1, data=data)


### PR DESCRIPTION
- [x] Pop must have ancestry.  Should this be true for new singletons? -> `Yes` (for now, at least)
- [x] If we cannot satisfy the number of descendants, error out.  This will be tricky to test -> return `None`.
- [x] Allow to specify which deme the mutation is in.  If -1, then any number of valid descendants will be accepted.
- [x] Update many of the data structures: mutations, mcounts, and `mut_lookup` at the very least. The tables and genomes, too.
- [x] Make new Python class and function
- [x] tests
- [x] doc string
- [x] Test error when trying to run during simulation
- [x] license headers in new files
- [x] add test of evolve forwards in time then add.
- [x] document that individual genetic values are not updated