### PR TITLE
Add copy/deepcopy semantics for DiploidPopulation

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -15,7 +15,11 @@ Bug fixes
 New features
 
 * Add {func}`fwdpy11.DiploidPopulation.add_mutation`.
+  {pr}`764`
 * Add {class}`fwdpy11.NewMutationData`.
+  {pr}`764`
+* Add `__copy__` and `__deepcopy__` to {class}`fwdpy11.DiploidPopulation`.
+  {pr}`770`
 
 C++ back-end
 

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -42,6 +42,14 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
 
         self._pytables = TableCollection(self._tables)
 
+    def __copy__(self):
+        ll_pop = super(DiploidPopulation, self).__copy__()
+        return self.__class__(0, 0.0, ll_pop=ll_pop)
+
+    def __deepcopy__(self, memo):
+        ll_pop = super(DiploidPopulation, self).__deepcopy__(memo)
+        return self.__class__(0, 0.0, ll_pop=ll_pop)
+
     @classmethod
     def create_from_tskit(cls, ts: tskit.TreeSequence):
         """

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -26,6 +26,16 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
     sizes N1 and N2 and genome length L:
 
     fwdpy11.DiploidPopulation([N1, N2], L)
+
+    .. versionchanged:: 0.16.0
+
+        Added __copy__ and __deepcopy__.
+        In general, the correct way to copy
+        instances if this class is via :func:`copy.deepcopy`.
+        Calling :func:`copy.copy` will copy some of the underlying
+        C++ objects, but the two objects will share the same
+        table collection.  This situation of sharing is almost certainly
+        not what one wants.
     """
 
     def __init__(

--- a/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
+++ b/fwdpy11/src/fwdpy11_types/DiploidPopulation.cc
@@ -66,6 +66,17 @@ init_DiploidPopulation(py::module& m)
         .def("clear", &fwdpy11::DiploidPopulation::clear, "Clears all population data.")
         .def("__eq__", [](const fwdpy11::DiploidPopulation& lhs,
                           const fwdpy11::DiploidPopulation& rhs) { return lhs == rhs; })
+        .def("__copy__",
+             [](const fwdpy11::DiploidPopulation& self) {
+                 return fwdpy11::DiploidPopulation(self);
+             })
+        .def("__deepcopy__",
+             [](const fwdpy11::DiploidPopulation& self, py::dict) {
+                 auto rv = fwdpy11::DiploidPopulation(self);
+                 rv.tables
+                     = std::make_shared<fwdpp::ts::std_table_collection>(*self.tables);
+                 return rv;
+             })
         .def_readonly("_diploids", &fwdpy11::DiploidPopulation::diploids)
         .def_readwrite("_diploid_metadata",
                        &fwdpy11::DiploidPopulation::diploid_metadata)
@@ -76,9 +87,7 @@ init_DiploidPopulation(py::module& m)
                  swap_with_empty(self.haploid_genomes);
              })
         .def("_clear_mutations",
-             [](fwdpy11::DiploidPopulation& self) {
-                 swap_with_empty(self.mutations);
-             })
+             [](fwdpy11::DiploidPopulation& self) { swap_with_empty(self.mutations); })
         .def("_clear_diploid_metadata",
              [](fwdpy11::DiploidPopulation& self) {
                  swap_with_empty(self.diploid_metadata);


### PR DESCRIPTION
A naive copy.copy/deepcopy does not do the right thing.  This PR adds the magic functions to both base and sub classes.  Only the deep copy function does a deep copy of the table.  The copy function simply copies the underlying shared_ptr.