### PR TITLE
Add extra warnings to gcc builds

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
+          echo "CPPFLAGS=-Wextra -Weffc++ -Woverloaded-virtual -Wold-style-cast -Werror=effc++ -Werror=old-style-cast -Werror=overloaded-virtual -Werror=unused-parameter" >> $GITHUB_ENV
 
       - name: Install clang-10
         if: matrix.compiler == 'clang10'
@@ -91,7 +92,7 @@ jobs:
         run: |
           cd cpptests
           autoreconf --install
-          CC=$CC CXX=$CXX ./configure
+          CPPFLAGS=$CPPFLAGS CC=$CC CXX=$CXX ./configure
           make check
 
       - name: Compile extension module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ if (ENABLE_PROFILING)
 endif()
 
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
+
+if (CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wextra -Weffc++ -Woverloaded-virtual -Wold-style-cast -Werror=effc++ -Werror=old-style-cast -Werror=overloaded-virtual -Werror=unused-parameter")
+endif()
+
 add_subdirectory(fwdpy11)
 
 if(BUILD_UNIT_TESTS)

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -40,6 +40,11 @@ C++ back-end
 * A population can now be checked that it is- or is not- being simulated.
   {pr}`762`
 
+Build system
+
+* All GCC builds and CI tests on Ubuntu + GCC now apply a much stricter set of compiler options.
+  {pr}`779` {issue}`778`
+
 Dependencies
 
 * Bump `pillow` version in doc/requirements.txt.

--- a/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/evolve_generation_ts.hpp
@@ -166,7 +166,7 @@ namespace fwdpy11
                         next_index_local = offspring_node_2;
                     }
             }
-        assert(next_index_local == pop.tables->num_nodes() - 1);
+        assert(static_cast<std::size_t>(next_index_local) == pop.tables->num_nodes() - 1);
         if (next_index_local
             != static_cast<decltype(next_index_local)>(pop.tables->num_nodes()
                                                        - 1))

--- a/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
+++ b/fwdpy11/headers/fwdpy11/evolvets/simplify_tables.hpp
@@ -46,7 +46,7 @@ namespace fwdpy11
         fwdpp::ts::std_table_collection &tables, SimplificationState &simplifier_state,
         fwdpp::ts::simplify_tables_output & simplification_output,
         fwdpp::ts::edge_buffer &new_edge_buffer, const bool preserve_selected_fixations,
-        const bool simulating_neutral_variants, const bool suppress_edge_table_indexing)
+        const bool suppress_edge_table_indexing)
     {
         // As of 0.8.0, we do not need to sort edges!
         fwdpp::ts::sort_mutation_table(tables);
@@ -101,6 +101,9 @@ namespace fwdpy11
                 pop.mcounts_from_preserved_nodes.resize(pop.mcounts.size(), 0);
             }
 
+        // TODO: revisit this comment.
+        // in pr 779, we removed simulating_neutral_variants b/c it was unused.
+        //
         // If we are here, then the tables are indexed and mutations are counted.
         // If there are ancient samples and we are simulating neutral variants,
         // then we do not know their frequencies.  Thus, neutral

--- a/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
+++ b/fwdpy11/headers/fwdpy11/mutation_dominance/LargeEffectExponentiallyRecessive.hpp
@@ -21,7 +21,7 @@ namespace fwdpy11
         }
 
         double
-        generate_dominance(const GSLrng_t& rng,
+        generate_dominance(const GSLrng_t& /*rng*/,
                            const double effect_size) const override final
         {
             return scaling * std::exp(-k * std::abs(effect_size));

--- a/fwdpy11/headers/fwdpy11/regions/mvDES.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/mvDES.hpp
@@ -390,7 +390,8 @@ namespace fwdpy11
         }
 
         double
-        generate_dominance(const GSLrng_t &rng, const double esize) const override final
+        generate_dominance(const GSLrng_t & /*rng*/,
+                           const double /*esize*/) const override final
         {
             throw std::runtime_error("mvDES::generate_dominance is not implemented");
             return std::numeric_limits<double>::quiet_NaN();

--- a/fwdpy11/src/discrete_demography/DiscreteDemography.cc
+++ b/fwdpy11/src/discrete_demography/DiscreteDemography.cc
@@ -113,8 +113,7 @@ void
 init_DiscreteDemography(py::module& m)
 {
     // TODO: decide if we need to pass fitnesses via asdict?
-    py::class_<ddemog::demographic_model_state>(m, "_ll_DemographicModelState")
-        .def("asdict", [](const ddemog::demographic_model_state& self) {});
+    py::class_<ddemog::demographic_model_state>(m, "_ll_DemographicModelState");
     py::class_<ddemog::DiscreteDemography>(m, "_ll_DiscreteDemography")
         .def(py::init([](py::object mass_migration_events, py::object set_growth_rates,
                          py::object set_deme_sizes, py::object set_selfing_rates,

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -46,8 +46,7 @@ clear_edge_table_indexes(fwdpp::ts::std_table_collection &tables)
 template <typename SimplificationState>
 void
 simplification(
-    bool preserve_selected_fixations, bool simulating_neutral_variants,
-    bool suppress_edge_table_indexing,
+    bool preserve_selected_fixations, bool suppress_edge_table_indexing,
     bool reset_treeseqs_to_alive_nodes_after_simplification,
     const fwdpy11::DiploidPopulation_temporal_sampler &post_simplification_recorder,
     SimplificationState &simplifier_state,
@@ -59,8 +58,7 @@ simplification(
     fwdpy11::simplify_tables(pop, pop.mcounts_from_preserved_nodes,
                              alive_at_last_simplification, *pop.tables, simplifier_state,
                              simplification_output, new_edge_buffer,
-                             preserve_selected_fixations, simulating_neutral_variants,
-                             suppress_edge_table_indexing);
+                             preserve_selected_fixations, suppress_edge_table_indexing);
     if (pop.mcounts.size() != pop.mcounts_from_preserved_nodes.size())
         {
             throw std::runtime_error("evolvets: count vector size mismatch after "
@@ -432,7 +430,6 @@ evolve_with_tree_sequences(
             if (current_demographic_state->will_go_globally_extinct() == true)
                 {
                     simplification(preserve_selected_fixations,
-                                   simulating_neutral_variants,
                                    suppress_edge_table_indexing,
                                    reset_treeseqs_to_alive_nodes_after_simplification,
                                    post_simplification_recorder, *simplifier_state,
@@ -454,7 +451,6 @@ evolve_with_tree_sequences(
             if (gen % simplification_interval == 0.0)
                 {
                     simplification(preserve_selected_fixations,
-                                   simulating_neutral_variants,
                                    suppress_edge_table_indexing,
                                    reset_treeseqs_to_alive_nodes_after_simplification,
                                    post_simplification_recorder, *simplifier_state,
@@ -600,8 +596,7 @@ evolve_with_tree_sequences(
 
     if (!simplified)
         {
-            simplification(preserve_selected_fixations, simulating_neutral_variants,
-                           suppress_edge_table_indexing,
+            simplification(preserve_selected_fixations, suppress_edge_table_indexing,
                            reset_treeseqs_to_alive_nodes_after_simplification,
                            post_simplification_recorder, *simplifier_state,
                            simplification_output, *new_edge_buffer,

--- a/fwdpy11/src/regions/DiscreteDESD.cc
+++ b/fwdpy11/src/regions/DiscreteDESD.cc
@@ -64,18 +64,19 @@ class DiscreteDESD : public fwdpy11::Sregion
             recycling_bin, mutations, lookup_table, false, generation,
             [this, &rng]() { return region(rng); },
             [this, idx]() { return esize[idx] / scaling; },
-            [this, idx](const double esize) { return h[idx]; }, this->label());
+            [this, idx](const double /*esize*/) { return h[idx]; }, this->label());
     }
 
     double
-    from_mvnorm(const double /*deviate*/, const double P) const override
+    from_mvnorm(const double /*deviate*/, const double /*P*/) const override
     {
         throw std::runtime_error("not implemented yet");
         return 1.;
     }
 
     double
-    generate_dominance(const fwdpy11::GSLrng_t& rng, const double esize) const override
+    generate_dominance(const fwdpy11::GSLrng_t& /*rng*/,
+                       const double /*esize*/) const override
     {
         return std::numeric_limits<double>::quiet_NaN();
     }

--- a/fwdpy11/src/ts/DataMatrixIterator.cc
+++ b/fwdpy11/src/ts/DataMatrixIterator.cc
@@ -373,18 +373,6 @@ class DataMatrixIterator
                && pos < position_ranges[current_range].second;
     }
 
-    void
-    process_current_site(const fwdpp::ts::marginal_tree& tree, const site_table_itr itr)
-    {
-        // Make sure we skip mutants on the
-        // current tree but not in the current
-        // genomic interval.
-        if (!site_in_current_range(itr))
-            {
-                return;
-            }
-    }
-
     py::array_t<std::int8_t>
     genotype_matrix_wrapper(const fwdpp::state_matrix& sm,
                             const std::vector<std::size_t>& keys) const

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -78,7 +78,7 @@ class tree_visitor_wrapper
           first_mutation(tables_->mutations.begin()),
           end_of_mutations(tables_->mutations.end()), current_mutation(first_mutation),
           update_samples(update_samples_below), from(start), until(stop),
-          visitor(*tables_, samples,
+          visitor(*tables_, samples, preserved_nodes,
                   fwdpp::ts::update_samples_list(update_samples_below)),
           samples_below_buffer()
     {

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,6 @@ from distutils.version import LooseVersion
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-if "--weffcpp" in sys.argv:
-    USE_WEFFCPP = True
-    sys.argv.remove("--weffcpp")
-else:
-    USE_WEFFCPP = False
-
 if "--debug" in sys.argv:
     DEBUG_MODE = True
     sys.argv.remove("--debug")
@@ -108,8 +102,6 @@ class CMakeBuild(build_ext):
             env.get("CXXFLAGS", ""), self.distribution.get_version()
         )
 
-        if USE_WEFFCPP is True:
-            cmake_args.append("-DUSE_WEFFCPP=ON")
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         if SKIP_BUILDING_TESTS is True:


### PR DESCRIPTION
- [x] Modify Linux CI to add these options to the `./configure` step for the `cpp` tests.
- [x] Update change log
- [x] Decide if we want a general `-Werror`.  Probably not--gcc vs clang by macOS vs Linux is likely to come up with one combo failing when all others pass.  Perhaps just for the cpp tests, and maybe just on Ubuntu/gcc?
- [x] Should unused parameters be an error?