### PR TITLE
Additional tests for migrations

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,17 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## 0.15.2
+
+Point release
+
+Bug fixes
+
+* {class}`fwdpy11.SetMigrationRates` now uses a tolerance when checking that rates sum to 0 or 1.
+  {issue}`787`
+  {user}`apragsdale`
+  {user}`molpopgen`
+
 ## 0.15.1
 
 Point release

--- a/fwdpy11/headers/fwdpy11/discrete_demography/SetMigrationRates.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/SetMigrationRates.hpp
@@ -38,6 +38,22 @@ namespace fwdpy11
             std::uint32_t when;
             std::int32_t deme; // source deme
             std::vector<double> migrates;
+
+            void
+            validate_sum(double sum)
+            {
+                bool close_to_zero = std::fabs(sum - 0.0)
+                                     <= 10. * std::numeric_limits<double>::epsilon();
+                bool close_to_one = std::fabs(sum - 1.0)
+                                    <= 10. * std::numeric_limits<double>::epsilon();
+                if (!close_to_one && !close_to_zero)
+                    {
+                        throw std::invalid_argument(
+                            "migration rates must sum to ~0. or ~1. in "
+                            "a row.");
+                    }
+            }
+
             SetMigrationRates(std::uint32_t w, std::int32_t d, std::vector<double> r)
                 : when(w), deme(d), migrates(std::move(r))
             {
@@ -69,12 +85,7 @@ namespace fwdpy11
                     }
 
                 auto sum = std::accumulate(begin(migrates), end(migrates), 0.0);
-                if (sum != 0. && sum != 1.0)
-                    {
-                        throw std::invalid_argument(
-                            "migration rates must sum to 0. or 1. in "
-                            "a row.");
-                    }
+                validate_sum(sum);
             }
 
             SetMigrationRates(std::uint32_t w, std::vector<double> migmatrix)
@@ -113,11 +124,7 @@ namespace fwdpy11
                                     }
                                 sum += v;
                             }
-                        if (sum != 0.0 && sum != 1.0)
-                            {
-                                throw std::invalid_argument(
-                                    "migration matrix rows must sum to 0.0 or 1.0");
-                            }
+                        validate_sum(sum);
                     }
             }
         };

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -521,3 +521,192 @@ class TestPulseMigration(unittest.TestCase):
         self.assertTrue(
             np.all(self.demog.model.set_migration_rates[1].migrates == [0, 1])
         )
+
+
+def check_debugger_passes(demog):
+    try:
+        _ = fwdpy11.DemographyDebugger(
+            [100] * len(demog.metadata["initial_sizes"]), demog
+        )
+    except:
+        raise "unexpected exception"
+
+
+def three_way_continuous_migration():
+    b = demes.Builder(description="many migrations", time_units="generations")
+    b.add_deme(name="A", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="B", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="C", epochs=[dict(start_size=100, end_time=0)])
+    b.add_migration(demes=["A", "B", "C"], rate=0.1)
+    g = b.resolve()
+    return fwdpy11.discrete_demography.from_demes(g, 1)
+
+
+def three_way_continuous_migration_pairwise():
+    b = demes.Builder(description="many migrations", time_units="generations")
+    b.add_deme(name="A", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="B", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="C", epochs=[dict(start_size=100, end_time=0)])
+    b.add_migration(demes=["A", "B"], rate=0.1)
+    b.add_migration(demes=["A", "C"], rate=0.1)
+    b.add_migration(demes=["B", "C"], rate=0.1)
+    g = b.resolve()
+    return fwdpy11.discrete_demography.from_demes(g, 1)
+
+
+@pytest.mark.parametrize(
+    "demog",
+    [three_way_continuous_migration(), three_way_continuous_migration_pairwise()],
+)
+def test_three_way_continuous_migration_pairwise(demog):
+    check_debugger_passes(demog)
+    assert np.all(
+        demog.model.migmatrix.M
+        == np.array([[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]])
+    )
+
+
+def multiple_migrations_delayed():
+    b = demes.Builder(description="many migrations", time_units="generations")
+    b.add_deme(name="A", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="B", epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="C", epochs=[dict(start_size=100, end_time=0)])
+    b.add_migration(demes=["A", "B"], rate=0.1)
+    b.add_migration(demes=["B", "C"], rate=0.1)
+    b.add_migration(demes=["A", "C"], rate=0.1, start_time=100)
+    g = b.resolve()
+    return fwdpy11.discrete_demography.from_demes(g, 1)
+
+
+@pytest.mark.parametrize("demog", [multiple_migrations_delayed()])
+def test_multiple_migrations_delayed(demog):
+    check_debugger_passes(demog)
+    assert np.all(
+        demog.model.migmatrix.M
+        == np.array([[0.9, 0.1, 0], [0.1, 0.8, 0.1], [0, 0.1, 0.9]])
+    )
+    assert len(demog.model.set_migration_rates) == 2
+
+    for set_mig in demog.model.set_migration_rates:
+        assert set_mig.deme in [0, 2]
+        if set_mig.deme == 0:
+            assert np.all(set_mig.migrates == np.array([0.8, 0.1, 0.1]))
+        elif set_mig.deme == 2:
+            assert np.all(set_mig.migrates == np.array([0.1, 0.1, 0.8]))
+
+
+def splits_with_migrations():
+    b = demes.Builder(description="splits with migration", time_units="generations")
+    b.add_deme(name="A", epochs=[dict(start_size=100, end_time=100)])
+    b.add_deme(name="B", ancestors=["A"], epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="C", ancestors=["A"], epochs=[dict(start_size=100, end_time=50)])
+    b.add_deme(name="D", ancestors=["C"], epochs=[dict(start_size=100, end_time=0)])
+    b.add_deme(name="E", ancestors=["C"], epochs=[dict(start_size=100, end_time=0)])
+    b.add_migration(demes=["B", "C"], rate=0.1)
+    b.add_migration(demes=["B", "D"], rate=0.1)
+    b.add_migration(demes=["B", "E"], rate=0.1)
+    b.add_migration(demes=["D", "E"], rate=0.1)
+    g = b.resolve()
+    return fwdpy11.discrete_demography.from_demes(g, 1)
+
+
+@pytest.mark.parametrize("demog", [splits_with_migrations()])
+def test_splits_with_migrations(demog):
+    check_debugger_passes(demog)
+    M = np.zeros(25).reshape(5, 5)
+    M[0, 0] = 1
+    assert np.all(demog.model.migmatrix.M == M)
+    num_splits = 2
+    len_set_migs = 3 * num_splits + 2 + 3
+    assert len(demog.model.set_migration_rates) == len_set_migs
+
+
+def yaml_migration_1():
+    return """
+description: test model
+time_units: generations
+demes:
+  - name: A
+    epochs:
+      - end_time: 200
+        start_size: 100
+  - name: B
+    ancestors: [A]
+    epochs:
+      - end_time: 100
+        start_size: 100
+  - name: C
+    ancestors: [A]
+    epochs:
+    - end_time: 20
+      start_size: 100
+  - name: D
+    ancestors: [B]
+    epochs:
+      - end_time: 2
+        start_size: 100
+      - end_time: 0
+        start_size: 10
+  - name: E
+    ancestors: [B]
+    epochs:
+      - end_time: 2
+        start_size: 100
+      - end_time: 0
+        start_size: 30
+migrations:
+  - demes: [C, D]
+    rate: 6.228e-5
+  - demes: [D, E]
+    rate: 4.14e-5
+"""
+
+
+def yaml_migration_2():
+    """
+    Same model as previous yaml with deme name D changed to F to switch sort order.
+    """
+    return """description: test model
+time_units: generations
+demes:
+  - name: A
+    epochs:
+      - end_time: 200
+        start_size: 100
+  - name: B
+    ancestors: [A]
+    epochs:
+      - end_time: 100
+        start_size: 100
+  - name: C
+    ancestors: [A]
+    epochs:
+    - end_time: 20
+      start_size: 100
+  - name: F
+    ancestors: [B]
+    epochs:
+      - end_time: 2
+        start_size: 100
+      - end_time: 0
+        start_size: 10
+  - name: E
+    ancestors: [B]
+    epochs:
+      - end_time: 2
+        start_size: 100
+      - end_time: 0
+        start_size: 30
+migrations:
+  - demes: [C, F]
+    rate: 6.228e-5
+  - demes: [F, E]
+    rate: 4.14e-5
+"""
+
+
+@pytest.mark.parametrize("data", [yaml_migration_1(), yaml_migration_2()])
+def test_yamls_with_migration(data):
+    g = demes.loads(data)
+    demog = fwdpy11.discrete_demography.from_demes(g, 1)
+    check_debugger_passes(demog)


### PR DESCRIPTION
Relating to #787, there are additional tests for migration matrix row sums. At the bottom of `test_demes2fwdpy11.py`, there are two example YAMLs, one that currently passes while the other fails. The only difference is one of the population names is different. So there is some sorting issue going on that we should also address after allowing some tolerance for numerical error in migration matrix row sums.