### PR TITLE
fix population table export

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -13,6 +13,9 @@ Bug fixes
   {issue}`787`
   {user}`apragsdale`
   {user}`molpopgen`
+* Fix bug where the number of rows in a {class}`tskit.PopulationTable` were incorrect upon export via {meth}`fwdpy11.DiploidPopulation.dump_tables_to_tskit`.
+  Issue {issue}`792`.
+  Fixed in PR {pr}`793`.
 
 ## 0.15.1
 

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -252,6 +252,11 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
             Added `model_params`, `demes_graph`, `population_metadata`,
             `data` keyword args.
 
+        .. versionchanged:: 0.15.2
+
+            Fixed bug that could generate a :class:`tskit.PopulationTable`
+            with an incorrect number of rows.
+
         """
         return fwdpy11.tskit_tools._dump_tables_to_tskit._dump_tables_to_tskit(
             self,

--- a/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
+++ b/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
@@ -36,7 +36,12 @@ def _initializePopulationTable(
     tc.populations.metadata_schema = (
         fwdpy11.tskit_tools.metadata_schema.PopulationMetadata
     )
-    for i in sorted(np.unique(node_view["deme"])):
+    # Prior to 0.15.2, we just iterated over unique values.
+    # However, that was incorrect (see GitHub issue 792)
+    # because the possibility of demes going extinct could leave
+    # nodes in the tree in a way that resulted in population IDs
+    # being shifted, giving a LibraryError from tskit.
+    for i in range(node_view["deme"].max() + 1):
         if population_metadata is not None and i in population_metadata:
             tc.populations.add_row(metadata=population_metadata[i])
         else:

--- a/tests/test_tskit_export.py
+++ b/tests/test_tskit_export.py
@@ -1,0 +1,51 @@
+import demes
+import fwdpy11
+import pytest
+
+
+@pytest.fixture
+def model_triggering_issue_792():
+    yaml = """
+description: Two deme model where only one makes it to the end.
+time_units: generations
+demes:
+- name: ancestral
+  description: ancestral deme, two epochs
+  epochs:
+  - {end_time: 50, start_size: 50}
+- name: deme1
+  description: child 1
+  epochs:
+  - {start_size: 50, end_size: 50, end_time: 10}
+  ancestors: [ancestral]
+- name: deme2
+  description: child 2
+  epochs:
+  - {start_size: 50, end_size: 50, end_time: 0}
+  ancestors: [ancestral]
+"""
+    g = demes.loads(yaml)
+    return g
+
+
+def test_issue_792(model_triggering_issue_792):
+    """
+    Test of GitHub Issue 792
+    """
+    demog = fwdpy11.discrete_demography.from_demes(model_triggering_issue_792, burnin=1)
+    pop = fwdpy11.DiploidPopulation(100, 1)
+
+    pdict = {
+        "rates": (0, 0, 0),
+        "gvalue": fwdpy11.Multiplicative(2.0),
+        "simlen": demog.metadata["total_simulation_length"],
+        "demography": demog,
+    }
+
+    params = fwdpy11.ModelParams(**pdict)
+
+    rng = fwdpy11.GSLrng(100)
+
+    fwdpy11.evolvets(rng, pop, params, 10)
+
+    _ = pop.dump_tables_to_tskit()


### PR DESCRIPTION
- Exporting to tskit now uses the max deme ID in the node table to populate rows of the PopulationTable.
- update docstring for DiploidPopulation.dump_tables_to_tskit
