### PR TITLE
Use np.float64 instead of the deprecated np.float.

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -17,6 +17,12 @@ Bug fixes
   Issue {issue}`792`.
   Fixed in PR {pr}`793`.
 
+Minor changes
+
+* Remove use of deprecated `numpy` `dtype` in tests.
+  Issue {issue}`789`.
+  Fixed in PR {pr}`794`
+
 ## 0.15.1
 
 Point release

--- a/tests/test_metadata_encoding_with_tskit.py
+++ b/tests/test_metadata_encoding_with_tskit.py
@@ -29,10 +29,10 @@ import tskit
 
 np.random.seed(54321)
 
-MOCK_NODE_TABLE_DTYPE = [("time", np.float), ("deme", np.int32)]
+MOCK_NODE_TABLE_DTYPE = [("time", np.float64), ("deme", np.int32)]
 MOCK_EDGE_TABLE_DTYPE = [
-    ("left", np.float),
-    ("right", np.float),
+    ("left", np.float64),
+    ("right", np.float64),
     ("parent", np.int32),
     ("child", np.int32),
 ]


### PR DESCRIPTION
Fixes #789
