### PR TITLE
Fix back-end bugs in "late" demographic events.

### DIFF
--- a/cpptests/discrete_demography_fixtures.hpp
+++ b/cpptests/discrete_demography_fixtures.hpp
@@ -6,7 +6,7 @@
 #include "make_DiscreteDemography.hpp"
 #include "discrete_demography_roundtrips.hpp"
 
-struct mock_population_fixture
+struct population_fixture
 {
     fwdpy11::GSLrng_t rng;
     fwdpy11::DiploidPopulation pop;
@@ -28,7 +28,7 @@ struct mock_population_fixture
 
     using gsl_matrix_ptr = std::unique_ptr<gsl_matrix, gsl_matrix_deleter>;
 
-    mock_population_fixture()
+    population_fixture()
         : rng{416134}, pop(100, 1.0), mass_migrations{}, set_growth_rates{},
           set_deme_sizes{}, set_migration_rates{}, set_selfing_rates{}, migmatrix{}
     {

--- a/cpptests/discrete_demography_roundtrips.cc
+++ b/cpptests/discrete_demography_roundtrips.cc
@@ -73,13 +73,13 @@ DiscreteDemography_roundtrip(
                                 fitness_lookup);
                             if (pdata.deme1 != deme)
                                 {
-                                    rv.emplace_back(pop.generation + 1, pdata.deme1,
-                                                    deme, pdata.mating);
+                                    rv.emplace_back(pop.generation, pdata.deme1, deme,
+                                                    pdata.mating);
                                 }
                             if (pdata.deme2 != deme)
                                 {
-                                    rv.emplace_back(pop.generation + 1, pdata.deme2,
-                                                    deme, pdata.mating);
+                                    rv.emplace_back(pop.generation, pdata.deme2, deme,
+                                                    pdata.mating);
                                 }
                             offspring_metadata.emplace_back(
                                 fwdpy11::DiploidMetadata{0.,

--- a/cpptests/test_lowlevel_demographic_events.cc
+++ b/cpptests/test_lowlevel_demographic_events.cc
@@ -15,7 +15,7 @@ using namespace fwdpy11::discrete_demography;
 
 using deme_sizes_t = std::unordered_map<int, int>;
 
-BOOST_FIXTURE_TEST_SUITE(test_lowlevel_demographic_events, mock_population_fixture)
+BOOST_FIXTURE_TEST_SUITE(test_lowlevel_demographic_events, population_fixture)
 
 BOOST_AUTO_TEST_CASE(test_simple_moves_from_single_deme)
 {

--- a/cpptests/test_lowlevel_demographic_events.cc
+++ b/cpptests/test_lowlevel_demographic_events.cc
@@ -377,5 +377,39 @@ BOOST_AUTO_TEST_CASE(bad_metadata_label_when_mass_migration_happens)
                       std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(mass_migration_via_change_in_migration_rates)
+{
+    // Set deme size 0 to 0 immediately.
+    set_deme_sizes.emplace_back(0, 0, 0, true);
+    // Create a new deme, that will get 100% of ancestry from
+    // individuals in deme 0
+    set_deme_sizes.emplace_back(0, 1, pop.N, true);
+
+    // Set an initial migration matrix representing just 100%
+    // ancestry of ancestral pop to itself.
+    set_migmatrix(std::vector<double>{1., 0., 0., 0.}, 2, false);
+
+    // Change the migration matrix to reflect the "mass migration"
+    // event founding deme 1
+    set_migration_rates.emplace_back(0, std::vector<double>{0., 0., 1., 0.});
+
+    // The mass migration event is done, so all the ancestry
+    // must now come from the new deme.
+    set_migration_rates.emplace_back(1, std::vector<double>{0., 0., 0., 1.});
+
+    auto demog = make_model();
+    auto migevents = DiscreteDemography_roundtrip(rng, pop, demog, 5);
+
+    // We only record migrations if parent deme != offspring deme,
+    // so all migrations should have generation 1 (the first offspring
+    // generation) and be from 0 -> 1, representing the pulse migration.
+    for (auto& m : migevents)
+        {
+            BOOST_REQUIRE_EQUAL(m.generation, 1);
+            BOOST_REQUIRE_EQUAL(m.parental_deme, 0);
+            BOOST_REQUIRE_EQUAL(m.offspring_deme, 1);
+        }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/cpptests/test_lowlevel_discrete_demography_bad_models.cc
+++ b/cpptests/test_lowlevel_discrete_demography_bad_models.cc
@@ -6,7 +6,7 @@
 #include "fwdpy11/discrete_demography/exceptions.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(test_lowlevel_discrete_demography_bad_models,
-                         mock_population_fixture)
+                         population_fixture)
 
 BOOST_AUTO_TEST_CASE(test_migration_matrix_too_small)
 /*

--- a/cpptests/test_lowlevel_discrete_demography_objects.cc
+++ b/cpptests/test_lowlevel_discrete_demography_objects.cc
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(wrong_number_of_rates)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_FIXTURE_TEST_SUITE(test_DiscreteDemography, mock_population_fixture)
+BOOST_FIXTURE_TEST_SUITE(test_DiscreteDemography, population_fixture)
 
 BOOST_AUTO_TEST_CASE(set_deme_size_twice)
 {

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -16,6 +16,10 @@ Bug fixes
   It is not possible that this bug affected results from earlier versions, as attempting to stop/start at these time points raised exceptions.
   {issue}`775`
   {pr}`774`
+* Fix bugs in C++ back-end for discrete demographic models.
+  In some cases, we were using the wrong vector of deme sizes to update the model,
+  leading to runtime exceptions.
+  {pr}`802`
 
 Behavior changes
 

--- a/fwdpy11/headers/fwdpy11/discrete_demography/DiscreteDemographyState.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/DiscreteDemographyState.hpp
@@ -189,27 +189,19 @@ namespace fwdpy11
                 std::copy(begin(current_deme_parameters.current_deme_sizes.get()),
                           end(current_deme_parameters.current_deme_sizes.get()),
                           begin(current_deme_parameters.next_deme_sizes.get()));
-                // Step 1, do the discrete changes of deme sizes
-                // NOTE: this may reset growth rates to zero
-                detail::update_current_deme_sizes(
+                detail::set_next_deme_sizes(
                     current_simulation_time, set_deme_sizes, current_deme_parameters);
-
-                // Step 2: set new growth rates
                 detail::update_growth_rates(current_simulation_time, set_growth_rates,
                                             current_deme_parameters);
-                // Step 3: update selfing rates
                 detail::update_selfing_rates(current_simulation_time, set_selfing_rates,
                                              current_deme_parameters);
                 detail::update_migration_matrix(current_simulation_time,
                                                 set_migration_rates, M);
-                // Step 4: set next deme sizes and apply growth rates
-                std::copy(begin(current_deme_parameters.current_deme_sizes.get()),
-                          end(current_deme_parameters.current_deme_sizes.get()),
-                          begin(current_deme_parameters.next_deme_sizes.get()));
                 auto next_global_N_ = detail::apply_growth_rates_get_next_global_N(
                     current_simulation_time, current_deme_parameters);
                 set_next_global_N(next_global_N_);
                 build_migration_lookup(M, current_deme_parameters.current_deme_sizes,
+                                       current_deme_parameters.next_deme_sizes,
                                        miglookup);
             }
         };

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/build_migration_lookup.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/build_migration_lookup.hpp
@@ -37,6 +37,7 @@ namespace fwdpy11
         inline void
         build_migration_lookup(const MigrationMatrix& M,
                                const current_deme_sizes_vector& current_deme_sizes,
+                               const next_deme_sizes_vector& next_deme_sizes,
                                migration_lookup& ml)
         {
             if (!M.empty())
@@ -44,28 +45,31 @@ namespace fwdpy11
                     std::vector<double> temp;
                     std::size_t npops = ml.lookups.size();
                     temp.reserve(npops);
-                    const auto& ref = current_deme_sizes.get();
+                    const auto& current_deme_sizes_ref = current_deme_sizes.get();
+                    const auto& next_deme_sizes_ref = next_deme_sizes.get();
                     for (std::size_t dest = 0; dest < npops; ++dest)
                         {
                             for (std::size_t source = 0; source < npops; ++source)
                                 {
                                     // By default, input migration rates are
                                     // weighted by the current deme size...
-                                    double scaling_factor
-                                        = static_cast<double>(ref[source]);
+                                    double scaling_factor = static_cast<double>(
+                                        current_deme_sizes_ref[source]);
                                     // ...unless we are told not to do that.
                                     // But if the deme size is zero, we make
                                     // sure it is removed as a possible source
                                     // of a parent.
-                                    if (M.scaled == false && ref[source] != 0)
+                                    if (M.scaled == false
+                                        && current_deme_sizes_ref[source] != 0)
                                         {
                                             scaling_factor = 1.0;
                                         }
                                     double rate_in = M.M[dest * npops + source];
                                     if (rate_in > 0.
-                                        && (ref[source] == 0 || ref[dest] == 0))
+                                        && (current_deme_sizes_ref[source] == 0
+                                            || next_deme_sizes_ref[dest] == 0))
                                         {
-                                            if (ref[dest] != 0)
+                                            if (current_deme_sizes_ref[dest] != 0)
                                                 {
                                                     std::ostringstream o;
                                                     o << "non-zero migration "
@@ -76,7 +80,7 @@ namespace fwdpy11
                                                       << dest;
                                                     throw DemographyError(o.str());
                                                 }
-                                            if (ref[source] != 0)
+                                            if (next_deme_sizes_ref[source] != 0)
                                                 {
                                                     std::ostringstream o;
                                                     o << "non-zero migration "

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
@@ -110,16 +110,15 @@ namespace fwdpy11
                     }
                 auto& rates = sizes_rates.growth_rates.get();
                 auto& onsets = sizes_rates.growth_rate_onset_times.get();
-                auto& current_deme_sizes = sizes_rates.current_deme_sizes.get();
+                auto& next_deme_sizes = sizes_rates.next_deme_sizes.get();
                 auto& N0 = sizes_rates.growth_initial_sizes.get();
-                auto& Ncurr = sizes_rates.current_deme_sizes.get();
                 for (; growth_rate_changes.current() < growth_rate_changes.last()
                        && growth_rate_changes.when() == t;
                      ++growth_rate_changes.current())
                     {
                         auto deme = growth_rate_changes.event().deme;
                         if (growth_rate_changes.event().G != NOGROWTH
-                            && Ncurr[deme] == 0)
+                            && next_deme_sizes[deme] == 0)
                             {
                                 throw DemographyError(
                                     "attempt to change growth rate in extinct "
@@ -127,7 +126,7 @@ namespace fwdpy11
                             }
                         rates[deme] = growth_rate_changes.event().G;
                         onsets[deme] = t;
-                        N0[deme] = current_deme_sizes[deme];
+                        N0[deme] = next_deme_sizes[deme];
                     }
             }
 

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
@@ -60,10 +60,9 @@ namespace fwdpy11
         namespace detail
         {
             inline void
-            update_current_deme_sizes(
-                const std::uint32_t t,
-                current_event_state<SetDemeSize>& size_change_events,
-                deme_properties& sizes_rates)
+            set_next_deme_sizes(const std::uint32_t t,
+                                current_event_state<SetDemeSize>& size_change_events,
+                                deme_properties& sizes_rates)
             // NOTE: this function may resent growth rates to zero.
             // see SetDemeSize for details.
             {
@@ -72,8 +71,8 @@ namespace fwdpy11
                     {
                         return;
                     }
-                current_deme_sizes_vector::value_type& current_deme_sizes
-                    = sizes_rates.current_deme_sizes.get();
+                next_deme_sizes_vector::value_type& current_deme_sizes
+                    = sizes_rates.next_deme_sizes.get();
                 growth_rates_vector::value_type& growth_rates
                     = sizes_rates.growth_rates.get();
                 growth_rates_onset_times_vector::value_type& growth_rate_onset_times

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -316,6 +316,7 @@ evolve_with_tree_sequences(
             build_migration_lookup(
                 current_demographic_state.M,
                 current_demographic_state.current_deme_parameters.current_deme_sizes,
+                current_demographic_state.current_deme_parameters.next_deme_sizes,
                 miglookup);
             fitness_lookup.update(current_demographic_state.fitness_bookmark);
             ddemog::validate_parental_state(


### PR DESCRIPTION
This PR fixes an error in the implementation of the back-end functions applying "late" events in DiscreteDemography models.

The error could be triggered by the sorts of events that we do when importing `demes` models with mass migrations, and a new test is added to the C++ test suite of such cases.