### PR TITLE
more back-end fixes for discrete demographic models

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -20,6 +20,7 @@ Bug fixes
   In some cases, we were using the wrong vector of deme sizes to update the model,
   leading to runtime exceptions.
   {pr}`802`
+  {pr}`803`
 
 Behavior changes
 

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
@@ -142,13 +142,13 @@ namespace fwdpy11
                         return;
                     }
                 auto& rates = sizes_rates.selfing_rates.get();
-                auto& Ncurr = sizes_rates.current_deme_sizes.get();
+                auto& Nnext = sizes_rates.next_deme_sizes.get();
                 for (; selfing_rate_changes.current() < selfing_rate_changes.last()
                        && selfing_rate_changes.when() == t;
                      ++selfing_rate_changes.current())
                     {
                         auto& event = selfing_rate_changes.event();
-                        if (Ncurr[event.deme] == 0)
+                        if (Nnext[event.deme] == 0)
                             {
                                 throw DemographyError("attempt to set selfing "
                                                       "rate in extinct deme");

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
@@ -182,7 +182,6 @@ namespace fwdpy11
             apply_growth_rates_get_next_global_N(const std::uint32_t t,
                                                  deme_properties& sizes_rates)
             {
-                auto& Ncurr = sizes_rates.current_deme_sizes.get();
                 auto& Nnext = sizes_rates.next_deme_sizes.get();
                 auto& G = sizes_rates.growth_rates.get();
                 auto& N0 = sizes_rates.growth_initial_sizes.get();
@@ -192,7 +191,7 @@ namespace fwdpy11
                     {
                         if (G[deme] != NOGROWTH)
                             {
-                                if (Ncurr[deme] == 0)
+                                if (Nnext[deme] == 0)
                                     {
                                         throw DemographyError(
                                             "growth is happening in an "

--- a/tests/test_discrete_demography_with_tree_sequences.py
+++ b/tests/test_discrete_demography_with_tree_sequences.py
@@ -962,5 +962,77 @@ def test_mass_migration_via_migration_rate_changes_and_set_selfing_rate_at_same_
         fwdpy11.evolvets(rng, pop, params, 100)
 
 
+@pytest.mark.parametrize("rng", [{"seed": 51253}], indirect=["rng"])
+@pytest.mark.parametrize(
+    "pop",
+    [
+        {"N": 100, "genome_length": 10.0},
+    ],
+    indirect=["pop"],
+)
+@pytest.mark.parametrize("new_size", [100])
+@pytest.mark.parametrize("migration_when", [0, 1, 7, 11])
+@pytest.mark.parametrize("growth_deme", [0, 1])
+@pytest.mark.parametrize("growth_rate", [1.01])
+def test_mass_migration_via_migration_rate_changes_and_set_growth_rate_at_same_time(
+    pop,
+    rng,
+    migration_when,
+    new_size,
+    growth_deme,
+    growth_rate,
+):
+    """
+    Mock up of how we treat demes models:
+
+    * mass migration by setting migration rates in 2 subsequent generations
+    * set some other property at the same time
+
+    Setting the growth rate in deme 0 should raise an exception
+    """
+    set_deme_sizes = [
+        fwdpy11.SetDemeSize(when=migration_when, deme=0, new_size=0),
+        fwdpy11.SetDemeSize(when=migration_when, deme=1, new_size=new_size),
+    ]
+    migmatrix = fwdpy11.MigrationMatrix(
+        np.array([1.0, 0.0, 0.0, 0.0]).reshape(2, 2), scaled=False
+    )
+    set_migration_rates = [
+        fwdpy11.SetMigrationRates(
+            when=migration_when,
+            deme=-1,
+            migrates=np.array([0.0, 0.0, 1.0, 0.0]).reshape(2, 2),
+        ),
+        fwdpy11.SetMigrationRates(
+            when=migration_when + 1,
+            deme=-1,
+            migrates=np.array([0.0, 0.0, 0.0, 1.0]).reshape(2, 2),
+        ),
+    ]
+    set_growth_rates = [
+        fwdpy11.SetExponentialGrowth(
+            when=migration_when, deme=growth_deme, G=growth_rate
+        )
+    ]
+    demog = fwdpy11.DiscreteDemography(
+        set_deme_sizes=set_deme_sizes,
+        migmatrix=migmatrix,
+        set_migration_rates=set_migration_rates,
+        set_growth_rates=set_growth_rates,
+    )
+    pdict = {
+        "demography": demog,
+        "gvalue": fwdpy11.Multiplicative(2.0),
+        "rates": (0.0, 0.0, 0.0),
+        "simlen": migration_when + 2,
+    }
+    params = fwdpy11.ModelParams(**pdict)
+    if growth_deme == 0:
+        with pytest.raises(fwdpy11.DemographyError):
+            fwdpy11.evolvets(rng, pop, params, 100)
+    else:
+        fwdpy11.evolvets(rng, pop, params, 100)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discrete_demography_with_tree_sequences.py
+++ b/tests/test_discrete_demography_with_tree_sequences.py
@@ -898,5 +898,69 @@ def test_set_deme_size_and_growth_rates_at_same_time(pop, rng, new_size, G):
     assert pop.N == expected_final_N
 
 
+@pytest.mark.parametrize("rng", [{"seed": 51253}], indirect=["rng"])
+@pytest.mark.parametrize(
+    "pop",
+    [
+        {"N": 100, "genome_length": 10.0},
+    ],
+    indirect=["pop"],
+)
+@pytest.mark.parametrize("new_size", [100])
+@pytest.mark.parametrize("migration_when", [0, 1, 7, 11])
+@pytest.mark.parametrize("selfing_deme", [0, 1])
+def test_mass_migration_via_migration_rate_changes_and_set_selfing_rate_at_same_time(
+    pop, rng, migration_when, new_size, selfing_deme
+):
+    """
+    Mock up of how we treat demes models:
+
+    * mass migration by setting migration rates in 2 subsequent generations
+    * set some other property at the same time
+
+    Setting the selfing rate in deme 0 should raise an exception
+    """
+    set_deme_sizes = [
+        fwdpy11.SetDemeSize(when=migration_when, deme=0, new_size=0),
+        fwdpy11.SetDemeSize(when=migration_when, deme=1, new_size=new_size),
+    ]
+    migmatrix = fwdpy11.MigrationMatrix(
+        np.array([1.0, 0.0, 0.0, 0.0]).reshape(2, 2), scaled=False
+    )
+    set_migration_rates = [
+        fwdpy11.SetMigrationRates(
+            when=migration_when,
+            deme=-1,
+            migrates=np.array([0.0, 0.0, 1.0, 0.0]).reshape(2, 2),
+        ),
+        fwdpy11.SetMigrationRates(
+            when=migration_when + 1,
+            deme=-1,
+            migrates=np.array([0.0, 0.0, 0.0, 1.0]).reshape(2, 2),
+        ),
+    ]
+    set_selfing_rates = [
+        fwdpy11.SetSelfingRate(when=migration_when, deme=selfing_deme, S=0.5)
+    ]
+    demog = fwdpy11.DiscreteDemography(
+        set_deme_sizes=set_deme_sizes,
+        migmatrix=migmatrix,
+        set_migration_rates=set_migration_rates,
+        set_selfing_rates=set_selfing_rates,
+    )
+    pdict = {
+        "demography": demog,
+        "gvalue": fwdpy11.Multiplicative(2.0),
+        "rates": (0.0, 0.0, 0.0),
+        "simlen": migration_when + 2,
+    }
+    params = fwdpy11.ModelParams(**pdict)
+    if selfing_deme == 0:
+        with pytest.raises(fwdpy11.DemographyError):
+            fwdpy11.evolvets(rng, pop, params, 100)
+    else:
+        fwdpy11.evolvets(rng, pop, params, 100)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Following up on #802:

* make sure that setting deme sizes uses the correct population size vector for validation
* make sure that applying growth rates uses the correct population size vector for validation