### PR TITLE
Change timing of mass migration events within a generation.

### DIFF
--- a/cpptests/discrete_demography_roundtrips.cc
+++ b/cpptests/discrete_demography_roundtrips.cc
@@ -40,7 +40,7 @@ DiscreteDemography_roundtrip(
     fwdpy11::discrete_demography::migration_lookup miglookup{
         current_demographic_state.maxdemes, current_demographic_state.M.empty()};
     current_demographic_state.early(rng, pop.generation, pop.diploid_metadata);
-    current_demographic_state.late(pop.generation, miglookup, pop.diploid_metadata);
+    current_demographic_state.late(rng, pop.generation, miglookup, pop.diploid_metadata);
     fitness_lookup.update(current_demographic_state.fitness_bookmark);
     fwdpy11::discrete_demography::validate_parental_state(
         pop.generation, fitness_lookup,
@@ -97,7 +97,7 @@ DiscreteDemography_roundtrip(
             offspring_metadata.clear();
 
             current_demographic_state.early(rng, pop.generation, pop.diploid_metadata);
-            current_demographic_state.late(pop.generation, miglookup,
+            current_demographic_state.late(rng, pop.generation, miglookup,
                                            pop.diploid_metadata);
             fitness_lookup.update(current_demographic_state.fitness_bookmark);
             fwdpy11::discrete_demography::validate_parental_state(

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -28,6 +28,11 @@ Behavior changes
   it is now possible that exceptions will raise.
   This change is due to the fix for Issue {issue}`775` introduced in PR {pr}`774`.
   See issue {issue}`777` for more background.
+* Mass migration events implemented via {func}`fwdpy11.copy_individuals`
+  and {func}`fwdpy11.move_individuals` now occur *after* sampling within a generation.  
+  This change makes the timings consistent with all other events and also makes
+  certain operations easier/feasible.
+  {pr}`809`
 
 New features
 

--- a/fwdpy11/headers/fwdpy11/discrete_demography/DiscreteDemographyState.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/DiscreteDemographyState.hpp
@@ -168,8 +168,15 @@ namespace fwdpy11
             }
 
             void
-            early(const GSLrng_t& rng, std::uint32_t current_simulation_time,
-                  std::vector<DiploidMetadata>& individual_metadata)
+            early(const GSLrng_t& /*rng*/, std::uint32_t /*current_simulation_time*/,
+                  std::vector<DiploidMetadata>& /*individual_metadata*/)
+            {
+            }
+
+            void
+            late(const GSLrng_t& rng, std::uint32_t current_simulation_time,
+                 migration_lookup& miglookup,
+                 std::vector<DiploidMetadata>& individual_metadata)
             {
                 mass_migration(rng, current_simulation_time, mass_migrations,
                                current_deme_parameters.growth_rates,
@@ -178,19 +185,13 @@ namespace fwdpy11
                                individual_metadata);
                 get_current_deme_sizes(individual_metadata,
                                        current_deme_parameters.current_deme_sizes);
-            }
-
-            void
-            late(std::uint32_t current_simulation_time, migration_lookup& miglookup,
-                 std::vector<DiploidMetadata>& individual_metadata)
-            {
                 fitness_bookmark.update(current_deme_parameters.current_deme_sizes,
                                         individual_metadata);
                 std::copy(begin(current_deme_parameters.current_deme_sizes.get()),
                           end(current_deme_parameters.current_deme_sizes.get()),
                           begin(current_deme_parameters.next_deme_sizes.get()));
-                detail::set_next_deme_sizes(
-                    current_simulation_time, set_deme_sizes, current_deme_parameters);
+                detail::set_next_deme_sizes(current_simulation_time, set_deme_sizes,
+                                            current_deme_parameters);
                 detail::update_growth_rates(current_simulation_time, set_growth_rates,
                                             current_deme_parameters);
                 detail::update_selfing_rates(current_simulation_time, set_selfing_rates,

--- a/tests/test_demographic_event_timings.py
+++ b/tests/test_demographic_event_timings.py
@@ -1,0 +1,448 @@
+#
+# Copyright (C) 2021 Kevin Thornton <krthornt@uci.edu>
+#
+# This file is part of fwdpy11.
+#
+# fwdpy11 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# fwdpy11 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import typing
+from dataclasses import dataclass
+
+import fwdpy11
+import numpy as np
+
+
+@dataclass
+class DemeSize:
+    generation: int
+    deme: int
+    size: int
+
+
+@dataclass
+class NumMigrants:
+    generation: int
+    num_migrants: typing.List[int]
+
+
+@dataclass
+class NumSelfers:
+    generation: int
+    num_selfers: int
+
+
+class Popsizes(object):
+    def __init__(self):
+        self.popsizes = []
+
+    def __call__(self, pop, _):
+        d = pop.deme_sizes()
+        for (i, j) in zip(d[0], d[1]):
+            self.popsizes.append(DemeSize(pop.generation, i, j))
+
+
+class Migrants(object):
+    def __init__(self):
+        self.migrants = []
+        self.popsizes = Popsizes()
+
+    def __call__(self, pop, sampler):
+        migrants = [0] * 2
+        for i, d in enumerate(pop.diploid_metadata):
+            if d.deme == 0:
+                if d.parents[0] >= 100:
+                    migrants[d.deme] += 1
+            else:
+                if d.parents[0] < 100:
+                    migrants[d.deme] += 1
+        self.migrants.append(NumMigrants(pop.generation, migrants))
+
+        self.popsizes(pop, sampler)
+
+
+class Selfers(object):
+    def __init__(self):
+        self.selfers = []
+
+    def __call__(self, pop, _):
+        selfers = 0
+        for d in pop.diploid_metadata:
+            if d.parents[0] == d.parents[1]:
+                selfers += 1
+        self.selfers.append(NumSelfers(pop.generation, selfers))
+
+
+def setup_sim(popsizes, demography, simlen=None, seed=None, genome_length=None):
+    if genome_length is None:
+        _genome_len = 1.0
+    else:
+        _genome_len = genome_length
+
+    if simlen is None:
+        _simlen = 5
+    else:
+        _simlen = simlen
+
+    if seed is None:
+        _seed = 100
+    else:
+        _seed = seed
+
+    pdict = {
+        "gvalue": [fwdpy11.Multiplicative(2.0)],
+        "rates": (0, 0, 0),
+        "simlen": _simlen,
+        "demography": demography,
+    }
+
+    params = fwdpy11.ModelParams(**pdict)
+    pop = fwdpy11.DiploidPopulation(popsizes, _genome_len)
+    rng = fwdpy11.GSLrng(_seed)
+
+    return rng, pop, params
+
+
+# Single events happening in isolation:
+
+
+def test_single_deme_set_size_time_0():
+    demog = fwdpy11.DiscreteDemography(
+        set_deme_sizes=[fwdpy11.SetDemeSize(when=0, deme=0, new_size=125)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    # All pop.generation after 0 (the founders) will have the new size
+    # Further, only generations 1- are seen by the sampler
+    for i in recorder.popsizes:
+        assert i.size == 125
+
+
+def test_single_deme_set_size_time_simlen():
+    demog = fwdpy11.DiscreteDemography(
+        set_deme_sizes=[fwdpy11.SetDemeSize(when=5, deme=0, new_size=125)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    # The size change will not be seen, as it
+    # the final generation has not reproduced
+    for i in recorder.popsizes:
+        assert i.size == 100
+
+
+def test_single_deme_set_size_time_simlen_then_continue_evolving():
+    demog = fwdpy11.DiscreteDemography(
+        set_deme_sizes=[fwdpy11.SetDemeSize(when=5, deme=0, new_size=125)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    assert pop.generation == 5
+
+    # The size change will not be seen, as it
+    # the final generation has not reproduced
+    for i in recorder.popsizes:
+        assert i.size == 100
+
+    # Evolve some more, and the pop size change will
+    # "hit" the first daughter generation, which is 6
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    assert pop.generation == 10
+
+    for i in recorder.popsizes:
+        if i.generation < 6:
+            assert i.size == 100
+        else:
+            assert i.size == 125
+
+
+def test_single_deme_set_selfing_rate_time_0():
+    demog = fwdpy11.DiscreteDemography(
+        set_selfing_rates=[fwdpy11.SetSelfingRate(when=0, deme=0, S=1.0)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Selfers()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.selfers:
+        assert i.num_selfers == pop.N
+
+
+def test_single_deme_set_selfing_rate_time_simlen():
+    demog = fwdpy11.DiscreteDemography(
+        set_selfing_rates=[fwdpy11.SetSelfingRate(when=5, deme=0, S=1.0)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Selfers()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    assert any([i.num_selfers < pop.N for i in recorder.selfers])
+
+
+def test_single_deme_set_selfing_rate_time_simlen_then_continue_evolving():
+    demog = fwdpy11.DiscreteDemography(
+        set_selfing_rates=[fwdpy11.SetSelfingRate(when=5, deme=0, S=1.0)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+
+    recorder = Selfers()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    assert any([i.num_selfers < pop.N for i in recorder.selfers])
+
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    assert all([i.num_selfers == pop.N for i in recorder.selfers if i.generation > 5])
+
+
+def test_single_deme_set_growth_rate_time_0():
+    demog = fwdpy11.DiscreteDemography(
+        set_growth_rates=[fwdpy11.SetExponentialGrowth(when=0, deme=0, G=1.05)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+    ancestral_size = pop.N
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.popsizes:
+        assert i.size > ancestral_size
+
+
+def test_single_deme_set_growth_rate_time_simlen():
+    demog = fwdpy11.DiscreteDemography(
+        set_growth_rates=[fwdpy11.SetExponentialGrowth(when=5, deme=0, G=1.05)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+    ancestral_size = pop.N
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.popsizes:
+        assert i.size == ancestral_size
+
+
+def test_single_deme_set_growth_rate_time_simlen_then_continue_evolving():
+    demog = fwdpy11.DiscreteDemography(
+        set_growth_rates=[fwdpy11.SetExponentialGrowth(when=5, deme=0, G=1.05)]
+    )
+
+    rng, pop, params = setup_sim(100, demog)
+    ancestral_size = pop.N
+
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.popsizes:
+        assert i.size == ancestral_size
+
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    assert all([i.size > ancestral_size for i in recorder.popsizes if i.generation > 5])
+
+
+def test_two_demes_set_migration_rates_time_0():
+    set_migration_rates = [fwdpy11.SetMigrationRates(when=0, deme=0, migrates=[0, 1])]
+    set_migration_rates.append(
+        fwdpy11.SetMigrationRates(when=0, deme=1, migrates=[1, 0])
+    )
+    demog = fwdpy11.DiscreteDemography(
+        set_migration_rates=set_migration_rates,
+        migmatrix=np.identity(2),
+    )
+
+    rng, pop, params = setup_sim([100, 100], demog)
+    ancestral_sizes = pop.deme_sizes()[1]
+
+    recorder = Migrants()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.migrants:
+        for j, n in enumerate(i.num_migrants):
+            assert n == ancestral_sizes[j]
+
+
+def test_two_demes_set_migration_rates_time_simlen():
+    set_migration_rates = [fwdpy11.SetMigrationRates(when=5, deme=0, migrates=[0, 1])]
+    set_migration_rates.append(
+        fwdpy11.SetMigrationRates(when=5, deme=1, migrates=[1, 0])
+    )
+    demog = fwdpy11.DiscreteDemography(
+        set_migration_rates=set_migration_rates,
+        migmatrix=np.identity(2),
+    )
+
+    rng, pop, params = setup_sim([100, 100], demog)
+
+    recorder = Migrants()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.migrants:
+        assert all([n == 0 for n in i.num_migrants])
+
+
+def test_two_demes_set_migration_rates_time_simlen_then_keep_evolving():
+    set_migration_rates = [fwdpy11.SetMigrationRates(when=5, deme=0, migrates=[0, 1])]
+    set_migration_rates.append(
+        fwdpy11.SetMigrationRates(when=5, deme=1, migrates=[1, 0])
+    )
+    demog = fwdpy11.DiscreteDemography(
+        set_migration_rates=set_migration_rates,
+        migmatrix=np.identity(2),
+    )
+
+    rng, pop, params = setup_sim([100, 100], demog)
+    ancestral_sizes = pop.deme_sizes()[1]
+
+    recorder = Migrants()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+
+    for i in recorder.migrants:
+        assert all([n == 0 for n in i.num_migrants])
+
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.migrants:
+        if i.generation > 5:
+            for j, n in enumerate(i.num_migrants):
+                assert n == ancestral_sizes[j]
+
+
+def test_single_deme_split_by_mass_migration_by_copy_time_0():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=0, source=0, destination=1, fraction=0.5)
+    ]
+    demog = fwdpy11.DiscreteDemography(mass_migrations=mass_migrations)
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        if i.deme == 0:
+            assert i.size == 100
+        else:
+            assert i.deme == 1
+            assert i.size == 50
+
+
+def test_single_deme_split_by_mass_migration_by_copy_time_simlen():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=5, source=0, destination=1, fraction=0.5)
+    ]
+    demog = fwdpy11.DiscreteDemography(mass_migrations=mass_migrations)
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        assert i.deme == 0
+        assert i.size == 100
+
+
+def test_single_deme_split_by_mass_migration_by_copy_time_simlen_then_keep_evolving():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=5, source=0, destination=1, fraction=0.5)
+    ]
+    demog = fwdpy11.DiscreteDemography(mass_migrations=mass_migrations)
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        assert i.deme == 0
+        assert i.size == 100
+
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    latest_popsizes = [i for i in recorder.popsizes if i.generation > 5]
+    for i in latest_popsizes:
+        if i.deme == 0:
+            assert i.size == 100
+        else:
+            assert i.deme == 1
+            assert i.size == 50
+
+
+# Simultaenous events applied to the same deme
+
+
+def test_single_deme_split_by_mass_migration_by_copy_with_size_change_time_0():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=0, source=0, destination=1, fraction=0.5)
+    ]
+    set_deme_sizes = [fwdpy11.SetDemeSize(when=0, deme=1, new_size=200)]
+    demog = fwdpy11.DiscreteDemography(
+        mass_migrations=mass_migrations, set_deme_sizes=set_deme_sizes
+    )
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        if i.deme == 0:
+            assert i.size == 100
+        else:
+            assert i.deme == 1
+            assert i.size == 200
+
+
+def test_single_deme_split_by_mass_migration_by_copy_with_size_change_time_simlen():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=5, source=0, destination=1, fraction=0.5)
+    ]
+    set_deme_sizes = [fwdpy11.SetDemeSize(when=5, deme=1, new_size=200)]
+    demog = fwdpy11.DiscreteDemography(
+        mass_migrations=mass_migrations, set_deme_sizes=set_deme_sizes
+    )
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        assert i.deme == 0
+        assert i.size == 100
+
+
+def test_single_deme_split_by_mass_migration_by_copy_with_size_change_time_simlen_then_keep_evolving():
+    mass_migrations = [
+        fwdpy11.copy_individuals(when=5, source=0, destination=1, fraction=0.5)
+    ]
+    set_deme_sizes = [fwdpy11.SetDemeSize(when=5, deme=1, new_size=200)]
+    demog = fwdpy11.DiscreteDemography(
+        mass_migrations=mass_migrations, set_deme_sizes=set_deme_sizes
+    )
+    rng, pop, params = setup_sim(100, demog)
+    recorder = Popsizes()
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    for i in recorder.popsizes:
+        assert i.deme == 0
+        assert i.size == 100
+    fwdpy11.evolvets(rng, pop, params, 50, recorder=recorder)
+    latest_popsizes = [i for i in recorder.popsizes if i.generation > 5]
+    for i in latest_popsizes:
+        if i.deme == 0:
+            assert i.size == 100
+        else:
+            assert i.deme == 1
+            assert i.size == 200

--- a/tests/test_tree_sequences_different_des_in_different_demes.py
+++ b/tests/test_tree_sequences_different_des_in_different_demes.py
@@ -23,9 +23,8 @@
 
 import unittest
 
-import numpy as np
-
 import fwdpy11
+import numpy as np
 
 
 def gvalue_multiplicative(pop, ind, scaling):
@@ -92,19 +91,21 @@ class TestMassMigrationsWithCopies(unittest.TestCase):
                 self.data = []
 
             def __call__(self, pop, sampler):
-                for i in range(len(pop.diploids), len(pop.diploid_metadata)):
-                    md = pop.diploid_metadata[i]
-                    dip = pop.diploids[md.label]
-                    a = len(pop.haploid_genomes[dip.first].smutations)
-                    b = len(pop.haploid_genomes[dip.second].smutations)
-                    self.data.append(
-                        (
-                            pop.generation,
-                            pop.diploid_metadata[i].w,
-                            pop.diploid_metadata[i].deme,
-                            a + b,
-                        )
-                    )
+                if pop.generation == 2:
+                    for i in range(0, len(pop.diploid_metadata)):
+                        md = pop.diploid_metadata[i]
+                        if md.deme == 1:
+                            dip = pop.diploids[md.label]
+                            a = len(pop.haploid_genomes[dip.first].smutations)
+                            b = len(pop.haploid_genomes[dip.second].smutations)
+                            self.data.append(
+                                (
+                                    pop.generation,
+                                    pop.diploid_metadata[i].w,
+                                    pop.diploid_metadata[i].deme,
+                                    a + b,
+                                )
+                            )
 
         self.f = CheckFitnesses()
         fwdpy11.evolvets(self.rng, self.pop, self.params, 100, self.f)
@@ -117,7 +118,7 @@ class TestMassMigrationsWithCopies(unittest.TestCase):
         for i in self.f.data:
             self.assertEqual(i[2], 1)  # deme == 1
             self.assertTrue(i[1] <= 1.0)  # Mutations are harmful in this deme
-            self.assertEqual(i[0], 1)  # Generation == 1, when mass mig happened
+            self.assertEqual(i[0], 2)  # Generation == 2, when mass mig happened
 
 
 class TestMassMigrationsWithMoves(unittest.TestCase):
@@ -167,7 +168,7 @@ class TestMassMigrationsWithMoves(unittest.TestCase):
                 # Moves don't affect the amount of metadata
                 # vs diploid genotypes
                 assert len(pop.diploids) == len(pop.diploid_metadata)
-                if pop.generation == 1:
+                if pop.generation == 2:
                     for i in range(len(pop.diploids)):
                         md = pop.diploid_metadata[i]
                         dip = pop.diploids[md.label]
@@ -199,10 +200,12 @@ class TestMassMigrationsWithMoves(unittest.TestCase):
         for i in self.f.data:
             if i[2] == 0:  # deme 0
                 self.assertTrue(i[1] >= 1.0)  # Mutations are beneficial in this deme
-                self.assertEqual(i[0], 1)  # Generation == 1, when mass mig happened
+                self.assertEqual(
+                    i[0], 2
+                )  # Generation == 2, when new deme first appeared
             else:
                 self.assertEqual(i[2], 1)
-                self.assertTrue(i[1] <= 1.0)  # Mutations are harmful in this deme
+                self.assertTrue(i[1] <= 2.0)  # Mutations are harmful in this deme
 
 
 class TestMultiplicativeWithExpSNoMigration(unittest.TestCase):


### PR DESCRIPTION
moves the timings of these events to after sampling/before post-simplification cleanup.  This change means that the `when` term for all event types share a common definition, and a new unit test file is added to demonstrate that point.
