### PR TITLE
Adjust demes model start time

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -33,6 +33,8 @@ Behavior changes
   This change makes the timings consistent with all other events and also makes
   certain operations easier/feasible.
   {pr}`809`
+* Demographic models imported from [demes](https://pypi.org/project/demes/) now begin 1 generation before the earliest ancestral deme's end time.
+  {pr}`810`
 
 New features
 

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -1,12 +1,11 @@
 import copy
+import typing
 import unittest
 from dataclasses import dataclass
 
 import demes
 import fwdpy11
 import numpy as np
-import unittest
-import typing
 import pytest
 
 
@@ -80,7 +79,7 @@ class TestTwoEpoch(unittest.TestCase):
         self.assertTrue(len(self.demog.model.set_deme_sizes) == 1)
         self.assertTrue(
             self.demog.model.set_deme_sizes[0].when
-            == self.demog.metadata["burnin_time"] - 1
+            == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(self.demog.model.set_deme_sizes[0].new_size == 2000)
 
@@ -105,10 +104,10 @@ class TestNonGenerationUnits(unittest.TestCase):
     def test_conversion_to_generations(self):
         self.assertTrue(
             self.demog.model.set_deme_sizes[0].when
-            == self.demog.metadata["burnin_time"] - 1
+            == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(
-            self.demog.metadata["total_simulation_length"]
+            self.demog.metadata["total_simulation_length"] - 1
             == self.demog.metadata["burnin_time"] + 25000 // 25
         )
         self.assertTrue(self.demog.model.set_deme_sizes[0].new_size == 1000)
@@ -133,7 +132,7 @@ class TestSelfingShift(unittest.TestCase):
         self.assertTrue(self.demog.model.set_selfing_rates[0].when == 0)
         self.assertTrue(self.demog.model.set_selfing_rates[0].S == 0.0)
         self.assertTrue(
-            self.demog.model.set_selfing_rates[1].when
+            self.demog.model.set_selfing_rates[1].when - 1
             == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(self.demog.model.set_selfing_rates[1].S == 0.2)
@@ -178,18 +177,18 @@ class TestSplit(unittest.TestCase):
         self.assertTrue(self.demog.model.set_deme_sizes[0].new_size == 100)
         self.assertTrue(
             self.demog.model.set_deme_sizes[0].when
-            == self.demog.metadata["burnin_time"] - 1
+            == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(self.demog.model.set_deme_sizes[1].deme == 2)
         self.assertTrue(self.demog.model.set_deme_sizes[1].new_size == 100)
         self.assertTrue(
             self.demog.model.set_deme_sizes[1].when
-            == self.demog.metadata["burnin_time"] - 1
+            == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(self.demog.model.set_deme_sizes[2].deme == 0)
         self.assertTrue(self.demog.model.set_deme_sizes[2].new_size == 0)
         self.assertTrue(
-            self.demog.model.set_deme_sizes[2].when
+            self.demog.model.set_deme_sizes[2].when - 1
             == self.demog.metadata["burnin_time"]
         )
 
@@ -399,7 +398,7 @@ class TestIslandModelRateChange(unittest.TestCase):
     def test_total_sim_length(self):
         self.assertTrue(
             self.demog.metadata["total_simulation_length"]
-            == self.demog.metadata["burnin_time"] + 500
+            == self.demog.metadata["burnin_time"] + 500 + 1
         )
 
 
@@ -434,7 +433,7 @@ class TestTwoPopMerger(unittest.TestCase):
     def test_total_sim_length(self):
         self.assertTrue(
             self.demog.metadata["total_simulation_length"]
-            == self.demog.metadata["burnin_time"] + 1000
+            == self.demog.metadata["burnin_time"] + 1000 + 1
         )
 
     def test_num_size_changes(self):
@@ -484,7 +483,7 @@ class TestFourWayMerger(unittest.TestCase):
     def test_total_sim_length(self):
         self.assertTrue(
             self.demog.metadata["total_simulation_length"]
-            == self.demog.metadata["burnin_time"] + 1000
+            == self.demog.metadata["burnin_time"] + 1000 + 1
         )
 
     def test_num_size_changes(self):
@@ -505,18 +504,18 @@ class TestPulseMigration(unittest.TestCase):
     def test_total_sim_length(self):
         self.assertTrue(
             self.demog.metadata["total_simulation_length"]
-            == self.demog.metadata["burnin_time"] + 100
+            == self.demog.metadata["burnin_time"] + 100 + 1
         )
 
     def test_pulse_migration_matrix(self):
         self.assertTrue(len(self.demog.model.set_migration_rates) == 2)
         self.assertTrue(
             self.demog.model.set_migration_rates[0].when
-            == self.demog.metadata["burnin_time"] - 1
+            == self.demog.metadata["burnin_time"]
         )
         self.assertTrue(
             self.demog.model.set_migration_rates[1].when
-            == self.demog.metadata["burnin_time"]
+            == self.demog.metadata["burnin_time"] + 1
         )
         self.assertTrue(self.demog.model.set_migration_rates[0].deme == 1)
         self.assertTrue(self.demog.model.set_migration_rates[1].deme == 1)
@@ -777,6 +776,7 @@ def test_yamls_with_migration(data):
     demog = fwdpy11.discrete_demography.from_demes(g, 1)
     check_debugger_passes(demog)
 
+
 def test_split_model_population_size_history(two_deme_split_with_ancestral_size_change):
     """
     This is a detailed test of the complete size history
@@ -816,13 +816,13 @@ def test_split_model_population_size_history(two_deme_split_with_ancestral_size_
     recorder = DemeSizes()
     fwdpy11.evolvets(rng, pop, params, 100, recorder=recorder)
 
-    # The ancestral deme exists until generation 110,
+    # The ancestral deme exists until generation 111,
     # and we only see offspring from birth time 1 on.
-    assert [i.when for i in recorder.sizes[0]] == [i for i in range(1, 111)]
+    assert [i.when for i in recorder.sizes[0]] == [i for i in range(1, 112)]
     # The daughter demes are seen from 110 till the end
     for deme in [1, 2]:
         assert [i.when for i in recorder.sizes[deme]] == [
-            i for i in range(110, model.metadata["total_simulation_length"] + 1)
+            i for i in range(111, model.metadata["total_simulation_length"] + 1)
         ]
     # initial daughter deme sizes
     assert recorder.sizes[1][0].size == 250
@@ -831,10 +831,10 @@ def test_split_model_population_size_history(two_deme_split_with_ancestral_size_
     assert recorder.sizes[1][-1].size == 500
     assert recorder.sizes[2][-1].size == 200
 
-    # At generation 100, the ancestral pop size changed from 100
+    # At generation 101, the ancestral pop size changed from 100
     # to 200
     for i in recorder.sizes[0]:
-        if i.when < 100:
+        if i.when < 101:
             assert i.size == 100, f"{i}"
         else:
             assert i.size == 200, f"{i}"
@@ -935,4 +935,3 @@ def test_evolve_demes_model_starting_with_two_pops_and_no_ancestry(
             assert value == 300
         else:
             raise RuntimeError("unexpected key")
-


### PR DESCRIPTION
Changes to `demes` model conversions:

* The start time of a model is 1 generation prior to the most ancient end time of any ancestor deme.

This PR is likely to replace #801 in terms of back-end changes.
We will likely have to lift some tests from there over to here, if this works out.