### PR TITLE
refine final mutation counting back end

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -15,6 +15,8 @@ Back end changes:
 
 * Add more runtime checks to {func}`fwdpy11.DiploidPopulation.add_mutation`
   PR {pr}`837`
+* Remove unnecessary copying of table collections in {mod}`fwdpy11.tskit_tools`.
+  PR {pr}`842`
 
 ## 0.16.2
 

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -10,6 +10,11 @@ Bug fixes
 * Fix error initializing the founder genome of {class}`fwdpy11.DiploidPopulation`
   Issue {issue}`836`
   PR {pr}`838`
+* Fix bug in handling mutation counts when final generation was recorded as "ancient samples".
+  This bug resulted in an exception being raised.
+  Thus, previous exception-free results were not affected.
+  Issue {issue}`844`
+  PR {pr}`845`
 
 Dependencies
 

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -11,6 +11,11 @@ Bug fixes
   Issue {issue}`836`
   PR {pr}`838`
 
+Dependencies
+
+* Deprecate `fwdpy11.tskit_tools.WrappedTreeSequence`
+  PR {pr}`841`
+
 Back end changes:
 
 * Add more runtime checks to {func}`fwdpy11.DiploidPopulation.add_mutation`

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,14 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## 0.17.0
+
+Bug fixes
+
+* Fix error initializing the founder genome of {class}`fwdpy11.DiploidPopulation`
+  `issue`{836}
+  `pr`{838}
+
 ## 0.16.2
 
 Documentation

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -8,29 +8,34 @@ updates to latest `fwdpp` version, etc.
 Bug fixes
 
 * Fix error initializing the founder genome of {class}`fwdpy11.DiploidPopulation`
-  `issue`{836}
-  `pr`{838}
+  Issue {issue}`836`
+  PR {pr}`838`
+
+Back end changes:
+
+* Add more runtime checks to {func}`fwdpy11.DiploidPopulation.add_mutation`
+  PR {pr}`837`
 
 ## 0.16.2
 
 Documentation
 
 * Document that virtual envs should upgrade `pip`.
-  `pr`{834}
-  `issue`{833}
+  PR {pr}`834`
+  Issue {issue}`833`
 
 Packaging
 
 * Fix import of functions in `fwdpy11.demographic_models.human`.
-  `pr`{835}
-  `issue`{832}
+  PR {pr}`835`
+  Issue {issue}`832`
 
 ## 0.16.1
 
 New features:
 
 * `Mutation.__str__` is now more informative.
-  `pr`{825}
+  PR {pr}`825`
 
 ## 0.16.0
 

--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -3,4 +3,4 @@ matplotlib
 msprime>=1.0.1
 pandas
 sphinx-issues
-git+git://github.com/grahamgower/demesdraw
+git+https://github.com/grahamgower/demesdraw

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -54,7 +54,7 @@ demes==0.1.2
     # via
     #   demesdraw
     #   msprime
-demesdraw @ git+git://github.com/grahamgower/demesdraw
+demesdraw @ git+https://github.com/grahamgower/demesdraw
     # via -r requirements.in
 docutils==0.16
     # via

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import IO, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import demes
@@ -276,7 +277,17 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
             Fixed bug that could generate a :class:`tskit.PopulationTable`
             with an incorrect number of rows.
 
+        .. versionchanged:: 0.17.0
+
+            The `wrapped` keyword argument is deprecated.
+
         """
+        if wrapped is True:
+            warnings.warn(
+                FutureWarning(
+                    "the wrapped kwarg is deprecated and will be removed in a future release"
+                )
+            )
         return fwdpy11.tskit_tools._dump_tables_to_tskit._dump_tables_to_tskit(
             self,
             model_params=model_params,

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -109,7 +109,7 @@ namespace fwdpy11
 
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
-            : Population{ N, length }, diploids(N, { 0, 0 }),
+            : Population{2, N, length }, diploids(N, { 0, 0 }),
               diploid_metadata(N), ancient_sample_metadata{}
         {
             finish_construction({ N });
@@ -117,7 +117,7 @@ namespace fwdpy11
 
         DiploidPopulation(const std::vector<std::uint32_t> &deme_sizes,
                           const double length)
-            : Population{ std::accumulate(begin(deme_sizes), end(deme_sizes),
+            : Population{2, std::accumulate(begin(deme_sizes), end(deme_sizes),
                                           0u),
                           length },
               diploids(std::accumulate(begin(deme_sizes), end(deme_sizes), 0u),

--- a/fwdpy11/headers/fwdpy11/types/Population.hpp
+++ b/fwdpy11/headers/fwdpy11/types/Population.hpp
@@ -69,8 +69,8 @@ namespace fwdpy11
         // represent a matrix of N rows by "dimensions" columns.
         std::vector<double> genetic_value_matrix, ancient_sample_genetic_value_matrix;
 
-        Population(fwdpp::uint_t N_, const double L)
-            : fwdpp_base{N_}, N{N_}, generation{0}, is_simulating{false},
+        Population(fwdpp::uint_t ploidy, fwdpp::uint_t N_, const double L)
+            : fwdpp_base{ploidy*N_}, N{N_}, generation{0}, is_simulating{false},
               tables(init_tables(N_, L)), alive_nodes{}, preserved_sample_nodes{},
               genetic_value_matrix{}, ancient_sample_genetic_value_matrix{}
         {

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -80,24 +80,26 @@ final_population_cleanup(
     bool suppress_edge_table_indexing, bool preserve_selected_fixations,
     bool remove_extinct_mutations_at_finish, bool simulating_neutral_variants,
     bool reset_treeseqs_to_alive_nodes_after_simplification,
-    std::uint32_t last_preserved_generation,
-    const std::vector<std::uint32_t> &last_preserved_generation_counts,
+    std::uint32_t /*last_preserved_generation*/,
+    const std::vector<std::uint32_t> & /*last_preserved_generation_counts*/,
     fwdpy11::DiploidPopulation &pop)
 {
     index_and_count_mutations(suppress_edge_table_indexing, simulating_neutral_variants,
                               reset_treeseqs_to_alive_nodes_after_simplification, pop);
     check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
-    if (pop.generation == last_preserved_generation
-        && !reset_treeseqs_to_alive_nodes_after_simplification
-        && !simulating_neutral_variants)
-        {
-            std::transform(begin(pop.mcounts_from_preserved_nodes),
-                           end(pop.mcounts_from_preserved_nodes),
-                           begin(last_preserved_generation_counts),
-                           begin(pop.mcounts_from_preserved_nodes),
-                           std::minus<std::uint32_t>());
-        }
-    check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
+    // The following block was commented out in GitHub PR 845
+    // in order to fix GitHub issue 844
+    // if (pop.generation == last_preserved_generation
+    //     && !reset_treeseqs_to_alive_nodes_after_simplification
+    //     && !simulating_neutral_variants)
+    //     {
+    //         std::transform(begin(pop.mcounts_from_preserved_nodes),
+    //                        end(pop.mcounts_from_preserved_nodes),
+    //                        begin(last_preserved_generation_counts),
+    //                        begin(pop.mcounts_from_preserved_nodes),
+    //                        std::minus<std::uint32_t>());
+    //     }
+    // check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
     if (!preserve_selected_fixations)
         {
             auto itr = std::remove_if(

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -80,12 +80,13 @@ final_population_cleanup(
     bool suppress_edge_table_indexing, bool preserve_selected_fixations,
     bool remove_extinct_mutations_at_finish, bool simulating_neutral_variants,
     bool reset_treeseqs_to_alive_nodes_after_simplification,
-    std::uint32_t /*last_preserved_generation*/,
+    std::uint32_t last_preserved_generation,
     const std::vector<std::uint32_t> & /*last_preserved_generation_counts*/,
     fwdpy11::DiploidPopulation &pop)
 {
     index_and_count_mutations(suppress_edge_table_indexing, simulating_neutral_variants,
-                              reset_treeseqs_to_alive_nodes_after_simplification, pop);
+                              reset_treeseqs_to_alive_nodes_after_simplification,
+                              last_preserved_generation == pop.generation, pop);
     check_mutation_table_consistency_with_count_vectors(pop, __FILE__, __LINE__);
     // The following block was commented out in GitHub PR 845
     // in order to fix GitHub issue 844

--- a/fwdpy11/src/evolve_population/evolvets.cc
+++ b/fwdpy11/src/evolve_population/evolvets.cc
@@ -660,6 +660,14 @@ evolve_with_tree_sequences(
         remove_extinct_mutations_at_finish, simulating_neutral_variants,
         reset_treeseqs_to_alive_nodes_after_simplification, last_preserved_generation,
         last_preserved_generation_counts, pop);
+    if (pop.tables->edges.size() != pop.tables->input_left.size()
+        || pop.tables->edges.size() != pop.tables->output_right.size())
+        {
+            std::ostringstream o;
+            o << "edge table is not indexed " << strip_unix_path(__FILE__) << ", line "
+              << __LINE__;
+            throw std::runtime_error(o.str());
+        }
     demography.set_model_state(std::move(current_demographic_state));
 }
 

--- a/fwdpy11/src/evolve_population/index_and_count_mutations.cc
+++ b/fwdpy11/src/evolve_population/index_and_count_mutations.cc
@@ -8,17 +8,20 @@ void
 index_and_count_mutations(bool suppress_edge_table_indexing,
                           bool simulating_neutral_variants,
                           bool reset_treeseqs_to_alive_nodes_after_simplification,
+                          bool last_generation_was_recorded,
                           fwdpy11::DiploidPopulation& pop)
 {
     pop.mcounts_from_preserved_nodes.resize(pop.mutations.size(), 0);
-    if (!suppress_edge_table_indexing && !simulating_neutral_variants
+    if (!last_generation_was_recorded && !suppress_edge_table_indexing
+        && !simulating_neutral_variants
         && !reset_treeseqs_to_alive_nodes_after_simplification)
         {
             return;
         }
-    if (pop.ancient_sample_metadata.empty() || simulating_neutral_variants)
+    pop.tables->build_indexes();
+    if (last_generation_was_recorded || pop.ancient_sample_metadata.empty()
+        || simulating_neutral_variants)
         {
-            pop.tables->build_indexes();
             pop.fill_alive_nodes();
             pop.fill_preserved_nodes();
             fwdpp::ts::count_mutations(*pop.tables, pop.mutations, pop.alive_nodes,

--- a/fwdpy11/src/evolve_population/index_and_count_mutations.hpp
+++ b/fwdpy11/src/evolve_population/index_and_count_mutations.hpp
@@ -6,6 +6,7 @@
 void index_and_count_mutations(bool suppress_edge_table_indexing,
                                bool simulating_neutral_variants,
                                bool reset_treeseqs_to_alive_nodes_after_simplification,
+                               bool last_generation_was_recorded,
                                fwdpy11::DiploidPopulation& pop);
 
 #endif

--- a/fwdpy11/src/evolve_population/runtime_checks.cc
+++ b/fwdpy11/src/evolve_population/runtime_checks.cc
@@ -1,7 +1,7 @@
 #include <sstream>
 #include <fwdpy11/types/DiploidPopulation.hpp>
 
-static std::string
+std::string
 strip_unix_path(const std::string file)
 {
     auto pos = file.find_last_of('/');

--- a/fwdpy11/src/evolve_population/runtime_checks.hpp
+++ b/fwdpy11/src/evolve_population/runtime_checks.hpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <fwdpy11/types/Population.hpp>
 
+std::string strip_unix_path(const std::string file);
 void check_mutation_table_consistency_with_count_vectors(const fwdpy11::Population& pop,
                                                          std::string file, int line);
 

--- a/fwdpy11/tskit_tools/metadata.py
+++ b/fwdpy11/tskit_tools/metadata.py
@@ -119,6 +119,10 @@ def decode_individual_metadata(
     .. versionchanged:: 0.15.0
 
         Add index/slice access to the table.
+
+    .. versionchanged:: 0.17.0
+
+        Change input from TableCollection to TreeSequence
     """
     rv = []
 
@@ -197,6 +201,10 @@ def decode_mutation_metadata(
         some elements to be `None`.
 
         Add index/slice access to the table.
+
+    .. versionchanged:: 0.17.0
+
+        Change input from TableCollection to TreeSequence
     """
     mutations = []
     if rows is None:

--- a/tests/test_DiploidPopulation.py
+++ b/tests/test_DiploidPopulation.py
@@ -29,6 +29,10 @@ class TestDiploidPopulation(unittest.TestCase):
     def test_N(self):
         self.assertEqual(self.pop.N, 1000)
 
+    def test_founder_genome_counts(self):
+        self.assertEqual(1, len(self.pop.haploid_genomes))
+        self.assertEqual(2 * self.pop.N, self.pop.haploid_genomes[0].n)
+
     def test_generation(self):
         self.assertEqual(self.pop.generation, 0)
 

--- a/tests/test_metadata_encoding_with_tskit.py
+++ b/tests/test_metadata_encoding_with_tskit.py
@@ -21,8 +21,8 @@ import math
 import typing
 
 import attr
-import fwdpy11.tskit_tools._dump_tables_to_tskit
 import fwdpy11.tskit_tools
+import fwdpy11.tskit_tools._dump_tables_to_tskit
 import numpy as np
 import pytest
 import tskit
@@ -165,7 +165,9 @@ def test_diploid_metadata(mock_population, tables):
         mock_population, tables
     )
 
-    decoded = fwdpy11.tskit_tools.decode_individual_metadata(tables)
+    ts = tables.tree_sequence()
+
+    decoded = fwdpy11.tskit_tools.decode_individual_metadata(ts)
 
     for i in decoded[: len(mock_population.diploid_metadata)]:
         assert i.alive
@@ -207,7 +209,10 @@ def test_mutation_metadata_without_vectors(mock_population, tables):
     fwdpy11.tskit_tools._dump_tables_to_tskit._dump_mutation_site_and_site_tables(
         mock_population, tables
     )
-    decoded = fwdpy11.tskit_tools.decode_mutation_metadata(tables)
+
+    tables.nodes.add_row(time=0.0)
+    ts = tables.tree_sequence()
+    decoded = fwdpy11.tskit_tools.decode_mutation_metadata(ts)
 
     assert len(decoded) == len(mock_population.tables.mutations)
 
@@ -248,7 +253,10 @@ def test_mutation_metadata_with_vectors(mock_population, tables):
     fwdpy11.tskit_tools._dump_tables_to_tskit._dump_mutation_site_and_site_tables(
         mock_population, tables
     )
-    decoded = fwdpy11.tskit_tools.decode_mutation_metadata(tables)
+
+    tables.nodes.add_row(time=0.0)
+    ts = tables.tree_sequence()
+    decoded = fwdpy11.tskit_tools.decode_mutation_metadata(ts)
 
     assert len(decoded) == len(mock_population.tables.mutations)
 

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -1084,7 +1084,7 @@ class TestMetaData(unittest.TestCase):
         MD = namedtuple("MD", ["g", "e", "w", "label"])
 
         class Recorder(object):
-            """ Records entire pop every 100 generations """
+            """Records entire pop every 100 generations"""
 
             def __init__(self):
                 self.data = []
@@ -1524,6 +1524,20 @@ def test_table_indexing_during_sim(test_table_indexing_during_sim_recorder):
         suppress_table_indexing=True,
     )
     assert test_table_indexing_during_sim_recorder.called > 0
+
+
+def test_only_preserve_final_generation():
+    """
+    This test also triggers GitHub issue 844
+    """
+    params, rng, pop = set_up_quant_trait_model(0.1)
+
+    def preserver(pop, sampler):
+        if pop.generation == preserver.when:
+            sampler.assign(np.arange(pop.N, dtype=np.uint32))
+
+    preserver.when = params.simlen
+    fwdpy11.evolvets(rng, pop, params, 100, recorder=preserver)
 
 
 if __name__ == "__main__":

--- a/tests/test_tree_sequences.py
+++ b/tests/test_tree_sequences.py
@@ -560,7 +560,7 @@ class TestTreeSequencesWithAncientSamplesKeepFixations(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.params, self.rng, self.pop = set_up_quant_trait_model(3.0)
-        self.stimes = [i for i in range(1, 101)]
+        self.stimes = [i for i in range(1, 101)] + [self.params.simlen]
         self.recorder = Recorder(42, 10, self.stimes)
         assert self.pop._is_simulating is False
         fwdpy11.evolvets(self.rng, self.pop, self.params, 100, self.recorder)

--- a/tests/test_tskit_metadata.py
+++ b/tests/test_tskit_metadata.py
@@ -17,6 +17,8 @@
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import warnings
+
 import demes
 import fwdpy11
 import pytest
@@ -117,7 +119,9 @@ def test_user_defined_data(pop):
     assert ts.metadata["data"]["mydata"] == 11
 
     # Test WrappedTreeSequence propery
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert wts.data["mydata"] == 11
 
     class MyType(object):
@@ -131,7 +135,9 @@ def test_user_defined_data(pop):
     assert eval(ts.metadata["data"]).x == 11
 
     # Test WrappedTreeSequence property
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert eval(wts.data).x == 11
 
 
@@ -141,7 +147,9 @@ def test_seed(pop):
     assert ts.metadata["seed"] == 333
 
     # Test WrappedTreeSequence property
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert wts.seed == 333
 
     with pytest.raises(ValueError):

--- a/tests/test_wrapped_tskit_tree_sequence.py
+++ b/tests/test_wrapped_tskit_tree_sequence.py
@@ -17,6 +17,8 @@
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import warnings
+
 import fwdpy11
 import msprime
 import numpy as np
@@ -50,36 +52,44 @@ def test_creation(pop):
 
     ts.dump("foo.trees")
 
-    fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        fwdpy11.tskit_tools.WrappedTreeSequence(ts)
 
 
 def test_on_simulated_example(simulation):
     pop, params = simulation
     ts = pop.dump_tables_to_tskit(model_params=params)
 
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts=ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts=ts)
 
     assert wts.model_params == params
 
     times = []
-    for time, nodes, md in wts.timepoints_with_individuals(decode_metadata=True):
-        assert np.all(wts.ts.tables.nodes.time[nodes] == time)
-        for i in md:
-            if time == 0.0:
-                assert i.alive is True
-                assert i.preserved is False
-            else:
-                assert i.alive is False
-                assert i.preserved is True
-            for n in i.nodes:
-                assert wts.ts.tables.nodes.time[n] == time
-        times.append(time)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        for time, nodes, md in wts.timepoints_with_individuals(decode_metadata=True):
+            assert np.all(wts.ts.tables.nodes.time[nodes] == time)
+            for i in md:
+                if time == 0.0:
+                    assert i.alive is True
+                    assert i.preserved is False
+                else:
+                    assert i.alive is False
+                    assert i.preserved is True
+                for n in i.nodes:
+                    assert wts.ts.tables.nodes.time[n] == time
+            times.append(time)
 
     assert np.all(np.array(times) == np.arange(pop.generation, dtype=np.float64)[::-1])
 
     ## Test storing two model param object
     ts = pop.dump_tables_to_tskit(model_params={"stage1": params, "stage2": params})
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     mp = wts.model_params
     assert len(mp) == 2
     for _, value in mp.items():
@@ -90,17 +100,23 @@ def test_generation_property(simulation):
     pop, _ = simulation
     assert pop.generation > 0
     ts = pop.dump_tables_to_tskit()
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts=ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts=ts)
     assert wts.generation == pop.generation
 
 
 def test_demes_graph_property(gutenkunst):
     pop = fwdpy11.DiploidPopulation(100, 1.0)
     ts = pop.dump_tables_to_tskit(demes_graph=gutenkunst)
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert wts.demes_graph == gutenkunst
     ts = pop.dump_tables_to_tskit()
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert wts.demes_graph is None
 
 
@@ -110,5 +126,7 @@ def test_with_msprime_provenance_added():
     ts = pop.dump_tables_to_tskit()
     ts = msprime.sim_mutations(ts, rate=1e-5, random_seed=1)
     assert ts.tables.provenances.num_rows == 2
-    wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        wts = fwdpy11.tskit_tools.WrappedTreeSequence(ts)
     assert wts.ts.tables.provenances.num_rows == 2


### PR DESCRIPTION
- C++ back-end for DiploidPopulation now passes ploidy to base class. (#838)
- Add additional runtime checks to fwdpy11.DiploidPopulation.add_mutation (#837)
- fix up change log (#839)
- Remove extra copies of tskit.TableCollection in metadata decoding functions (#842)
- Deprecate WrappedTreeSequence (#841)
- Use git+https to install demesdraw for docs (#843)
- Fix population cleanup code in back-end (#845)
- Change index_and_count_mutations to force a count when individuals from final generation got marked as ancient samples.
- enforce returning indexed edge tables
