### PR TITLE
Refactor demography debugger

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -12,6 +12,12 @@ Breaking changes
   headaches when new Python point releases come out.
   PR {pr}`924`. Issue {issue}`876`.
 
+Behavior changes
+
+* {func}`fwdpy11.DemographyDebugger.report` raises a warning
+  to state that it has not been implemented.
+  It returns a string with a message to that effect.
+
 Bug fixes
 
 * Fixed a bug in event time handling from `demes` models.
@@ -47,6 +53,8 @@ Back end changes
   aid in importing models from `demes`.
   PR {pr}`900`.
   PR {pr}`904`.
+* Completely rebuild {class}`fwdpy11.DemographyDebugger`.
+  PR {pr}`906`.
 
 Dependencies
 

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -16,17 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 #
-import collections
+from dataclasses import dataclass
 import copy
 import warnings
 from typing import Dict, List, Optional, Union
 
-import attr
 import fwdpy11
 import numpy as np
 
 from ..demographic_models import DemographicModelDetails
-from ..discrete_demography import DiscreteDemography, _DemeSizeHistory
+from ..discrete_demography import (
+    DiscreteDemography,
+    _DemeSizeHistory,
+    SetSelfingRate,
+    SetDemeSize,
+    SetExponentialGrowth,
+    MassMigration,
+    SetMigrationRates,
+    MigrationMatrix,
+)
 from .diploid_population import DiploidPopulation
 
 
@@ -43,10 +51,17 @@ def _create_event_list(o):
 
 def _create_initial_deme_sizes(o):
     try:
-        md = np.array(o.diploid_metadata, copy=False)
-        return np.unique(md["deme"], return_counts=True)[1].tolist()
+        sizes = o.deme_sizes(as_dict=True)
+        return sizes
     except AttributeError:
-        return o
+        if isinstance(o, dict):
+            return o
+        else:
+            rv = {}
+            for i, s in enumerate(o):
+                if s > 0:
+                    rv[i] = s
+            return rv
 
 
 def _convert_simlen(simlen):
@@ -55,7 +70,23 @@ def _convert_simlen(simlen):
     return int(simlen)
 
 
-@attr.s()
+@dataclass
+class _DemographyEvents:
+    migmatrix: Optional[MigrationMatrix]
+    mass_migrations: Optional[List[MassMigration]]
+    set_deme_sizes: Optional[List[SetDemeSize]]
+    set_growth_rates: Optional[List[SetExponentialGrowth]]
+    set_selfing_rates: Optional[List[SetSelfingRate]]
+    set_migration_rates: Optional[List[SetMigrationRates]]
+
+
+@dataclass
+class MigrationMatrixEpoch:
+    start: int
+    migration_matrix: MigrationMatrix
+
+
+@dataclass
 class DemographyDebugger(object):
     """
     Efficiently debug demographic events.
@@ -90,508 +121,176 @@ class DemographyDebugger(object):
         A list of initial deme sizes is now accepted.
     """
 
-    initial_deme_sizes: Union[List[int], DiploidPopulation] = attr.ib(
-        converter=_create_initial_deme_sizes
-    )
-    _events: Union[DiscreteDemography, DemographicModelDetails] = attr.ib(
-        converter=_create_event_list
-    )
-    simlen: int = attr.ib(converter=_convert_simlen, default=None)
-    deme_labels: Optional[Dict] = attr.ib(default=None)
+    initial_deme_sizes: Union[List[int], Dict[int, int], DiploidPopulation]
+    events: Union[DiscreteDemography, DemographicModelDetails]
+    simlen: Optional[int] = None
+    deme_labels: Optional[Dict] = None
 
-    def __attrs_post_init__(self):
-        self._validate_migration_rate_change_lengths(self._events)
-
-        self.maxdemes = self._get_maxdemes()
-
-        if self.maxdemes < 1:
-            raise ValueError(
-                "Invalid number of " "demes in simulation: {}".format(self.maxdemes)
+    def __post_init__(self):
+        sizes = _create_initial_deme_sizes(self.initial_deme_sizes)
+        if isinstance(self.events, DiscreteDemography):
+            self._size_history = _DemeSizeHistory.from_lowlevel(
+                sizes,
+                mass_migrations=self.events.mass_migrations,
+                set_deme_sizes=self.events.set_deme_sizes,
+                set_growth_rates=self.events.set_growth_rates,
+                total_simulation_length=self.simlen,
             )
+            temp: fwdpy11.DiscreteDemography = self.events
+        else:
+            self._size_history = _DemeSizeHistory.from_lowlevel(
+                sizes,
+                mass_migrations=self.events.model.mass_migrations,
+                set_deme_sizes=self.events.model.set_deme_sizes,
+                set_growth_rates=self.events.model.set_growth_rates,
+                total_simulation_length=self.simlen,
+            )
+            temp: fwdpy11.DiscreteDemography = self.events.model
 
-        self.current_deme_sizes = np.zeros(self.maxdemes, dtype=np.uint32)
-        for i, j in enumerate(self.initial_deme_sizes):
-            self.current_deme_sizes[i] = j
-
-        self.growth_rates = np.array([fwdpy11.NOGROWTH] * self.maxdemes)
-        self.growth_onset_times = np.zeros(self.maxdemes, dtype=np.uint32)
-        self.selfing_rates = np.zeros(self.maxdemes)
-        self.growth_initial_sizes = np.copy(self.current_deme_sizes)
-        # NOTE/FIXME: some of the logic re: went_extinct and has_metadata
-        # is redundant, convoluted, or both.
-        self.went_extinct = np.zeros(self.maxdemes, dtype=np.int32)
-        self.has_metadata = np.zeros(self.maxdemes, dtype=np.int32)
-        self.has_metadata[(self.current_deme_sizes > 0)] = 1
-
-        # The real work
-        self._report = None
-        self._process_demographic_model(self._events, self.simlen)
-
-        # NOTE: this is a placeholder for refactoring this entire
-        # class
-        if isinstance(self._events, fwdpy11.DiscreteDemography):
-            self.size_history = _DemeSizeHistory.from_lowlevel(
-                {i: j for i, j in enumerate(self.initial_deme_sizes)},
-                mass_migrations=self._events.mass_migrations,
-                set_deme_sizes=self._events.set_deme_sizes,
-                set_growth_rates=self._events.set_growth_rates,
+        if temp.migmatrix is not None:
+            event_list = _DemographyEvents(
+                np.copy(temp.migmatrix.migmatrix),
+                temp.mass_migrations,
+                temp.set_deme_sizes,
+                temp.set_growth_rates,
+                temp.set_selfing_rates,
+                temp.set_migration_rates,
             )
         else:
-            self.size_history = _DemeSizeHistory.from_lowlevel(
-                {i: j for i, j in enumerate(self.initial_deme_sizes)},
-                mass_migrations=self._events.model.mass_migrations,
-                set_deme_sizes=self._events.model.set_deme_sizes,
-                set_growth_rates=self._events.model.set_growth_rates,
+            event_list = _DemographyEvents(
+                temp.migmatrix,
+                temp.mass_migrations,
+                temp.set_deme_sizes,
+                temp.set_growth_rates,
+                temp.set_selfing_rates,
+                temp.set_migration_rates,
             )
 
-    @initial_deme_sizes.validator
-    def validate_initial_deme_sizes(self, attribute, value):
-        if len(value) == 0:
-            raise ValueError("Initial deme sizes not provided")
-        if any([i < 0 for i in value]) is True:
-            raise ValueError("Initial deme sizes cannot be negative")
-        for i in value:
-            attr.validators.instance_of(int)(self, attribute, i)
+        self.migration_history = self._build_migration_history(event_list)
+        self._validate_epochs(event_list)
 
-    @simlen.validator
-    def validate_simlen(self, attribute, value):
-        if value is not None:
-            attr.validators.instance_of(int)(self, attribute, value)
-            if value <= 0:
-                raise ValueError("simlen must be None or > 0")
+    def _build_migration_history(
+        self, events: _DemographyEvents
+    ) -> Optional[List[MigrationMatrixEpoch]]:
+        if events.migmatrix is None:
+            return None
 
-    def _get_maxdemes(self):
-        """
-        The maximum number of demes the sim can ever see.
-        """
-        max_from_md = len(self.initial_deme_sizes)
-        max_from_events = -1
-
-        def update_max_from_events(m, e):
-            if e is None:
-                return m
-            for i in e:
-                try:
-                    m = max(m, i.deme)
-                except AttributeError:
-                    m = max(m, i.source)
-                    m = max(m, i.destination)
-            return m
-
-        for i in [
-            self._events.mass_migrations,
-            self._events.set_growth_rates,
-            self._events.set_deme_sizes,
-            self._events.set_selfing_rates,
-            self._events.set_migration_rates,
-        ]:
-            max_from_events = update_max_from_events(max_from_events, i)
-
-        # NOTE: Changed in 0.10.1 from
-        # current_max = max(max_from_md, max_from_events) + 1
-        # to addres GitHub issue 594.
-        current_max = max(max_from_md, max_from_events + 1)
-        if self._events.migmatrix is None:
-            return current_max
-
-        # NOTE: changed from < to != in 0.10.1
-        if self._events.migmatrix.shape[0] != current_max:
-            raise ValueError(
-                f"The MigrationMatrix shape, {self._events.migmatrix.shape}, "
-                f"does not match the max number of "
-                f"demes present in the "
-                f"simulation, {current_max}"
-            )
-
-        if self._events.migmatrix.shape[0] == 1:
+        current_migmatrix = np.copy(events.migmatrix)
+        if current_migmatrix.ndim == 1 and len(current_migmatrix) == 1:
             warnings.warn(
                 "You are using a 1x1 migration matrix."
-                " You should prefer a migration matrix set to None in this case."
+                " You should prefer a migration matrix set to None."
             )
 
-        # NOTE: this is the return value prior to 0.10.1:
-        # max(current_max, self._events.migmatrix.shape[0])
-        return current_max
+        # For the input migration matrix, make sure that all
+        # source/dest pairings exist in generation 1
+        for dest in range(current_migmatrix.shape[0]):
+            for source, rate in enumerate(current_migmatrix[dest, :]):
+                if rate > 0.0:
+                    if self._size_history.deme_exists_at(source, 1) is False:
+                        raise ValueError(
+                            f"deme {source} does not exist at generation 1"
+                        )
+                    if self._size_history.deme_exists_at(dest, 1) is False:
+                        raise ValueError(f"deme {dest} does not exist at generation 1")
 
-    def _validate_migration_rate_change_lengths(self, events):
-        """
-        Various checks on the lengths of new migration rates.
-        """
-        if (
-            self._events.migmatrix is None
-            and events.set_migration_rates is not None
-            and len(events.set_migration_rates) > 0
-        ):
-            raise ValueError(
-                "migration rate changes are " "set but there is no migration matrix"
-            )
-        if events.set_migration_rates is not None:
-            for i in events.set_migration_rates:
-                if i.deme >= 0:
-                    if len(i.migrates) != self._events.migmatrix.shape[0]:
-                        raise ValueError("Migration rates mismatch")
-                else:  # Are replacing the entire matrix
-                    if len(i.migrates.flatten()) != len(
-                        self._events.migmatrix.M.flatten()
-                    ):
-                        raise ValueError("Migration rates mismatch")
+        rv = []
+        if events.set_migration_rates is None:
+            rv.append(MigrationMatrixEpoch(0, current_migmatrix))
+        else:
+            times = []
+            for m in events.set_migration_rates:
+                if m.when not in times:
+                    times.append(m.when)
+            times = sorted(times)
+            for time in times:
+                destinations = set()
+                for m in [m for m in events.set_migration_rates if m.when == time]:
+                    if m.deme is not None and m.deme < 0:
+                        if len(destinations) > 0:
+                            raise ValueError(
+                                f"entire migration matrix changed at when={m.when} in combination with"
+                                " migration rate changes set for other demes individually"
+                            )
+                        if current_migmatrix.shape != m.migrates.shape:
+                            raise ValueError(
+                                f"migration matrix change at when={m.when} has an invalid shape"
+                            )
+                        current_migmatrix = np.copy(m.migrates).reshape(
+                            current_migmatrix.shape
+                        )
+                    else:
+                        if -1 in destinations:
+                            raise ValueError(
+                                f"entire migration matrix changed at when={m.when} in combination with"
+                                " migration rate changes set for other demes individually"
+                            )
+                        if m.deme in destinations:
+                            raise ValueError(
+                                f"mutltiple migration rate changes for deme {m.deme} at when={m.when}"
+                            )
+                        # TODO: This will error out via numpy if the dimensions are bad.
+                        # It would be better to have a clearer message.
+                        current_migmatrix[m.deme, :] = np.copy(m.migrates)
+                    destinations.add(m.deme)
 
-    def _make_event_queues(self, events):
-        """
-        Take references from the input so that we can process them
-        w/o affecting the input.
-        """
-        from collections import deque
-
-        rv = {}
-        for e in fwdpy11.DiscreteDemography._event_names_list():
-            if events.__getattribute__(e) is not None:
-                rv[e] = deque([i for i in events.__getattribute__(e)])
-            else:
-                rv[e] = deque([])
-
+                rv.append(MigrationMatrixEpoch(time + 1, np.copy(current_migmatrix)))
         return rv
 
-    def _get_next_event_time(self, event_queues):
-        t = None
-        for _, value in event_queues.items():
-            if len(value) > 0:
-                if t is None:
-                    t = value[0].when
-                else:
-                    t = min(t, value[0].when)
-        return t
-
-    def _current_events(self, t, event_queues, event):
-        elist = []
-        while len(event_queues[event]) > 0 and event_queues[event][0].when == t:
-            e = event_queues[event][0]
-            elist.append(e)
-            event_queues[event].popleft()
-        return elist
-
-    def _label_deme(self, d):
-        if self.deme_labels is None:
-            return d
-        if d not in self.deme_labels:
-            return d
-        return self.deme_labels[d]
-
-    def _format_deme_sizes(self, sizes):
-        rv = collections.OrderedDict()
-        for i, j in enumerate(sizes):
-            rv[self._label_deme(i)] = j
-        return [(i, j) for i, j in rv.items()]
-
-    def _apply_MassMigration(self, t, event_queues):
-        for e in self._current_events(t, event_queues, "mass_migrations"):
-            if self.current_deme_sizes[e.source] == 0:
-                temp = (e, self._label_deme(e.source))
-                raise ValueError(
-                    "mass migration at time {} involves "
-                    "empty source deme {}".format(*temp)
-                )
-            # NOTE: what is the C++ back-end doing if n_from_source < 1?
-            # Answer: currently, that passes silently--is that okay?
-            n_from_source = np.rint(
-                self.current_deme_sizes[e.source] * e.fraction
-            ).astype(int)
-            if n_from_source == 0:
-                # Assume that this occurs from rounding issues,
-                # so we treat it as a warning rather than an error
-                temp = (t, self._label_deme(e.source), self._label_deme(e.destination))
-                message = (
-                    "mass migration at time {} from {} " + "to {} moves no individuals"
-                )
-                warnings.warn(message.format(*temp))
-            if (
-                n_from_source > self.current_deme_sizes[e.source]
-                and e.move_individuals is True
-            ):
-                temp = (t, n_from_source, self._label_deme(e.source))
-                raise ValueError(
-                    "mass migration at time {} "
-                    "moves {} individuals from "
-                    "source deme {}".format(*temp)
-                )
-            if e.move_individuals is True:
-                self.current_deme_sizes[e.source] -= n_from_source
-                self.current_deme_sizes[e.destination] += n_from_source
-                temp = (
-                    n_from_source,
-                    self._label_deme(e.source),
-                    self._label_deme(e.destination),
-                )
-                self._report.append(
-                    "\tMass movement of {} " "from {} to {}\n".format(*temp)
-                )
-                if n_from_source > 0:
-                    self.has_metadata[e.destination] = 1
-                if e.fraction == 1.0:
-                    self.went_extinct[e.source] = 1
-                    self.has_metadata[e.source] = 0
-            else:  # A copy
-                if n_from_source > 0:
-                    self.has_metadata[e.destination] = 1
-                self.current_deme_sizes[e.destination] += n_from_source
-                temp = (
-                    n_from_source,
-                    self._label_deme(e.source),
-                    self._label_deme(e.destination),
-                )
-                self._report.append(
-                    "\tMass copy of {} " "from {} to {}\n".format(*temp)
-                )
-            if e.resets_growth_rate is True:
-                self.growth_rates[e.source] = fwdpy11.NOGROWTH
-                self.growth_rates[e.destination] = fwdpy11.NOGROWTH
-                s = "\t\tGrowth rates reset to {} in {} and {}\n"
-                temp = (
-                    fwdpy11.NOGROWTH,
-                    self._label_deme(e.source),
-                    self._label_deme(e.destination),
-                )
-                self._report.append(s.format(*temp))
-            # Even if growth rates are not reset,
-            # the onset times and initial sizes are affected
-            self.growth_onset_times[e.source] = t
-            self.growth_onset_times[e.destination] = t
-            self.growth_initial_sizes[e.source] = self.current_deme_sizes[e.source]
-            self.growth_initial_sizes[e.destination] = self.current_deme_sizes[
-                e.destination
-            ]
-            self._report.append("\t\tGrowth onset times changed:\n")
-            temp = (t, self._label_deme(e.source))
-            self._report.append("\t\t\t{} in deme {}\n".format(*temp))
-            temp = (t, self._label_deme(e.destination))
-            self._report.append("\t\t\t{} in deme {}\n".format(*temp))
-            self._report.append("\t\tGrowth initial sizes changed:\n")
-            temp = (self.growth_initial_sizes[e.source], self._label_deme(e.source))
-            self._report.append("\t\t\t{} in deme {}\n".format(*temp))
-            temp = (
-                self.growth_initial_sizes[e.destination],
-                self._label_deme(e.destination),
-            )
-            self._report.append("\t\t\t{} in deme {}\n".format(*temp))
-
-    def _apply_SetDemeSize(self, t, event_queues):
-        for e in self._current_events(t, event_queues, "set_deme_sizes"):
-            self.current_deme_sizes[e.deme] = e.new_size
-            if e.new_size == 0:
-                self.went_extinct[e.deme] = 1
-            temp = (e.new_size, self._label_deme(e.deme))
-            self._report.append("\tDeme size set to {} " "in deme {}\n".format(*temp))
-            if e.resets_growth_rate is True:
-                self.growth_rates[e.deme] = fwdpy11.NOGROWTH
-                temp = (fwdpy11.NOGROWTH,)
-                self._report.append("\t\tGrowth rate set to " "{}\n".format(*temp))
-
-            # Deme size has change.  So, no matter what,
-            # there is a new onsite time for growth!
-            self.growth_onset_times[e.deme] = t
-            self.growth_initial_sizes[e.deme] = self.current_deme_sizes[e.deme]
-            temp = self.growth_initial_sizes[e.deme]
-            self._report.append("\t\tGrowth initial size " "set to {}\n".format(temp))
-
-    def _apply_SetSelfingRate(self, t, event_queues):
-        for e in self._current_events(t, event_queues, "set_selfing_rates"):
-            if self.current_deme_sizes[e.deme] == 0:
-                temp = (self._label_deme(e.deme), e.when)
-                raise ValueError(
-                    "Setting selfing rate in "
-                    "extinct deme {} at "
-                    "time {}".format(*temp)
-                )
-            self.selfing_rates[e.deme] = e.S
-            temp = (e.S, self._label_deme(e.deme))
-            self._report.append(
-                "\tSelfing probability " "set to {} in deme {}\n".format(*temp)
-            )
-
-    def _apply_SetExponentialGrowth(self, t, event_queues):
-        for e in self._current_events(t, event_queues, "set_growth_rates"):
-            if self.current_deme_sizes[e.deme] == 0:
-                temp = (self._label_deme(e.deme), e.when)
-                raise ValueError(
-                    "attempt to change growth "
-                    "rate in extinct deme {} "
-                    "at time {}".format(*temp)
-                )
-            self.growth_rates[e.deme] = e.G
-            self.growth_onset_times[e.deme] = t
-            self.growth_initial_sizes[e.deme] = self.current_deme_sizes[e.deme]
-            temp = (self._label_deme(e.deme), e.G)
-            self._report.append("\tGrowth rate " "in deme {} set to {}\n".format(*temp))
-            self._report.append("\t\tOnset time: {}\n".format(t))
-            N = self.growth_initial_sizes[e.deme]
-            self._report.append("\t\tOnset size: {}\n".format(N))
-
-    def _apply_SetMigrationRates(self, t, event_queues):
-        for e in self._current_events(t, event_queues, "set_migration_rates"):
-            if e.deme >= 0:
-                self._events.migmatrix.M[e.deme, :] = e.migrates
-                temp = (self._label_deme(e.deme), e.migrates)
-                self._report.append(
-                    "\tMigration rates into " "deme {} set to {}\n".format(*temp)
-                )
+    def _validate_epochs(self, events: _DemographyEvents):
+        for epoch in self._size_history.epochs:
+            if epoch.begin > 0:
+                when_ancestor_must_exist = epoch.begin - 1
             else:
-                self._events.migmatrix.M[:] = e.migrates.reshape(
-                    self._events.migmatrix.M.shape
-                )
-                self._report.append(
-                    "\tMigration matrix "
-                    "reset to:\n\t\t{}".format(self._events.migmatrix.M)
-                )
-
-    def _apply_growth_rates(self, t, event_queues):
-        next_deme_sizes = np.copy(self.current_deme_sizes)
-        for i, j in enumerate(self.growth_rates):
-            if j != fwdpy11.NOGROWTH:
-                if self.current_deme_sizes[i] == 0:
-                    temp = (t, self._label_deme(i))
-                    raise ValueError(
-                        "growth is happening "
-                        "at time {} in extinct "
-                        "deme {}".format(*temp)
-                    )
-                onset = self.growth_onset_times[i]
-                G = self.growth_rates[i]
-                Nonset = self.growth_initial_sizes[i]
-                nextN = np.rint(Nonset * np.power(G, t - onset + 1)).astype(int)
-                if nextN <= 0:
-                    nextN = 0
-                    self.growth_rates[i] = fwdpy11.NOGROWTH
-                    self.growth_initial_sizes[i] = 0
-                    self.growth_onset_times[i] = t
-                    self.went_extinct[i] = 1
-                next_deme_sizes[i] = nextN
-
-        return next_deme_sizes
-
-    def _validate_migration_rates(self, t, next_deme_sizes):
-        if self._events.migmatrix is None:
-            return
-        for i, j in enumerate(next_deme_sizes):
-            if j == 0:
-                if (
-                    self._events.migmatrix.M[
-                        i,
-                    ].sum()
-                    != 0
-                ):
-                    temp = (self._label_deme(i), t, self._events.migmatrix.M[i, j])
-                    raise ValueError(
-                        "there is migration "
-                        "into empty deme {} "
-                        "at time {}, "
-                        "migrates={}".format(*temp)
-                    )
-
-    def _check_for_valid_parents(self, t):
-        for i, j in enumerate(self.has_metadata):
-            if j == 0 and self.current_deme_sizes[i] > 0:
-                N = self.current_deme_sizes[i]
-                if self._events.migmatrix is None:
-                    s = "deme {} has size {} at time {} " + "but has no valid parents"
-                    temp = (self._label_deme(i), N, t)
-                    raise ValueError(s.format(*temp))
-                elif self._events.migmatrix.M[i, i] != 0.0:
-                    s = (
-                        "deme {} at time {} "
-                        + "has no valid parents in that deme "
-                        + "but M[i, i] != 0"
-                    )
-                    temp = (self._label_deme(i), N, t)
-                    raise ValueError(s.format(*temp))
-                elif (
-                    self._events.migmatrix.M[
-                        i,
-                    ].sum()
-                    > 0
-                ):
-                    self.has_metadata[i] = 1
-                    self.went_extinct[i] = 0
-            elif self.current_deme_sizes[i] > 0 and self._events.migmatrix is not None:
-                # NOTE: Fix for issue 538, in 0.8.2
-                if (
-                    self._events.migmatrix.M[
-                        i,
-                    ].sum()
-                    == 0
-                ):
-                    s = (
-                        f"deme {i} at time {t} has size {self.current_deme_sizes[i]} "
-                        f"but an empty row in the migration matrix"
-                    )
-                    raise ValueError(s)
-
-    def _generate_report(self, event_queues, simlen):
-        """
-        Apply events in the same way as the C++
-        back-end.
-        """
-        temp = self._format_deme_sizes(self.current_deme_sizes)
-        self._report = ["Deme sizes at time {}: {}\n".format(0, temp)]
-        t = self._get_next_event_time(event_queues)
-        if t is not None and t > 0:
-            # If the first event is after time zero, let's make
-            # sure that the input migration matrix is valid.
-            # This fixes github issue 544
-            self._validate_migration_rates(0, self.current_deme_sizes)
-        global_extinction = False
-        last_t = None
-        while t is not None and global_extinction is False:
-            self.has_metadata[(self.went_extinct == 1)] = 0
-            self.went_extinct[:] = 0
-            self.current_deme_sizes[:] = self._apply_growth_rates(t - 1, event_queues)
-            self._report.append("Events at time {}:\n".format(t))
-            self._apply_MassMigration(t, event_queues)
-            self._apply_SetDemeSize(t, event_queues)
-            self._apply_SetExponentialGrowth(t, event_queues)
-            self._apply_SetSelfingRate(t, event_queues)
-            self._apply_SetMigrationRates(t, event_queues)
-            next_deme_sizes = self._apply_growth_rates(t, event_queues)
-            self._check_for_valid_parents(t)
-            temp = self._format_deme_sizes(next_deme_sizes)
-            sizes = "\tDeme sizes after growth: {}\n".format(temp)
-            self._report.append(sizes)
-            extinct = "\tThe following demes went extinct: {}\n"
-            e = np.where(self.went_extinct == 1)[0]
-            if len(e) > 0:
-                self._report.append(extinct.format(e))
-            extinct = "\tThe following demes are extinct: {}\n"
-            e = np.where(self.has_metadata == 0)[0]
-            if len(e) > 0:
-                self._report.append(extinct.format(e))
-            if next_deme_sizes.sum() == 0:
-                global_extinction = True
-                temp = "Global extinction occurs at time {}".format(t)
-                warnings.warn(temp)
-                self._report.append(temp + "\n")
-            self._validate_migration_rates(t, next_deme_sizes)
-            self.current_deme_sizes = next_deme_sizes
-            last_t = t
-            if simlen is not None and last_t > simlen:
-                warnings.warn(f"current time {last_t} is > simulation length {simlen}")
-            t = self._get_next_event_time(event_queues)
-
-        if simlen is not None and simlen > last_t:
-            deme_sizes = np.copy(self.current_deme_sizes)
-            for i, j in enumerate(deme_sizes):
-                if j > 0:
-                    G = self.growth_rates[i]
-                    if G != fwdpy11.NOGROWTH:
-                        N0 = self.growth_initial_sizes[i]
-                        t0 = self.growth_onset_times[i]
-                        N = np.rint(N0 * np.power(G, simlen - t0)).astype(int)
-                        deme_sizes[i] = N
-            temp = "Final deme sizes at time {}: {}"
-            deme_sizes = self._format_deme_sizes(deme_sizes)
-            self._report.append(temp.format(simlen, deme_sizes))
-
-    def _process_demographic_model(self, events, simlen):
-        event_queues = self._make_event_queues(events)
-        self._generate_report(event_queues, simlen)
+                when_ancestor_must_exist = 0
+            if epoch.data.ancestors is not None:
+                for a in epoch.data.ancestors:
+                    if (
+                        self._size_history.deme_exists_at(a, when_ancestor_must_exist)
+                        is False
+                    ):
+                        raise ValueError(
+                            f"deme {a} does not exist at {when_ancestor_must_exist}"
+                        )
+                    if (
+                        when_ancestor_must_exist > 0
+                        and self.migration_history is not None
+                    ):
+                        i = None
+                        for j in reversed([m for m in self.migration_history]):
+                            # TODO: is this correct?
+                            # Go back and check how we are building
+                            # the migration history
+                            if when_ancestor_must_exist >= j.start:
+                                i = j
+                                break
+                        if i is not None:
+                            ttl_rate_in = i.migration_matrix[epoch.data.deme, :].sum()
+                            if not ttl_rate_in > 0:
+                                raise ValueError(
+                                    f"the migration rantes into deme {epoch.data.deme} are 0.0 at time {i.start}"
+                                )
+            else:
+                if events.migmatrix is None:
+                    raise ValueError("a MigrationMatrix is required for this model.")
+                else:
+                    # TODO: does migration fix this?
+                    if self.migration_history is not None:
+                        i = None
+                        for j in reversed([m for m in self.migration_history]):
+                            if when_ancestor_must_exist >= j.start:
+                                i = j
+                                break
+                        if i is not None:
+                            row = i.migration_matrix[epoch.data.deme, :]
+                            for source, rate in enumerate(row):
+                                source_exists = self._size_history.deme_exists_at(
+                                    source, i.start - 1
+                                )
+                                if rate > 0.0 and source_exists is False:
+                                    raise ValueError(
+                                        f"migration rate is > 0.0 from deme {source}, which doest not exist at time {i.start-1}"
+                                    )
 
     @property
     def report(self):
@@ -599,4 +298,5 @@ class DemographyDebugger(object):
         Obtain the details of the demographic
         model as a nicely-formatting string.
         """
-        return str("").join(self._report)
+        warnings.warn("report generation has not been implemented")
+        return "DemographyDebugger::report not yet implemented"

--- a/fwdpy11/discrete_demography.py
+++ b/fwdpy11/discrete_demography.py
@@ -712,7 +712,7 @@ class _SortedEvents:
 
 
 def _get_N_exp_growth(N0: int, t: int, G: float) -> int:
-    return int(np.rint(N0 * G ** t))
+    return int(np.rint(N0 * G**t))
 
 
 def _get_epoch_end_size(
@@ -794,6 +794,10 @@ def _process_lowlevel_mass_migrations(mass_migrations, deme_sizes):
                         new_ancestors = sorted(new_ancestors)
                 else:
                     new_ancestors = [mass_mig_event.source]
+
+                if mass_mig_event.fraction == 1.0:
+                    new_ancestors = None
+
                 deme_sizes[mass_mig_event.source].append(
                     _DemeSize(
                         mass_mig_event.source,
@@ -942,6 +946,8 @@ def _process_lowlevel_set_deme_sizes(set_deme_sizes, deme_sizes):
             if event.when + 1 != deme_sizes[event.deme][-1].when:
                 if deme_sizes[event.deme][-1].ancestors is None:
                     new_ancestors = None
+                elif deme_sizes[event.deme][-1].size == 0:
+                    new_ancestors = None
                 else:
                     new_ancestors = [event.deme]
 
@@ -957,6 +963,8 @@ def _process_lowlevel_set_deme_sizes(set_deme_sizes, deme_sizes):
             else:
                 deme_sizes[event.deme][-1].size = event.new_size
                 deme_sizes[event.deme][-1].growth_parameter = 1.0
+                if deme_sizes[event.deme][-1].size == 0:
+                    deme_sizes[event.deme][-1].ancestors = None
         else:
             # Inherit the growth rate from the previous epoch
             if event.deme in deme_sizes:
@@ -964,6 +972,8 @@ def _process_lowlevel_set_deme_sizes(set_deme_sizes, deme_sizes):
                 lastG = deme_sizes[event.deme][-1].growth_parameter
                 if event.when + 1 != deme_sizes[event.deme][-1].when:
                     if deme_sizes[event.deme][-1].ancestors is None:
+                        new_ancestors = None
+                    elif deme_sizes[event.deme][-1].size == 0:
                         new_ancestors = None
                     else:
                         new_ancestors = [event.deme]
@@ -980,6 +990,8 @@ def _process_lowlevel_set_deme_sizes(set_deme_sizes, deme_sizes):
                 else:
                     deme_sizes[event.deme][-1].size = event.new_size
                     deme_sizes[event.deme][-1].growth_parameter = lastG
+                    if event.new_size == 0:
+                        deme_sizes[event.deme][-1].ancestors = None
             else:
                 # There is no previous epoch for this deme,
                 # so we initialize with G = 1.0
@@ -1189,7 +1201,7 @@ class _DemeSizeHistory:
             if interval.data.deme == deme:
                 data = interval.data
                 t = generation - interval.begin + 1
-                return int(np.rint(data.initial_size * data.growth_parameter ** t))
+                return int(np.rint(data.initial_size * data.growth_parameter**t))
 
     def demes_coexist_at(self, demes: typing.Tuple[int, int], generation: int) -> bool:
         for deme in demes:


### PR DESCRIPTION
This PR rebuilds the DemographyDebugger, which is meant to validate
models involving discrete demes.

This PR builds on types introduced in #900.  It also fixes some bugs in those types.

Related issues:

#887
#890
#881
