### PR TITLE
pin python versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,12 +69,13 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          python -m pip install --upgrade pip setuptools
           python -m pip install --user "pybind11[global]" wheel
           python -m pip install --user --upgrade -r requirements/development.txt
 
       - name: Build module
         run: |
-            python3 setup.py build_ext -i
+            python3 -m pip install -e .
 
       - name: Build the docs
         working-directory: doc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,9 @@ jobs:
           # conda init bash
           source ~/.bashrc
           conda activate anaconda-client-env
-          python setup.py build_ext --inplace
+          # NOTE: python -m pip install -e . 
+          # fails in GitHub actions on conda/macOS
+          python setup.py build_ext -i
 
       - name: Build and run C++ tests
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Compile extension module
         run: |
-            CXX=$CXX CC=$CC python setup.py build_ext -i
+            CXX=$CXX CC=$CC python -m pip install -e .
 
       - name: Run Python tests
         run: |

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -46,6 +46,11 @@ Dependencies
 * Bump minimum `pybind11` to 2.9.0.
   PR {pr}`922`.
 
+Build System
+
+* `setup.cfg` now pins minimum and maximum Python versions.
+  PR {pr}`923`.  Issue {issue}`914`.
+
 ## 0.17.1
 
 Bug fixes

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 packages = fwdpy11
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.7, <3.11
 # NOTE: any pinning should also be coordinated
 # with requirements.in and doc/requirements.in
 # and may require regenerating the .txt files.


### PR DESCRIPTION
- Change python_requires in setup.cfg to >=3.7, < 3.11
- Use pip install -e to build/install module for Ubuntu tests.
- Use pip install -e . for conda build/install.
