### PR TITLE
update demes2fwdpy11 test

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -12,6 +12,11 @@ Back end changes
 * Refactor a class decorator used to pickle/unpickle `attrs`-based classes.
   PR {pr}`948`.
 
+Bug fixes
+
+* Fixed edge case when importing demes models with burn-in time of 0.
+  PR {pr}`949`.
+
 ## 0.18.1
 
 Bug fixes

--- a/fwdpy11/_functions/import_demes.py
+++ b/fwdpy11/_functions/import_demes.py
@@ -506,9 +506,19 @@ def _process_epoch(
         assert size_history.deme_exists_at(idmap[deme_id], when)
 
     if e.selfing_rate is not None:
-        events.set_selfing_rates.append(
-            SetSelfingRate(when=when, deme=idmap[deme_id], S=e.selfing_rate)
-        )
+        # Guard against double-setting selfing rates
+        # This guard is necessary because we skip size changes
+        # for founder demes that happen before a natural time 0.
+        # See test_evolve_demes_model_starting_with_two_pops_and_no_ancestry.
+        if not any(
+            [
+                i.when == when and i.deme == idmap[deme_id]
+                for i in events.set_selfing_rates
+            ]
+        ):
+            events.set_selfing_rates.append(
+                SetSelfingRate(when=when, deme=idmap[deme_id], S=e.selfing_rate)
+            )
 
     if e.cloning_rate is not None:
         if e.cloning_rate > 0.0:

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -1056,12 +1056,7 @@ def test_evolve_population_in_two_stages_with_deepcopy(
     assert counts[1][1] == 200, f"{counts}"
 
 
-# NOTE: update this test to have burnin=0 once GittHub issue 776
-# is fixed
-# NOTE: models like this are important to applications where
-# the ancestor is simulated with msprime, and the split part
-# happens in fwdpy11
-@pytest.mark.parametrize("burnin", [1])
+@pytest.mark.parametrize("burnin", [1, 0])
 def test_evolve_demes_model_starting_with_two_pops_and_no_ancestry(
     burnin,
     start_demes_model_with_two_pops,


### PR DESCRIPTION
This PR addresses a note in the test suite.  Unfortunately, adding a test of burnin=0 revealed a bug, which we try to fix here.
