### PR TITLE
add strict pulse validation

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -11,6 +11,10 @@ Back end changes
   PR {pr}`947`.
 * Refactor a class decorator used to pickle/unpickle `attrs`-based classes.
   PR {pr}`948`.
+* Reject any `demes` models that involve multiple pulse events into the
+  same source deme at the same time.  Such models are better written
+  in a different way.
+  PR {pr}`953`
 
 Bug fixes
 

--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -89,5 +89,10 @@ from ._functions import (
     simplify_tables,
 )  # NOQA
 
+
+class AmbiguousPulses(Exception):
+    pass
+
+
 if sys.version_info[0] < 3:
     raise ValueError("Python3 required!")

--- a/fwdpy11/_functions/import_demes.py
+++ b/fwdpy11/_functions/import_demes.py
@@ -51,8 +51,25 @@ def demography_from_demes(
     if burnin < 0:
         raise ValueError("Burn in factor must be non-negative")
 
+    _validate_pulses(g)
+
     demography = _build_from_deme_graph(g, burnin, source)
     return demography
+
+
+def _validate_pulses(graph: demes.Graph):
+    from fwdpy11 import AmbiguousPulses
+
+    unique_pulse_times = set([np.rint(p.time) for p in graph.pulses])
+    for time in unique_pulse_times:
+        pulses = [p for p in graph.pulses if np.rint(p.time) == time]
+        dests = set()
+        for p in pulses:
+            if p.dest in dests:
+                raise AmbiguousPulses(
+                    f"multiple pulse events into deme {p.dest} at time {time}"
+                )
+            dests.add(p.dest)
 
 
 def _build_from_deme_graph(

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -1887,6 +1887,7 @@ demes:
     with pytest.raises(ValueError):
         _ = fwdpy11.discrete_demography.from_demes(graph, burnin=0)
 
+
 def test_epoch_rounding_02():
     yaml = """
 time_units: generations
@@ -1899,4 +1900,29 @@ demes:
 """
     graph = demes.loads(yaml)
     with pytest.raises(ValueError):
+        _ = fwdpy11.discrete_demography.from_demes(graph, burnin=0)
+
+
+def test_ambiguous_pulses():
+    yaml = """
+time_units: generations
+demes:
+ - name: A
+   epochs:
+    - start_size: 50
+ - name: B
+   epochs:
+    - start_size: 50
+pulses:
+ - sources: [A]
+   dest: B
+   proportions: [0.9]
+   time: 25
+ - sources: [A]
+   dest: B
+   proportions: [0.9]
+   time: 25
+"""
+    graph = demes.loads(yaml)
+    with pytest.raises(fwdpy11.AmbiguousPulses):
         _ = fwdpy11.discrete_demography.from_demes(graph, burnin=0)


### PR DESCRIPTION
Reject any demes models where more than one Pulse event has the same destination deme at the same time.