### PR TITLE
Fix compatibility with pybind11 2.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 
 find_package(pybind11)
 message(STATUS "Found pybind11: ${pybind11_VERSION}")
-if(${pybind11_VERSION} VERSION_LESS '2.4.3')
-    message(FATAL_ERROR "pybind11 version must be >= '2.4.3'")
+if(${pybind11_VERSION} VERSION_LESS '2.10.0')
+    message(FATAL_ERROR "pybind11 version must be >= '2.10.0'")
 endif()
 add_definitions(-DPYBIND11_VERSION="${pybind11_VERSION}")
 

--- a/fwdpy11/src/ts/TreeIterator.cc
+++ b/fwdpy11/src/ts/TreeIterator.cc
@@ -237,6 +237,9 @@ class tree_visitor_wrapper
             {
                 ++end_of_range;
             }
+        if (end_of_range > end_of_sites) {
+            throw std::runtime_error("invalid end of site range");
+        }
         return std::make_pair(current_site, end_of_range);
     }
 
@@ -250,6 +253,9 @@ class tree_visitor_wrapper
             {
                 ++current_site;
             }
+        if (current_site > end_of_sites) {
+            throw std::runtime_error("invalid end of site range during mutation iteration");
+        }
         while ((current_site < end_of_sites) && (current_mutation < end_of_mutations)
                && (first_site + current_mutation->site)->position
                       != current_site->position)
@@ -272,6 +278,9 @@ class tree_visitor_wrapper
             {
                 ++end_of_range;
             }
+        if (end_of_range > end_of_mutations) {
+            throw std::runtime_error("invalid end of mutation range");
+        }
         return std::make_pair(current_mutation, end_of_range);
     }
 };
@@ -352,14 +361,14 @@ init_tree_iterator(py::module& m)
             "_sites",
             [](tree_visitor_wrapper& self) {
                 auto rv = self.get_sites_on_current_tree();
-                return py::make_iterator(rv.first, rv.second);
+                return py::make_iterator(std::move(rv.first), std::move(rv.second));
             },
             py::keep_alive<0, 1>())
         .def(
             "_mutations",
             [](tree_visitor_wrapper& self) {
                 auto r = self.get_mutations_on_current_tree();
-                return py::make_iterator(r.first, r.second);
+                return py::make_iterator(std::move(r.first), std::move(r.second));
             },
             py::keep_alive<0, 1>());
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # We need setup.cfg support, which setuptools indtroduced in 30.3.0.
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm", "pybind11[global]==2.9.1"]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm", "pybind11[global]==2.10.0"]
 
 [tool.setuptools_scm]
 write_to = "fwdpy11/_version.py"

--- a/requirements/conda_minimal_deps.txt
+++ b/requirements/conda_minimal_deps.txt
@@ -1,5 +1,5 @@
 intervaltree
-pybind11==2.9.1
+pybind11==2.10.0
 numpy
 scipy
 attrs>=0.19.2

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,7 +1,7 @@
 # NOTE: any pinning should also be coordinated
 # with requirements.in and doc/requirements.in
 # and may require regenerating the .txt files.
-pybind11[global]==2.9.1
+pybind11[global]==2.10.0
 intervaltree
 numpy
 scipy

--- a/tests/test_tree_sequences_with_neutral_mutations.py
+++ b/tests/test_tree_sequences_with_neutral_mutations.py
@@ -76,8 +76,15 @@ class TestKeepFixations(unittest.TestCase):
         )
         ti = fwdpy11.TreeIterator(self.pop.tables, [i for i in range(2 * self.pop.N)])
         mc = _count_mutations_from_diploids(self.pop)
+        # This assert was added when working
+        # on GitHub isuse 954
+        for m in pop2.tables.mutations:
+            assert m.key < len(pop2.tables.mutations)
         for t in ti:
             for m in t.mutations():
+                # This assert was added when working
+                # on GitHub isuse 954
+                assert m.key < len(pop2.mutations)
                 # Have to skip neutral mutations b/c they won't
                 # end up in mc b/c it is obtained from genomes
                 if pop2.mutations[m.key].neutral is False:


### PR DESCRIPTION
- Add asserts to hit #954 without triggering segfault
- Fixes for py::make_iterator.
- bump to pybind11 2.10.0 in pyproject.toml
- Bump to pybind11 2.10.0 in requirements/development.txt
- bump to pybind11 2.10.0 in conda/conda_minimal_deps.txt
- CMakeLists.txt now enforces pybind11 2.10.0 or later
