### PR TITLE
Add Python validation of region [beg, end) with respect to genome length.

### DIFF
--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -87,6 +87,7 @@ from ._functions import (
     make_data_matrix,
     simplify,
     simplify_tables,
+    _validate_regions,
 )  # NOQA
 
 

--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -188,6 +188,10 @@ def evolvets(
         evolve_with_tree_sequences,
     )
 
+    fwdpy11._validate_regions(params.sregions, pop.tables.genome_length)
+    fwdpy11._validate_regions(params.nregions, pop.tables.genome_length)
+    fwdpy11._validate_regions(params.recregions, pop.tables.genome_length)
+
     try:
         # DemographicModelDetails ?
         demographic_model = params.demography.model

--- a/fwdpy11/_functions/__init__.py
+++ b/fwdpy11/_functions/__init__.py
@@ -8,3 +8,17 @@ from fwdpy11 import GSLrng, DiploidPopulation
 
 def infinite_sites(rng: GSLrng, pop: DiploidPopulation, mu: float) -> int:
     return _infinite_sites(rng, pop, mu)
+
+def _validate_regions(regions, sequence_length):
+    for r in regions:
+        try:
+            if r.beg >= sequence_length or r.end > sequence_length:
+                raise ValueError(f"Region {r} extends beyond the sequence length {sequence_length}")
+        except AttributeError:
+            try:
+                for des in r.des:
+                    if des.beg >= sequence_length or des.end > sequence_length:
+                        raise ValueError(f"Region {des} in {r} extends beyond the sequence length {sequence_length}")
+            except TypeError: # r.des not Iterable
+                if r.des.beg >= sequence_length or r.des.end > sequence_length:
+                    raise ValueError(f"Region {des} in {r} extends beyond the sequence length {sequence_length}")

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -4,6 +4,7 @@ import pickle
 import unittest
 
 import numpy as np
+import pytest
 
 import fwdpy11
 


### PR DESCRIPTION
See issues #910 and #908.
This is not a fix for those issues,
which would require that the validation
happen on the C++ side.
