### PR TITLE
Fix mypy errors

### DIFF
--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -45,12 +45,15 @@ def evolvets(
     pop: DiploidPopulation,
     params: ModelParams,
     simplification_interval: int,
-    recorder: Optional[Callable[[DiploidPopulation, SampleRecorder], None]] = None,
+    recorder: Optional[Callable[[
+        DiploidPopulation, SampleRecorder], None]] = None,
     *,
-    post_simplification_recorder: Optional[Callable[[DiploidPopulation], None]] = None,
+    post_simplification_recorder: Optional[Callable[[
+        DiploidPopulation], None]] = None,
     suppress_table_indexing: Optional[bool] = None,
     record_gvalue_matrix: bool = False,
-    stopping_criterion: Optional[Callable[[DiploidPopulation, bool], bool]] = None,
+    stopping_criterion: Optional[Callable[[
+        DiploidPopulation, bool], bool]] = None,
     track_mutation_counts: bool = False,
     remove_extinct_variants: bool = True,
     preserve_first_generation: bool = False,
@@ -127,28 +130,36 @@ def evolvets(
         if isinstance(r, fwdpy11.mvDES):
             if isinstance(r.des, list):
                 for rr in r.des:
+                    assert isinstance(rr, fwdpy11.Sregion)  # type: ignore
                     if rr.beg < 0:
                         raise ValueError(f"{r} has begin value < 0.0")
                     if rr.end > pop.tables.genome_length:
                         raise ValueError(
-                            f"{r} has end value >= genome length of {pop.tables.genome_length}"
+                            f"{r} has end value >= genome length"
+                            " of {pop.tables.genome_length}"
                         )
             else:
+                assert isinstance(r, fwdpy11.mvDES), f"{type(r)}"
+                assert isinstance(r.des, fwdpy11.Sregion)  # type: ignore
                 if r.des.beg < 0:
                     raise ValueError(f"{r} has begin value < 0.0")
                 if r.des.end > pop.tables.genome_length:
                     raise ValueError(
-                        f"{r} has end value >= genome length of {pop.tables.genome_length}"
+                        f"{r} has end value >= genome"
+                        " length of {pop.tables.genome_length}"
                     )
         else:
+            assert isinstance(r, fwdpy11.Sregion)  # type: ignore
             if r.beg < 0:
                 raise ValueError(f"{r} has begin value < 0.0")
             if r.end > pop.tables.genome_length:
                 raise ValueError(
-                    f"{r} has end value >= genome length of {pop.tables.genome_length}"
+                    f"{r} has end value >= genome"
+                    " length of {pop.tables.genome_length}"
                 )
 
     for r in params.nregions:
+        assert isinstance(r, fwdpy11.Region)
         if r.beg < 0:
             raise ValueError(f"{r} has begin value < 0.0")
         if r.end > pop.tables.genome_length:
@@ -157,6 +168,8 @@ def evolvets(
             )
 
     for r in params.recregions:
+        assert isinstance(r, fwdpy11.Region) or \
+            isinstance(r, fwdpy11._fwdpy11.GeneticMapUnit)
         if r.beg < 0:
             raise ValueError(f"{r} has begin value < 0.0")
         if r.end > pop.tables.genome_length:
@@ -210,7 +223,8 @@ def evolvets(
             params.rates.neutral_mutation_rate + params.rates.selected_mutation_rate
         )
     mm = MutationRegions.create(pneutral, params.nregions, params.sregions)
-    rm = dispatch_create_GeneticMap(params.rates.recombination_rate, params.recregions)
+    rm = dispatch_create_GeneticMap(
+        params.rates.recombination_rate, params.recregions)
 
     from ._fwdpy11 import SampleRecorder
 

--- a/fwdpy11/_functions/data_matrix_from_tables.py
+++ b/fwdpy11/_functions/data_matrix_from_tables.py
@@ -100,7 +100,7 @@ def data_matrix_from_tables(
     if end is not None:
         _end = end
     else:
-        _end = np.finfo(np.float64).max
+        _end = float(np.finfo(np.float64).max)
     return DataMatrix(
         _data_matrix_from_tables(
             tables,

--- a/fwdpy11/_types/demography_debugger.py
+++ b/fwdpy11/_types/demography_debugger.py
@@ -83,7 +83,7 @@ class _DemographyEvents:
 @dataclass
 class MigrationMatrixEpoch:
     start: int
-    migration_matrix: MigrationMatrix
+    migration_matrix: np.ndarray
 
 
 @dataclass
@@ -171,7 +171,7 @@ class DemographyDebugger(object):
 
     def _build_migration_history(
         self, events: _DemographyEvents
-    ) -> Optional[List[MigrationMatrixEpoch]]:
+    ):
         if events.migmatrix is None:
             return None
 
@@ -192,11 +192,13 @@ class DemographyDebugger(object):
                             f"deme {source} does not exist at generation 1"
                         )
                     if self._size_history.deme_exists_at(dest, 1) is False:
-                        raise ValueError(f"deme {dest} does not exist at generation 1")
+                        raise ValueError(
+                            f"deme {dest} does not exist at generation 1")
 
         rv = []
         if events.set_migration_rates is None:
-            rv.append(MigrationMatrixEpoch(0, current_migmatrix))
+            rv.append(MigrationMatrixEpoch(
+                0, current_migmatrix))
         else:
             times = []
             for m in events.set_migration_rates:
@@ -204,7 +206,7 @@ class DemographyDebugger(object):
                     times.append(m.when)
             times = sorted(times)
             for time in times:
-                destinations = set()
+                destinations = set()  # type: ignore
                 for m in [m for m in events.set_migration_rates if m.when == time]:
                     if m.deme is not None and m.deme < 0:
                         if len(destinations) > 0:
@@ -234,7 +236,8 @@ class DemographyDebugger(object):
                         current_migmatrix[m.deme, :] = np.copy(m.migrates)
                     destinations.add(m.deme)
 
-                rv.append(MigrationMatrixEpoch(time + 1, np.copy(current_migmatrix)))
+                rv.append(MigrationMatrixEpoch(
+                    time + 1, np.copy(current_migmatrix)))
         return rv
 
     def _validate_epochs(self, events: _DemographyEvents):
@@ -246,7 +249,8 @@ class DemographyDebugger(object):
             if epoch.data.ancestors is not None:
                 for a in epoch.data.ancestors:
                     if (
-                        self._size_history.deme_exists_at(a, when_ancestor_must_exist)
+                        self._size_history.deme_exists_at(
+                            a, when_ancestor_must_exist)
                         is False
                     ):
                         raise ValueError(
@@ -265,14 +269,16 @@ class DemographyDebugger(object):
                                 i = j
                                 break
                         if i is not None:
-                            ttl_rate_in = i.migration_matrix[epoch.data.deme, :].sum()
+                            ttl_rate_in = i.migration_matrix[epoch.data.deme, :].sum(
+                            )
                             if not ttl_rate_in > 0:
                                 raise ValueError(
                                     f"the migration rantes into deme {epoch.data.deme} are 0.0 at time {i.start}"
                                 )
             else:
                 if events.migmatrix is None:
-                    raise ValueError("a MigrationMatrix is required for this model.")
+                    raise ValueError(
+                        "a MigrationMatrix is required for this model.")
                 else:
                     # TODO: does migration fix this?
                     if self.migration_history is not None:

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -1,11 +1,10 @@
-import warnings
 from typing import IO, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import demes
 import fwdpy11._types
 import fwdpy11.tskit_tools._dump_tables_to_tskit
 import numpy as np
-import tskit
+import tskit  # type: ignore
 
 from .._fwdpy11 import DiploidGenotype, DiploidMetadata, ll_DiploidPopulation
 from .model_params import ModelParams
@@ -175,7 +174,7 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
         utimes = np.unique(times)
         return times, utimes
 
-    def deme_sizes(self, as_dict=False) -> Union[np.ndarray, Dict]:
+    def deme_sizes(self, as_dict=False):
         """
         Return the number of individuals in each deme.
 
@@ -200,7 +199,8 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
     def dump_tables_to_tskit(
         self,
         *,
-        model_params: Optional[Union[ModelParams, Dict[str, ModelParams]]] = None,
+        model_params: Optional[Union[ModelParams,
+                                     Dict[str, ModelParams]]] = None,
         demes_graph: Optional[demes.Graph] = None,
         population_metadata: Optional[Dict[int, object]] = None,
         data: Optional[object] = None,
@@ -318,7 +318,7 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
 
     def sample_timepoints(
         self, include_alive=True
-    ) -> Iterator[Tuple[int, np.ndarray, np.recarray]]:
+    ):
         """
         Return an iterator over all sample time points.
         The iterator yields time, nodes, and metadata.

--- a/fwdpy11/_types/table_collection.py
+++ b/fwdpy11/_types/table_collection.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
 import numpy as np
-import scipy.sparse
+import scipy.sparse # type: ignore
 
 from .._fwdpy11 import Edge, MutationRecord, Node, Site, ll_TableCollection
 
@@ -71,6 +71,7 @@ def _position_in_window(pos, window):
 
 
 def _simplify(tables, samples, simplify):
+    import fwdpy11
     if simplify is False:
         return tables, samples
 

--- a/fwdpy11/_types/tree_iterator.py
+++ b/fwdpy11/_types/tree_iterator.py
@@ -75,7 +75,7 @@ class TreeIterator(ll_TreeIterator):
     ):
         _end = end
         if _end is None:
-            _end = np.finfo(np.float64).max
+            _end = float(np.finfo(np.float64).max)
         if ancient_samples is None:
             super(TreeIterator, self).__init__(
                 tables, samples, update_samples, begin, _end

--- a/fwdpy11/_types/variant_iterator.py
+++ b/fwdpy11/_types/variant_iterator.py
@@ -79,7 +79,7 @@ class VariantIterator(ll_VariantIterator):
         if end is not None:
             _end = end
         else:
-            _end = np.finfo(np.float64).max
+            _end = float(np.finfo(np.float64).max)
 
         super(VariantIterator, self).__init__(
             tables,

--- a/fwdpy11/conditional_models/__init__.py
+++ b/fwdpy11/conditional_models/__init__.py
@@ -82,7 +82,8 @@ def _right_greater_left(instance, attribute, value):
 
 def _is_polymorphic_frequency(_, attribute, value):
     if not 0.0 < value < 1.0:
-        raise ValueError(f"{attribute.name} must be 0.0 < {attribute.name} < 1.0")
+        raise ValueError(
+            f"{attribute.name} must be 0.0 < {attribute.name} < 1.0")
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -139,7 +140,8 @@ class FrequencyRange:
     """
 
     minimum: float = attr.ib(
-        validator=[attr.validators.instance_of(float), _is_polymorphic_frequency]
+        validator=[attr.validators.instance_of(
+            float), _is_polymorphic_frequency]
     )
     maximum: float = attr.ib(
         validator=[
@@ -216,7 +218,8 @@ class SimulationStatus:
     For examples, see implementations of :class:`GlobalFixation` and :class:`FocalDemeFixation`.
     """
 
-    should_terminate: bool = attr.ib(validator=attr.validators.instance_of(bool))
+    should_terminate: bool = attr.ib(
+        validator=attr.validators.instance_of(bool))
     condition_met: bool = attr.ib(validator=attr.validators.instance_of(bool))
 
 
@@ -239,7 +242,7 @@ class GlobalFixation(object):
     """
 
     def __call__(
-        self, pop: fwdpy11.DiploidPopulation, index: int, key: tuple
+        self, pop, index: int, key: tuple
     ) -> SimulationStatus:
         if pop.mutations[index].key != key:
             # The key has changed, meaning the mutation is
@@ -268,7 +271,7 @@ class FocalDemeFixation:
         validator=[attr.validators.instance_of(int), _non_negative_value]
     )
 
-    def __call__(self, pop: fwdpy11.DiploidPopulation, index, key) -> SimulationStatus:
+    def __call__(self, pop, index, key) -> SimulationStatus:
         deme_sizes = pop.deme_sizes(as_dict=True)
         if pop.mutations[index].key != key:
             # check for a global fixation

--- a/fwdpy11/regions.py
+++ b/fwdpy11/regions.py
@@ -617,7 +617,7 @@ class mvDES(fwdpy11._fwdpy11._ll_mvDES):
     also determine the order of positional arguments:
 
     :param des: Distributions of effect sizes
-    :type des: list
+    :type des: list or mvDES
     :param means: means marginal gaussian Distributions
     :type means: :class:`numpy.ndarray`
     :param matrix: Variance/covariance matrix
@@ -630,9 +630,8 @@ class mvDES(fwdpy11._fwdpy11._ll_mvDES):
         Refactored to use attrs and inherit from
         low-level C++ class
     """
-
-    des: object
-    means: object
+    des: typing.Union[typing.List, fwdpy11._fwdpy11.Sregion]
+    means: np.ndarray
     matrix: typing.Optional[np.ndarray] = None
 
     def __attrs_post_init__(self):

--- a/fwdpy11/tskit_tools/__init__.py
+++ b/fwdpy11/tskit_tools/__init__.py
@@ -28,7 +28,7 @@ import typing
 import warnings
 
 import numpy as np
-import tskit
+import tskit  # type: ignore
 
 from ._flags import *  # NOQA
 from .metadata import (
@@ -55,7 +55,7 @@ def get_toplevel_metadata(ts: tskit.TreeSequence, name: str) -> typing.Optional[
 
 
 def iterate_timepoints_with_individuals(
-    ts: tskit.TreeSequence, *, decode_metadata=False
+    ts, *, decode_metadata=False
 ):
     """
     Return an iterator over all unique time points with individuals.
@@ -91,7 +91,8 @@ def iterate_timepoints_with_individuals(
         # Get the node tables rows in individuals at this time
         x = np.where(node_times == utime)
         node_table_rows = nodes_in_individuals[x]
-        assert np.all(np.array([ts.node(i).time for i in node_table_rows]) == utime)
+        assert np.all(
+            np.array([ts.node(i).time for i in node_table_rows]) == utime)
 
         # Get the individuals
         individuals = np.unique(

--- a/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
+++ b/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
@@ -24,7 +24,7 @@ import demes
 import fwdpy11.tskit_tools
 import fwdpy11.tskit_tools.metadata_schema
 import numpy as np
-import tskit
+import tskit  # type: ignore
 from fwdpy11._types.model_params import ModelParams
 
 
@@ -89,9 +89,12 @@ def _initializeIndividualTable(self, tc):
 
 
 def _dump_mutation_site_and_site_tables(self, tc: tskit.TableCollection) -> None:
-    mpos = np.array([self.mutations[mr.key].pos for mr in self.tables.mutations])
-    ancestral_state = np.zeros(len(self.tables.mutations), dtype=np.int8) + ord("0")
-    ancestral_state_offset = np.arange(len(self.tables.mutations) + 1, dtype=np.uint32)
+    mpos = np.array(
+        [self.mutations[mr.key].pos for mr in self.tables.mutations])
+    ancestral_state = np.zeros(
+        len(self.tables.mutations), dtype=np.int8) + ord("0")
+    ancestral_state_offset = np.arange(
+        len(self.tables.mutations) + 1, dtype=np.uint32)
     tc.sites.set_columns(
         position=mpos,
         ancestral_state=ancestral_state,
@@ -123,14 +126,12 @@ def _dump_mutation_site_and_site_tables(self, tc: tskit.TableCollection) -> None
 def _dump_tables_to_tskit(
     self,
     *,
-    model_params: typing.Optional[
-        typing.Union[ModelParams, typing.Dict[str, ModelParams]]
-    ] = None,
-    demes_graph: typing.Optional[demes.Graph] = None,
-    population_metadata: typing.Optional[typing.Dict[int, object]] = None,
-    data: typing.Optional[object] = None,
-    seed: typing.Optional[int] = None,
-    parameters: typing.Optional[typing.Dict] = None,
+    model_params=None,
+    demes_graph=None,
+    population_metadata=None,
+    data=None,
+    seed=None,
+    parameters=None,
     destructive=False,
 ) -> tskit.TreeSequence:
     from .._fwdpy11 import gsl_version, pybind11_version
@@ -169,7 +170,7 @@ def _dump_tables_to_tskit(
     if model_params is not None:
         try:
             top_level_metadata["model_params"] = str(model_params.asdict())
-        except:
+        except Exception:
             mp = {}
             for key, value in model_params.items():
                 mp[key] = str(value.asdict())
@@ -215,7 +216,6 @@ def _dump_tables_to_tskit(
     if destructive is True:
         self._clear_diploid_metadata()
         self._clear_ancient_sample_metadata()
-        node_view = None
         self.tables._clear_nodes()
 
     _dump_mutation_site_and_site_tables(self, tc)
@@ -231,7 +231,6 @@ def _dump_tables_to_tskit(
         child=edge_view["child"],
     )
     if destructive is True:
-        edge_view = None
         self.tables._clear_edges()
 
     tc.provenances.add_row(json.dumps(provenance))

--- a/fwdpy11/tskit_tools/metadata_schema.py
+++ b/fwdpy11/tskit_tools/metadata_schema.py
@@ -20,7 +20,7 @@ import copy
 import typing
 
 import fwdpy11
-import tskit
+import tskit  # type: ignore
 
 TopLevelMetadata = tskit.metadata.MetadataSchema(
     {

--- a/tests/test_tree_sequences_different_des_in_different_demes.py
+++ b/tests/test_tree_sequences_different_des_in_different_demes.py
@@ -30,7 +30,8 @@ import numpy as np
 def gvalue_multiplicative(pop, ind, scaling):
     g = 1.0
     keys = [k for k in pop.haploid_genomes[pop.diploids[ind].first].smutations]
-    keys.extend([k for k in pop.haploid_genomes[pop.diploids[ind].second].smutations])
+    keys.extend(
+        [k for k in pop.haploid_genomes[pop.diploids[ind].second].smutations])
     keys = np.array(keys, dtype=np.uint32)
     key_counts = np.unique(keys, return_counts=True)
 
@@ -62,7 +63,8 @@ class TestMassMigrationsWithCopies(unittest.TestCase):
         self.pop = fwdpy11.DiploidPopulation(100, 1)
         vcv_matrix = np.array([1, 0.99, 0.99, 1.0]).reshape((2, 2))
         mvDES = fwdpy11.mvDES(
-            [fwdpy11.ConstantS(0, 1, 1, 0.1), fwdpy11.ConstantS(0, 1, 1, -0.1)],
+            [fwdpy11.ConstantS(0, 1, 1, 0.1),
+             fwdpy11.ConstantS(0, 1, 1, -0.1)],
             np.zeros(2),
             vcv_matrix,
         )
@@ -118,7 +120,8 @@ class TestMassMigrationsWithCopies(unittest.TestCase):
         for i in self.f.data:
             self.assertEqual(i[2], 1)  # deme == 1
             self.assertTrue(i[1] <= 1.0)  # Mutations are harmful in this deme
-            self.assertEqual(i[0], 2)  # Generation == 2, when mass mig happened
+            # Generation == 2, when mass mig happened
+            self.assertEqual(i[0], 2)
 
 
 class TestMassMigrationsWithMoves(unittest.TestCase):
@@ -136,7 +139,8 @@ class TestMassMigrationsWithMoves(unittest.TestCase):
         self.pop = fwdpy11.DiploidPopulation(100, 1)
         vcv_matrix = np.array([1, 0.99, 0.99, 1.0]).reshape((2, 2))
         mvDES = fwdpy11.mvDES(
-            [fwdpy11.ConstantS(0, 1, 1, 0.1), fwdpy11.ConstantS(0, 1, 1, -0.1)],
+            [fwdpy11.ConstantS(0, 1, 1, 0.1),
+             fwdpy11.ConstantS(0, 1, 1, -0.1)],
             np.zeros(2),
             vcv_matrix,
         )
@@ -199,13 +203,15 @@ class TestMassMigrationsWithMoves(unittest.TestCase):
             self.assertEqual(deme_counts[1][i], self.pop.N // 2)
         for i in self.f.data:
             if i[2] == 0:  # deme 0
-                self.assertTrue(i[1] >= 1.0)  # Mutations are beneficial in this deme
+                # Mutations are beneficial in this deme
+                self.assertTrue(i[1] >= 1.0)
                 self.assertEqual(
                     i[0], 2
                 )  # Generation == 2, when new deme first appeared
             else:
                 self.assertEqual(i[2], 1)
-                self.assertTrue(i[1] <= 2.0)  # Mutations are harmful in this deme
+                # Mutations are harmful in this deme
+                self.assertTrue(i[1] <= 2.0)
 
 
 class TestMultiplicativeWithExpSNoMigration(unittest.TestCase):
@@ -234,15 +240,18 @@ class TestMultiplicativeWithExpSNoMigration(unittest.TestCase):
         n0 = 0
         n1 = 0
         for i, md in enumerate(self.pop.diploid_metadata):
-            ng0 = len(self.pop.haploid_genomes[self.pop.diploids[i].first].smutations)
-            ng1 = len(self.pop.haploid_genomes[self.pop.diploids[i].second].smutations)
+            ng0 = len(
+                self.pop.haploid_genomes[self.pop.diploids[i].first].smutations)
+            ng1 = len(
+                self.pop.haploid_genomes[self.pop.diploids[i].second].smutations)
             if ng0 + ng1 > 0:
                 if md.deme == 0:
                     n0 += 1
                 elif md.deme == 1:
                     n1 += 1
         if n0 == 0 or n1 == 0:
-            self.assertFail("we don't have individuals with mutations in each deme")
+            self.assertFail(
+                "we don't have individuals with mutations in each deme")
 
     def test_it(self):
         gv = np.zeros(self.pop.N)
@@ -296,7 +305,8 @@ class TestGaussianStabilizingSelection(unittest.TestCase):
                 demes = np.unique(nt["deme"][t.samples_below(m.node)])
                 for d in demes:
                     demes_with_muts[d] += 1
-        assert np.all(demes_with_muts > 0), "test requires mutations in both demes"
+        assert np.all(demes_with_muts >
+                      0), "test requires mutations in both demes"
 
     def test_genetic_values(self):
         for m in self.pop.diploid_metadata:
@@ -346,7 +356,8 @@ class TestMultivariateLogNormalS(unittest.TestCase):
                 demes = np.unique(nt["deme"][t.samples_below(m.node)])
                 for d in demes:
                     demes_with_muts[d] += 1
-        assert np.all(demes_with_muts > 0), "test requires mutations in both demes"
+        assert np.all(demes_with_muts >
+                      0), "test requires mutations in both demes"
 
     def test_genetic_values(self):
         for i, m in enumerate(self.pop.diploid_metadata):


### PR DESCRIPTION
Most `mypy` errors come from function arguments.
This PR simply deletes the type hints when possible as a sanity-preserving measure.

Closes #998
