### PR TITLE
C++ back end of Region/Sregion now validated beg/end at start of sim.

### DIFF
--- a/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/RecombinationRegions.hpp
@@ -19,8 +19,8 @@ namespace fwdpy11
         GeneticMap() = default;
         GeneticMap(const GeneticMap&) = delete;
         GeneticMap(GeneticMap&&) = default;
-        GeneticMap& operator=(const GeneticMap&)=delete;
-        GeneticMap& operator=(GeneticMap&&)=default;
+        GeneticMap& operator=(const GeneticMap&) = delete;
+        GeneticMap& operator=(GeneticMap&&) = default;
         virtual std::vector<double> operator()(const GSLrng_t& rng) const = 0;
     };
 
@@ -39,8 +39,8 @@ namespace fwdpy11
                 }
             if (!weights.empty())
                 {
-                    lookup.reset(gsl_ran_discrete_preproc(weights.size(),
-                                                          weights.data()));
+                    lookup.reset(
+                        gsl_ran_discrete_preproc(weights.size(), weights.data()));
                 }
             else if (rate > 0.0)
                 {
@@ -74,8 +74,7 @@ namespace fwdpy11
     struct GeneralizedGeneticMap : public GeneticMap
     {
         std::vector<std::unique_ptr<fwdpp::genetic_map_unit>> callbacks;
-        GeneralizedGeneticMap(
-            std::vector<std::unique_ptr<fwdpp::genetic_map_unit>> c)
+        GeneralizedGeneticMap(std::vector<std::unique_ptr<fwdpp::genetic_map_unit>> c)
             : callbacks(std::move(c))
         {
         }

--- a/fwdpy11/headers/fwdpy11/regions/Region.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Region.hpp
@@ -16,8 +16,8 @@ namespace fwdpy11
         std::uint16_t label;
         bool coupled;
         Region(double b, double e, double w, bool c, std::uint16_t l)
-            : beg(b), end(e), weight((c == true) ? (end - beg) * w : w),
-              label(l), coupled(c)
+            : beg(b), end(e), weight((c == true) ? (end - beg) * w : w), label(l),
+              coupled(c)
         {
             if (!std::isfinite(beg))
                 {
@@ -37,8 +37,7 @@ namespace fwdpy11
                 }
             if (!(end > beg))
                 {
-                    throw std::invalid_argument(
-                        "end must be greater than beg");
+                    throw std::invalid_argument("end must be greater than beg");
                 }
         }
 
@@ -46,6 +45,14 @@ namespace fwdpy11
         operator()(const GSLrng_t& rng) const
         {
             return gsl_ran_flat(rng.get(), beg, end);
+        }
+
+        inline bool
+        valid(double start, double stop) const
+        {
+            auto beg_ok = beg >= start && beg < stop;
+            auto end_ok = end > start && end <= stop;
+            return beg_ok && end_ok;
         }
     };
 } // namespace fwdpy11

--- a/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
+++ b/fwdpy11/headers/fwdpy11/regions/Sregion.hpp
@@ -69,18 +69,24 @@ namespace fwdpy11
             return region.label;
         }
 
+        inline bool
+        valid(double start, double stop) const
+        {
+            return this->region.valid(start, stop);
+        }
+
         virtual std::unique_ptr<Sregion> clone() const = 0;
         virtual std::uint32_t
         operator()(fwdpp::flagged_mutation_queue& /*recycling_bin*/,
                    std::vector<Mutation>& /*mutations*/,
                    std::unordered_multimap<double, std::uint32_t>& /*lookup_table*/,
-                   const std::uint32_t /*generation*/,
-                   const GSLrng_t& /*rng*/) const = 0;
+                   const std::uint32_t /*generation*/, const GSLrng_t& /*rng*/) const
+            = 0;
         // Added in 0.7.0.  We now require that these types
         // are able to return deviates from the relevant cdf_P
         // function.
-        virtual double from_mvnorm(const double /*deviate*/,
-                                   const double /*P*/) const = 0;
+        virtual double from_mvnorm(const double /*deviate*/, const double /*P*/) const
+            = 0;
         virtual double
         generate_dominance(const GSLrng_t& rng, const double esize) const
         {

--- a/lib/evolve_discrete_demes/evolvets.cc
+++ b/lib/evolve_discrete_demes/evolvets.cc
@@ -228,6 +228,17 @@ evolve_with_tree_sequences(
             // then we reset it back to an unevolved one.
             demography.reset_model_state();
         }
+    for (auto &region : mmodel.regions)
+        {
+            if (!region->valid(0.0, pop.tables->genome_length()))
+                {
+                    std::ostringstream o;
+                    o << "region contains invalid beg and/or end values: "
+                      << region->beg() << ", " << region->end()
+                      << ", genome_length = " << pop.tables->genome_length();
+                    throw std::invalid_argument(o.str().c_str());
+                }
+        }
 
     auto current_demographic_state = demography.get_model_state();
 
@@ -644,4 +655,3 @@ evolve_with_tree_sequences(
         }
     demography.set_model_state(std::move(current_demographic_state));
 }
-


### PR DESCRIPTION
* The genetic map objects cannot do this.
  Type erasure is at work here and access to start/stop
  is not part of the API.
  Fixing this requires changes to upstream (fwdpp).

Closes #910
