### PR TITLE
Use ForwardDemesGraph in refactored back end code.

### DIFF
--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,13 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## 0.XX.Y
+
+Back end changes
+
+* Use demes models directly for evolving populations.
+  PR {pr}`1069`.
+
 ## 0.19.3
 
 Deprecations

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/functions.hpp
@@ -26,6 +26,7 @@
 #include "apply_mass_migrations.hpp"
 #include "../MassMigration.hpp"
 #include "../exceptions.hpp"
+#include "core/demes/forward_graph.hpp"
 #include "multideme_fitness_lookups.hpp"
 #include "migration_lookup.hpp"
 #include "deme_properties.hpp"
@@ -277,6 +278,63 @@ namespace fwdpy11
                             else
                                 {
                                     detail::check_migration_in(i, generation, M);
+                                }
+                        }
+                }
+        }
+
+        inline void
+        validate_parental_state(
+            std::uint32_t generation,
+            const multideme_fitness_lookups<std::uint32_t>& fitnesses,
+            const fwdpy11_core::ForwardDemesGraph& demography)
+        {
+            auto offspring_deme_sizes = demography.offspring_deme_sizes();
+            auto parental_deme_sizes = demography.parental_deme_sizes();
+
+            std::size_t offspring_deme = 0;
+            for (auto size = std::begin(offspring_deme_sizes);
+                 size != std::end(offspring_deme_sizes); ++size, ++offspring_deme)
+                {
+                    if (*size > 0.0)
+                        {
+                            // offspring deme exists
+                            auto ancestry_proportions
+                                = demography.offspring_ancestry_proportions(
+                                    offspring_deme);
+                            std::uint32_t parental_deme = 0;
+                            for (auto prop = std::begin(ancestry_proportions);
+                                 prop != std::end(ancestry_proportions);
+                                 ++prop, ++parental_deme)
+                                {
+                                    if (*prop > 0.0)
+                                        {
+                                            auto parental_deme_size
+                                                = *(std::begin(parental_deme_sizes)
+                                                    + parental_deme);
+                                            if (parental_deme_size == 0.0)
+                                                {
+                                                    std::ostringstream o;
+                                                    o << "deme " << offspring_deme
+                                                      << " has ancestry from deme "
+                                                      << parental_deme << " at time "
+                                                      << generation
+                                                      << " but the parental deme size "
+                                                         "is 0";
+                                                    throw DemographyError(o.str());
+                                                }
+                                            if (fitnesses.lookups[parental_deme]
+                                                == nullptr)
+                                                {
+                                                    std::ostringstream o;
+                                                    o << "fitness lookup table for "
+                                                         "parental deme "
+                                                      << parental_deme
+                                                      << " is empty at time "
+                                                      << generation;
+                                                    throw DemographyError(o.str());
+                                                }
+                                        }
                                 }
                         }
                 }

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/multideme_fitness_bookmark.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/multideme_fitness_bookmark.hpp
@@ -17,11 +17,13 @@
 
 #pragma once
 
+#include <system_error>
 #include <vector>
 #include <utility>
 #include <numeric>
 #include <limits>
 #include <cstdint>
+#include "core/demes/forward_graph.hpp"
 #include "deme_property_types.hpp"
 
 namespace fwdpy11
@@ -48,6 +50,41 @@ namespace fwdpy11
                   individuals{std::move(individuals)}, individual_fitness{
                                                            std::move(individual_fitness)}
             {
+            }
+
+            template <typename METADATATYPE>
+            void
+            update(const fwdpy11_core::ForwardDemesGraphDataIterator<double> deme_sizes,
+                   const std::vector<METADATATYPE>& individual_metadata)
+            {
+                std::vector<std::uint32_t> deme_sizes_uint;
+                for (auto i = std::begin(deme_sizes); i != std::end(deme_sizes); ++i)
+                    {
+                        deme_sizes_uint.push_back(static_cast<std::uint32_t>(*i));
+                    }
+                auto ndemes = deme_sizes_uint.size();
+                starts.resize(ndemes);
+                stops.resize(ndemes);
+                offsets.resize(ndemes);
+                std::uint32_t ttl_N = std::accumulate(std::begin(deme_sizes_uint),
+                                                      std::end(deme_sizes_uint), 0);
+                individual_fitness.resize(ttl_N, -1.0);
+                individuals.resize(individual_fitness.size(),
+                                   std::numeric_limits<std::uint32_t>::max());
+                // These -1 are useful b/c if our bookkeeping is bad,
+                // we'll get errors from GSL.
+                std::fill(begin(individual_fitness), end(individual_fitness), -1);
+                std::partial_sum(std::begin(deme_sizes_uint), std::end(deme_sizes_uint),
+                                 begin(stops));
+                std::copy(begin(stops), end(stops) - 1, begin(starts) + 1);
+                std::fill(begin(offsets), end(offsets), 0);
+                for (auto&& md : individual_metadata)
+                    {
+                        auto i = starts[md.deme] + offsets[md.deme];
+                        individual_fitness[i] = md.w;
+                        individuals[i] = md.label;
+                        offsets[md.deme]++;
+                    }
             }
 
             template <typename METADATATYPE>

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/multideme_fitness_lookups.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/multideme_fitness_lookups.hpp
@@ -95,6 +95,9 @@ namespace fwdpy11
                             {
                                 // NOTE: the size of the i-th deme's
                                 // fitness array is starts[i]-stops[i]
+                                //
+                                // FIXME: this is the cause of the segfault
+                                // in testing
                                 lookups[i].reset(gsl_ran_discrete_preproc(
                                     fitness_bookmark.stops[i]
                                         - fitness_bookmark.starts[i],
@@ -117,6 +120,15 @@ namespace fwdpy11
                     {
                         throw EmptyDeme("parental deme is empty");
                     }
+                auto o = gsl_ran_discrete(rng.get(), lookups[deme].get());
+                return fitness_bookmark.individuals[fitness_bookmark.starts[deme] + o];
+            }
+
+            T
+            get_parent(const GSLrng_t& rng,
+                       const multideme_fitness_bookmark& fitness_bookmark,
+                       const std::int32_t deme) const
+            {
                 auto o = gsl_ran_discrete(rng.get(), lookups[deme].get());
                 return fitness_bookmark.individuals[fitness_bookmark.starts[deme] + o];
             }

--- a/fwdpy11/headers/fwdpy11/discrete_demography/simulation/pick_parents.hpp
+++ b/fwdpy11/headers/fwdpy11/discrete_demography/simulation/pick_parents.hpp
@@ -24,6 +24,8 @@
 #include <sstream>
 #include "../../rng.hpp"
 #include "../MigrationMatrix.hpp"
+#include "core/demes/forward_graph.hpp"
+#include "fwdpp/gsl_discrete.hpp"
 #include "migration_lookup.hpp"
 #include "deme_property_types.hpp"
 #include "multideme_fitness_lookups.hpp"
@@ -90,6 +92,32 @@ namespace fwdpy11
                 = wlookups.get_parent(rng, current_deme_sizes, fitness_bookmark, pdeme);
             return {p1, p2, pdeme, pdeme, mating_event_type::outcrossing};
         }
+
+        inline parent_data
+        pick_parents(const GSLrng_t& rng, const std::int32_t offspring_deme,
+                     const fwdpy11_core::ForwardDemesGraph& demography,
+                     const fwdpp::gsl_ran_discrete_t_ptr& ancestor_deme_lookup,
+                     const multideme_fitness_bookmark& fitness_bookmark,
+                     const multideme_fitness_lookups<std::uint32_t>& wlookups)
+        {
+            std::int32_t pdeme = static_cast<std::int32_t>(
+                gsl_ran_discrete(rng.get(), ancestor_deme_lookup.get()));
+
+            auto selfing_rates = demography.offspring_selfing_rates();
+            auto selfing_rate_offspring_deme
+                = *(std::begin(selfing_rates) + offspring_deme);
+
+            auto p1 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
+            // FIXME: this gives rise to residual selfing
+            if (selfing_rate_offspring_deme > 0.
+                && gsl_rng_uniform(rng.get()) <= selfing_rate_offspring_deme)
+                {
+                    return {p1, p1, pdeme, pdeme, mating_event_type::selfing};
+                }
+            auto p2 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
+            return {p1, p2, pdeme, pdeme, mating_event_type::outcrossing};
+        }
+
     } // namespace discrete_demography
 } // namespace fwdpy11
 

--- a/lib/core/demes/forward_graph.hpp
+++ b/lib/core/demes/forward_graph.hpp
@@ -40,6 +40,7 @@ namespace fwdpy11_core
 
         void initialize_model(std::uint32_t);
         bool iterating_model() const;
+        bool in_error_state() const;
         void iterate_state();
         std::uint32_t model_end_time() const;
         std::ptrdiff_t number_of_demes() const;

--- a/lib/core/evolve_discrete_demes/evolvets.hpp
+++ b/lib/core/evolve_discrete_demes/evolvets.hpp
@@ -11,6 +11,8 @@
 #include <fwdpy11/gsl/gsl_error_handler_wrapper.hpp>
 #include <fwdpy11/samplers.hpp>
 
+#include <core/demes/forward_graph.hpp>
+
 struct evolve_with_tree_sequences_options
 {
     // NOTE: this is the complement of what a user will input, which is "prune_selected"
@@ -53,7 +55,7 @@ void evolve_with_tree_sequences(
 void evolve_with_tree_sequences_refactor(
     const fwdpy11::GSLrng_t &rng, fwdpy11::DiploidPopulation &pop,
     fwdpy11::SampleRecorder &sr, const unsigned simplification_interval,
-    fwdpy11::discrete_demography::DiscreteDemography &demography,
+    fwdpy11_core::ForwardDemesGraph &demography,
     const std::uint32_t simlen, const double mu_neutral, const double mu_selected,
     const fwdpy11::MutationRegions &mmodel, const fwdpy11::GeneticMap &rmodel,
     // NOTE: gvalue_pointers is a change in 0.6.0,

--- a/lib/demes/forward_graph.cc
+++ b/lib/demes/forward_graph.cc
@@ -54,6 +54,7 @@ namespace fwdpy11_core
         void initialize_time_iteration();
         const double *iterate();
         bool offspring_demes_exist() const;
+        bool in_error_state() const;
         void update_internal_state(double time);
     };
 
@@ -113,6 +114,13 @@ namespace fwdpy11_core
         return rv;
     }
 
+    bool
+    ForwardDemesGraph::forward_graph_implementation::in_error_state() const
+    {
+        auto rv = demes_forward_graph_is_error_state(graph.get());
+        return rv;
+    }
+
     void
     ForwardDemesGraph::forward_graph_implementation::update_internal_state(double time)
     {
@@ -150,6 +158,12 @@ namespace fwdpy11_core
     ForwardDemesGraph::iterating_model() const
     {
         return pimpl->offspring_demes_exist();
+    };
+
+    bool
+    ForwardDemesGraph::in_error_state() const
+    {
+        return pimpl->in_error_state();
     };
 
     void


### PR DESCRIPTION
This will be simplistic and only visible to the cpptests/.

* Only the minimal changes to evolve a demographic model 
  beginning to end.
* All individual fitnesses for valid parents will be set to 1.0
