### PR TITLE
Add C++ tests of demes models with invalid epoch rounding

### DIFF
--- a/cpptests/forward_demes_graph_fixtures.cc
+++ b/cpptests/forward_demes_graph_fixtures.cc
@@ -104,6 +104,16 @@ migrations:
    end_time: 1
 )";
 
+const char* bad_epoch_rounding_02 = R"(
+time_units: generations
+demes:
+- name: bad
+  epochs:
+  - {end_time: 1.5, start_size: 1}
+  - {end_time: 0.4, start_size: 2}
+  - {end_time: 0, start_size: 3}
+)";
+
 SingleDemeModel::SingleDemeModel() : yaml(single_deme_model)
 {
 }
@@ -135,5 +145,9 @@ VeryRecentPulseTwoGenerationsAgo::VeryRecentPulseTwoGenerationsAgo()
 
 ExtremeMigrationUntilOneGenerationAgo::ExtremeMigrationUntilOneGenerationAgo()
     : yaml(extreme_migration_until_one_generation_ago)
+{
+}
+
+BadEpochRounding02::BadEpochRounding02() : yaml(bad_epoch_rounding_02)
 {
 }

--- a/cpptests/forward_demes_graph_fixtures.hpp
+++ b/cpptests/forward_demes_graph_fixtures.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <exception>
 #include <string>
 
 struct SingleDemeModel
@@ -38,7 +39,14 @@ struct VeryRecentPulseTwoGenerationsAgo
     VeryRecentPulseTwoGenerationsAgo();
 };
 
-struct ExtremeMigrationUntilOneGenerationAgo {
+struct ExtremeMigrationUntilOneGenerationAgo
+{
     std::string yaml;
     ExtremeMigrationUntilOneGenerationAgo();
+};
+
+struct BadEpochRounding02
+{
+    std::string yaml;
+    BadEpochRounding02();
 };

--- a/cpptests/test_forward_demes_graph.cc
+++ b/cpptests/test_forward_demes_graph.cc
@@ -103,3 +103,13 @@ BOOST_FIXTURE_TEST_CASE(single_deme_model_with_burn_in_invalid_ancestry_request,
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(test_forward_demes_graph_with_bad_models)
+
+BOOST_FIXTURE_TEST_CASE(test_bad_epoch_rounding_02, BadEpochRounding02)
+{
+    BOOST_REQUIRE_THROW({ fwdpy11_core::ForwardDemesGraph g(yaml, 10); },
+                        fwdpy11::discrete_demography::DemographyError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/demes/forward_graph.cc
+++ b/lib/demes/forward_graph.cc
@@ -41,6 +41,18 @@ namespace fwdpy11_core
             auto code = demes_forward_graph_initialize_from_yaml(
                 yaml.c_str(), static_cast<double>(burnin), graph.get());
             handle_error_code(code);
+            if (demes_forward_graph_is_error_state(graph.get()))
+                {
+                    int status = 0;
+                    auto message
+                        = demes_forward_graph_get_error_message(graph.get(), &status);
+                    if (message == nullptr)
+                        {
+                            throw std::runtime_error(
+                                "graph in error state but message is nullptr");
+                        }
+                    throw fwdpy11::discrete_demography::DemographyError(message);
+                }
             number_of_demes = demes_forward_graph_number_of_demes(graph.get());
             if (number_of_demes < 1)
                 {


### PR DESCRIPTION
The rust back end uses f64.round() where we were using
np.rint() before. This change affects which models are
valid for corner cases where rounding method matters.
