### PR TITLE
use rust for size rounding

### DIFF
--- a/cpp/demes/forward_graph.cc
+++ b/cpp/demes/forward_graph.cc
@@ -8,6 +8,8 @@ void
 init_forward_graph(py::module &m)
 {
     py::class_<fwdpy11_core::ForwardDemesGraph>(m, "_ForwardDemesGraph")
-        .def(py::init<const std::string & /*yaml*/, std::uint32_t /*burnin*/>(),
-             py::arg("yaml"), py::arg("burnin"), py::kw_only());
+        .def(py::init<const std::string & /*yaml*/, std::uint32_t /*burnin*/,
+                      bool /*round_epoch_sizes*/>(),
+             py::arg("yaml"), py::arg("burnin"), py::arg("round_epoch_sizes"),
+             py::kw_only());
 }

--- a/lib/core/demes/forward_graph.hpp
+++ b/lib/core/demes/forward_graph.hpp
@@ -31,7 +31,8 @@ namespace fwdpy11_core
         std::unique_ptr<forward_graph_implementation> pimpl;
 
       public:
-        ForwardDemesGraph(const std::string &yaml, std::uint32_t burnin);
+        ForwardDemesGraph(const std::string &yaml, std::uint32_t burnin,
+                          bool round = false);
         // The constructor has default behavior.
         // We must declare it as non-default
         // so that this class looks like a complete type

--- a/lib/demes/forward_graph.cc
+++ b/lib/demes/forward_graph.cc
@@ -34,12 +34,22 @@ namespace fwdpy11_core
         graph_ptr_t graph;
         std::ptrdiff_t number_of_demes;
 
-        forward_graph_implementation(const std::string &yaml, std::uint32_t burnin)
+        forward_graph_implementation(const std::string &yaml, std::uint32_t burnin,
+                                     bool round)
             : graph(demes_forward_graph_allocate(), &demes_forward_graph_deallocate),
               number_of_demes{-1}
         {
-            auto code = demes_forward_graph_initialize_from_yaml(
-                yaml.c_str(), static_cast<double>(burnin), graph.get());
+            auto code = 0;
+            if (round == true)
+                {
+                    code = demes_forward_graph_initialize_from_yaml_round_epoch_sizes(
+                        yaml.c_str(), static_cast<double>(burnin), graph.get());
+                }
+            else
+                {
+                    code = demes_forward_graph_initialize_from_yaml(
+                        yaml.c_str(), static_cast<double>(burnin), graph.get());
+                }
 
             // FIXME: dup of handle_error_code
             if (code < 0)
@@ -160,8 +170,9 @@ namespace fwdpy11_core
     {
     }
 
-    ForwardDemesGraph::ForwardDemesGraph(const std::string &yaml, std::uint32_t burnin)
-        : pimpl{new forward_graph_implementation(yaml, burnin)}
+    ForwardDemesGraph::ForwardDemesGraph(const std::string &yaml, std::uint32_t burnin,
+                                         bool round)
+        : pimpl{new forward_graph_implementation(yaml, burnin, round)}
     {
     }
 

--- a/rust/fp11rust/Cargo.toml
+++ b/rust/fp11rust/Cargo.toml
@@ -16,5 +16,5 @@ panic = "abort"
 strip = true
 
 [dependencies]
-demes-forward-capi = {version="0.3.1-alpha.0", git="https://github.com/molpopgen/demes-rs"}
+demes-forward-capi = {version="0.4.0-alpha.0"}
 libc = "~0.2"

--- a/rust/fp11rust/src/demes_capi_bridge.rs
+++ b/rust/fp11rust/src/demes_capi_bridge.rs
@@ -25,6 +25,15 @@ pub unsafe extern "C" fn demes_forward_graph_initialize_from_yaml_file(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn demes_forward_graph_initialize_from_yaml_round_epoch_sizes(
+    file_name: *const c_char,
+    burnin: f64,
+    graph: *mut OpaqueForwardGraph,
+) -> i32 {
+    forward_graph_initialize_from_yaml_round_epoch_sizes(file_name, burnin, graph)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn demes_forward_graph_is_error_state(
     graph: *const OpaqueForwardGraph,
 ) -> bool {

--- a/tests/test_ForwardDemesGraph.py
+++ b/tests/test_ForwardDemesGraph.py
@@ -42,18 +42,25 @@ def test_valid_demes_spec_modules():
                 with pytest.raises(ValueError):
                     _ = fwdpy11.ForwardDemesGraph.from_demes(
                         yaml, burnin=0, round_non_integer_sizes=False)
-                if all(int(np.rint(i)) > 0 for i in non_integer_deme_sizes):
-                    for round_it in [None, True]:
+                if all(i > 0.5 for i in non_integer_deme_sizes):
+                    for round_it in [True]:
                         _ = fwdpy11.ForwardDemesGraph.from_demes(
                             yaml, burnin=0, round_non_integer_sizes=round_it)
                         _ = fwdpy11.discrete_demography.from_demes(
                             good, burnin=0, round_non_integer_sizes=round_it)
+                    for round_it in [None, False]:
+                        with pytest.raises(ValueError):
+                            _ = fwdpy11.ForwardDemesGraph.from_demes(
+                                yaml, burnin=0, round_non_integer_sizes=round_it)
+                            _ = fwdpy11.discrete_demography.from_demes(
+                                good, burnin=0, round_non_integer_sizes=round_it)
                 else:
-                    with pytest.raises(ValueError):
-                        _ = fwdpy11.ForwardDemesGraph.from_demes(
-                            yaml, burnin=0, round_non_integer_sizes=True)
-                        _ = fwdpy11.discrete_demography.from_demes(
-                            good, burnin=0, round_non_integer_sizes=True)
+                    for round_it in [None, False]:
+                        with pytest.raises(ValueError):
+                            _ = fwdpy11.ForwardDemesGraph.from_demes(
+                                yaml, burnin=0, round_non_integer_sizes=round_it)
+                            _ = fwdpy11.discrete_demography.from_demes(
+                                good, burnin=0, round_non_integer_sizes=round_it)
 
 
 def test_pickle():

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -1712,7 +1712,7 @@ def test_non_integer_size_change():
                epochs=[{"start_size": 100.5}])
     g = b.resolve()
 
-    _ = fwdpy11.discrete_demography.from_demes(g)
+    _ = fwdpy11.discrete_demography.from_demes(g, round_non_integer_sizes=True)
 
 
 def test_non_integer_initial_epoch_size():
@@ -1720,14 +1720,16 @@ def test_non_integer_initial_epoch_size():
     b.add_deme("A", epochs=[{"start_size": 100.5}])
     g = b.resolve()
 
-    demog = fwdpy11.discrete_demography.from_demes(g)
+    demog = fwdpy11.discrete_demography.from_demes(
+        g, round_non_integer_sizes=True)
 
     # initialize the ancestral population
     initial_sizes = [
         demog.metadata["initial_sizes"][i]
         for i in sorted(demog.metadata["initial_sizes"].keys())
     ]
-    _ = fwdpy11.DiploidPopulation(initial_sizes, 1)
+    _ = fwdpy11.DiploidPopulation(
+        initial_sizes, 1)
 
 
 def test_very_short_epoch():


### PR DESCRIPTION
Use upstream to handle the details
of converting epoch start/end sizes
to integer values.
