### PR TITLE
Fix error with mutation origin times

### DIFF
--- a/cpp/fwdpy11_types/DiploidPopulation.cc
+++ b/cpp/fwdpy11_types/DiploidPopulation.cc
@@ -111,8 +111,9 @@ init_DiploidPopulation(py::module& m)
         .def("_set_mutations",
              [](fwdpy11::DiploidPopulation& self,
                 const std::vector<fwdpy11::Mutation>& mutations,
-                const std::vector<std::int32_t>& mutation_nodes) {
-                 self.set_mutations(mutations, mutation_nodes);
+                const std::vector<std::int32_t>& mutation_nodes,
+                const std::vector<fwdpy11::mutation_origin_time>& origin_times) {
+                 self.set_mutations(mutations, mutation_nodes, origin_times);
              })
         .def(py::pickle(
             [](const fwdpy11::DiploidPopulation& pop) -> py::object {

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,15 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## 0.19.9
+
+Big fix
+
+* Use the mutation's time field rather than
+  the metadata "origin" time when creating
+  a DiploidPopulation from a tskit tree sequence.
+  PR {pr}`1113`
+
 ## 0.19.8
 
 Big fix/new feature (take your pick)

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -113,10 +113,10 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
         if import_mutations is True:
             import fwdpy11.tskit_tools
             for mutation in ts.mutations():
-                if mutation.metadata["origin"] < 0.0:
-                    msg = "all origin fields in mutation metadata"
-                    msg += "must be non-negative"
-                    raise ValueError(msg)
+                # if mutation.metadata["origin"] < 0.0:
+                #     msg = "all origin fields in mutation metadata"
+                #     msg += "must be non-negative"
+                #     raise ValueError(msg)
                 if not mutation.time.is_integer():
                     raise ValueError("mutation times cannot contain decimals")
             mutation_nodes = [i.node for i in ts.mutations()]
@@ -144,7 +144,8 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
             for i in decoded_md:
                 if i is not None:
                     mvec.append(i)
-            ll._set_mutations(mvec, mutation_nodes)
+            ll._set_mutations(mvec, mutation_nodes,
+                              [int(i.time) for i in ts.mutations()])
         return cls(0, 0.0, ll_pop=ll)
 
     @ classmethod

--- a/tests/test_import_tskit_mutations.py
+++ b/tests/test_import_tskit_mutations.py
@@ -182,11 +182,14 @@ def test_import_msprime_mutations_bad_metadata(seed1, seed2):
     # The "origin time" in the metadata
     # must equal the mutation's time value
 
-    def bad_origin(md):
-        if md['origin'] > 0.0:
-            md['origin'] = -1*md['origin']
-        else:
-            md['origin'] = -1
+    # NOTE: disabled in 0.19.9 to allow
+    # creating of pops from fwdpy11-generated
+    # mutations
+    # def bad_origin(md):
+    #     if md['origin'] > 0.0:
+    #         md['origin'] = -1*md['origin']
+    #     else:
+    #         md['origin'] = -1
 
     # NOTE: disable in 0.19.8 to
     # fix #1109 but this should be
@@ -203,8 +206,8 @@ def test_import_msprime_mutations_bad_metadata(seed1, seed2):
     # def neutrality_mismatch1(md):
     #     md['neutral'] = 1
 
-    # NOTE: bring back bad_origin2 in 0.20.0 if possible
-    for callback in [bad_effect_size, bad_dominance, bad_origin]:
+    # NOTE: bring back bad_origin and bad_origin2 in 0.20.0 if possible
+    for callback in [bad_effect_size, bad_dominance]:
         ts = make_treeseq_with_one_row_containing_bad_metadata(seed2, callback)
         with pytest.raises(ValueError):
             _ = fwdpy11.DiploidPopulation.create_from_tskit(


### PR DESCRIPTION
When building a DiploidPopulation from a tree sequence
that was originally exported from fwdpy11, we are
incorrectly assigning mutation origin times.

The error arises because this use case wasn't
originally anticipated.
