### PR TITLE
Allow models with no residual selfing

### DIFF
--- a/cpp/evolve_population/_evolvets.cc
+++ b/cpp/evolve_population/_evolvets.cc
@@ -48,7 +48,9 @@ init_evolve_with_tree_sequences(py::module &m)
                        &evolve_with_tree_sequences_options::
                            reset_treeseqs_to_alive_nodes_after_simplification)
         .def_readwrite("preserve_first_generation",
-                       &evolve_with_tree_sequences_options::preserve_first_generation);
+                       &evolve_with_tree_sequences_options::preserve_first_generation)
+        .def_readwrite("allow_residual_selfing",
+                       &evolve_with_tree_sequences_options::allow_residual_selfing);
 
     m.def("evolve_with_tree_sequences", &evolve_with_tree_sequences);
 }

--- a/fwdpy11/_evolvets.py
+++ b/fwdpy11/_evolvets.py
@@ -274,6 +274,21 @@ def evolvets(
     options.remove_extinct_mutations_at_finish = remove_extinct_variants
     options.reset_treeseqs_to_alive_nodes_after_simplification = reset_treeseqs_after_simplify
     options.preserve_first_generation = preserve_first_generation
+    options.allow_residual_selfing = params.allow_residual_selfing
+
+    if options.allow_residual_selfing is False:
+        from fwdpy11._types.forward_demes_graph import _round_via_decimal
+        for d, deme in enumerate(demographic_model.graph.demes):
+            for e, epoch in enumerate(deme.epochs):
+                start_size = _round_via_decimal(epoch.start_size)
+                end_size = _round_via_decimal(epoch.end_size)
+                if start_size == 1 or end_size == 1:
+                    msg = f"deme {d} epoch {e} has a size of 1"
+                    msg += " but residual selfing is not allowed."
+                    msg += " This model will raise an error if this deme "
+                    msg += "contributes to ancestry after the size of 1"
+                    msg += " is reached."
+                    warnings.warn(msg, UserWarning)
 
     gvpointers = _dgvalue_pointer_vector(params.gvalue)
     evolve_with_tree_sequences(

--- a/fwdpy11/_types/model_params.py
+++ b/fwdpy11/_types/model_params.py
@@ -126,6 +126,18 @@ class ModelParams(object):
                            the population when they are first detected
                            as fixed.
     :type prune_selected: bool
+    :param allow_residual_selfing: If ``True``, then an individual may
+                                   be chosen twice as a parent.
+                                   If ``False``, two distinct parents
+                                   are required.
+    :type allow_residual_selfing: bool
+
+    .. warning::
+
+        When ``allow_residual_selfing`` is ``False``, an exception
+        will be raised if the parental deme has a size of 1.
+        The reason is that outcrossing is not possible in order
+        to generate the offspring.
 
     .. note::
 
@@ -163,6 +175,10 @@ class ModelParams(object):
     .. versionchanged:: 0.14.0
 
         Remove deprecated kwargs pself and popsizes.
+
+    .. versionchanged:: 0.20.0
+
+        Add `allow_residual_selfing`
     """
 
     nregions = attr.ib(factory=list)
@@ -175,6 +191,7 @@ class ModelParams(object):
         default=None)
     simlen: int = attr.ib(converter=int, default=0)
     prune_selected: bool = attr.ib(default=True)
+    allow_residual_selfing: bool = attr.ib(default=True)
 
     @nregions.validator
     def validate_nregions(self, attribute, value):

--- a/lib/evolve_discrete_demes/discrete_demography/simulation/pick_parents.cc
+++ b/lib/evolve_discrete_demes/discrete_demography/simulation/pick_parents.cc
@@ -19,19 +19,7 @@ namespace fwdpy11_core
             std::int32_t pdeme = static_cast<std::int32_t>(
                 gsl_ran_discrete(rng.get(), ancestor_deme_lookup.get()));
 
-            auto selfing_rates = demography.offspring_selfing_rates();
-            auto selfing_rate_offspring_deme
-                = *(std::begin(selfing_rates) + offspring_deme);
-
-            auto p1 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
-            // FIXME: this gives rise to residual selfing
-            if (selfing_rate_offspring_deme > 0.
-                && gsl_rng_uniform(rng.get()) <= selfing_rate_offspring_deme)
-                {
-                    return {p1, p1, pdeme, pdeme, mating_event_type::selfing};
-                }
-            auto p2 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
-            if (allow_residual_selfing == false && p1 == p2)
+            if (allow_residual_selfing == false)
                 {
                     auto p = demography.parental_deme_sizes();
                     if (std::begin(p) == std::end(p))
@@ -46,6 +34,22 @@ namespace fwdpy11_core
                               << " has a size of 1";
                             throw fwdpy11::discrete_demography::DemographyError(o.str());
                         }
+                }
+
+            auto selfing_rates = demography.offspring_selfing_rates();
+            auto selfing_rate_offspring_deme
+                = *(std::begin(selfing_rates) + offspring_deme);
+
+            auto p1 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
+            // FIXME: this gives rise to residual selfing
+            if (selfing_rate_offspring_deme > 0.
+                && gsl_rng_uniform(rng.get()) <= selfing_rate_offspring_deme)
+                {
+                    return {p1, p1, pdeme, pdeme, mating_event_type::selfing};
+                }
+            auto p2 = wlookups.get_parent(rng, fitness_bookmark, pdeme);
+            if (allow_residual_selfing == false && p1 == p2)
+                {
                     while (p1 == p2)
                         {
                             p2 = wlookups.get_parent(rng, fitness_bookmark, pdeme);

--- a/tests/test_demes2fwdpy11.py
+++ b/tests/test_demes2fwdpy11.py
@@ -1822,3 +1822,30 @@ demes:
     model = fwdpy11.discrete_demography.from_demes(graph, burnin=0)
     assert model.metadata["deme_labels"][0] == "B"
     assert model.metadata["deme_labels"][1] == "A"
+
+
+def test_residual_selfing_exception():
+    yaml = """
+description: single deme model
+time_units: generations
+demes:
+ - name: B
+   epochs:
+    - start_size: 1
+"""
+    graph = demes.loads(yaml)
+    model = fwdpy11.discrete_demography.from_demes(graph, burnin=10)
+    pop = fwdpy11.DiploidPopulation([1], 1.0)
+    pdict = {"recregions": [],
+             "nregions": [],
+             "rates": (0, 0, 0),
+             "gvalue": fwdpy11.Multiplicative(2.),
+             "simlen": 10,
+             "demography": model,
+             "allow_residual_selfing": False
+             }
+    params = fwdpy11.ModelParams(**pdict)
+    rng = fwdpy11.GSLrng(42)
+    with pytest.raises(fwdpy11.DemographyError):
+        with pytest.warns(UserWarning):
+            fwdpy11.evolvets(rng, pop, params, 5)


### PR DESCRIPTION
* Add ModelParams::allow_residual_selfing
* Python support for allow_residual_selfing
  in _evolve_with_tree_sequences_options
* Update fwdpy11.evolvets

Closes #925
