### PR TITLE
Add useful properties for ForwardDemeGraph

### DIFF
--- a/fwdpy11/_functions/import_demes.py
+++ b/fwdpy11/_functions/import_demes.py
@@ -46,7 +46,7 @@ def _build_from_foward_demes_graph(
     """
     The workhorse.
     """
-    idmap = _build_deme_id_to_int_map(fg.graph)
+    idmap = fg.deme_labels
 
     if fg.graph.doi != "None":
         doi = fg.graph.doi
@@ -66,14 +66,6 @@ def _build_from_foward_demes_graph(
             "deme_labels": idmap,
             "initial_sizes": _initial_sizes,
             "burnin_time": fg.burnin_generation,
-            "total_simulation_length": fg._model_end_time() - 1
+            "total_simulation_length": fg.final_generation
         },
     )
-
-
-def _build_deme_id_to_int_map(dg: demes.Graph) -> Dict:
-    """
-    Convert the string input ID to output integer values.
-    """
-    labels = {i: d.name for i, d in enumerate(dg.demes)}
-    return labels

--- a/fwdpy11/_types/forward_demes_graph.py
+++ b/fwdpy11/_types/forward_demes_graph.py
@@ -157,3 +157,22 @@ class ForwardDemesGraph(fwdpy11._fwdpy11._ForwardDemesGraph):
         :class:`fwdpy11.DiploidPopulation`.
         """
         return [i for i in self._parental_deme_sizes_at_time_zero() if i > 0]
+
+    @property
+    def final_generation(self) -> int:
+        """
+        This is the final offspring generation of the model.
+        In other words, a model evolved from parental generation
+        zero until time zero of the graph (backwards in time)
+        will result in individuals whose birth times equal
+        the value of this property.
+        """
+        return self._model_end_time() - 1
+
+    @property
+    def deme_labels(self) -> typing.Dict[int, str]:
+        """
+        A dictionary mapping integer deme IDs to deme names
+        (strings).
+        """
+        return {i: j.name for i, j in enumerate(self.graph.demes)}


### PR DESCRIPTION
We want feature parity with DemographicModelDetails,
which is theoretically redundant in light of ForwardDemesGraph.
