### PR TITLE
Support evolve/export/restart work flows with complex demes models

### DIFF
--- a/cpp/fwdpy11_types/DiploidPopulation.cc
+++ b/cpp/fwdpy11_types/DiploidPopulation.cc
@@ -309,7 +309,14 @@ init_DiploidPopulation(py::module& m)
                     = load(f).cast<decltype(rv.ancient_sample_genetic_value_matrix)>();
                 return rv;
             })
-        .def_static("_create_from_tskit", [](py::object ts) {
-            return create_DiploidPopulation_from_tree_sequence(ts);
+        .def_static("_create_from_tskit",
+                    [](py::object ts) {
+                        return create_DiploidPopulation_from_tree_sequence(ts);
+                    })
+        .def_readonly("forward_model_time",
+                      &fwdpy11::DiploidPopulation::forward_model_time)
+        .def("_set_forward_model_time", [](fwdpy11::DiploidPopulation& self,
+                                           const std::uint32_t forward_model_time) {
+            self.forward_model_time = forward_model_time;
         });
 }

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -110,6 +110,10 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
 
         """
         ll = ll_DiploidPopulation._create_from_tskit(ts)
+        if len(ts.metadata) > 0:
+            if "forward_model_time" in ts.metadata:
+                forward_model_time = ts.metadata["forward_model_time"]
+                ll._set_forward_model_time(forward_model_time)
         if import_mutations is True:
             import fwdpy11.tskit_tools
             for mutation in ts.mutations():

--- a/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
+++ b/fwdpy11/headers/fwdpy11/types/DiploidPopulation.hpp
@@ -108,11 +108,16 @@ namespace fwdpy11
         //TODO figure out what to do with class constructor??
         //TODO Introduce types for ancient sample individual and node tracking
         std::vector<DiploidMetadata> diploid_metadata, ancient_sample_metadata;
+        
+        // Added in 0.20.0.
+        // This is the forward (parental)
+        // generation time of a demographic model.
+        std::uint32_t forward_model_time;
 
         // Constructors for Python
         DiploidPopulation(const fwdpp::uint_t N, const double length)
             : Population{2, N, length}, diploids(N, {0, 0}),
-              diploid_metadata(N), ancient_sample_metadata{}
+              diploid_metadata(N), ancient_sample_metadata{}, forward_model_time(0)
         {
             finish_construction({N});
         }
@@ -122,7 +127,7 @@ namespace fwdpy11
             : Population{2, std::accumulate(begin(deme_sizes), end(deme_sizes), 0u),
                          length},
               diploids(std::accumulate(begin(deme_sizes), end(deme_sizes), 0u), {0, 0}),
-              diploid_metadata(N), ancient_sample_metadata{}
+              diploid_metadata(N), ancient_sample_metadata{}, forward_model_time(0)
         {
             finish_construction(deme_sizes);
         }

--- a/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
+++ b/fwdpy11/tskit_tools/_dump_tables_to_tskit.py
@@ -165,7 +165,8 @@ def _dump_tables_to_tskit(
     tc.metadata_schema = fwdpy11.tskit_tools.metadata_schema.TopLevelMetadata
 
     # Populate the required fields
-    top_level_metadata = {"generation": self.generation}
+    top_level_metadata = {"generation": self.generation,
+                          "forward_model_time": self.forward_model_time}
 
     if model_params is not None:
         try:

--- a/lib/evolve_discrete_demes/evolvets.cc
+++ b/lib/evolve_discrete_demes/evolvets.cc
@@ -283,7 +283,7 @@ evolve_with_tree_sequences(
                 "current time of population is past the end of the model");
         }
 
-    demography.initialize_model(pop.generation);
+    demography.initialize_model(pop.forward_model_time);
 
     if (demography.number_of_demes() <= 0)
         {
@@ -446,7 +446,7 @@ evolve_with_tree_sequences(
     clear_edge_table_indexes(*pop.tables);
     fwdpp::ts::simplify_tables_output simplification_output;
     pop.is_simulating = true;
-    for (std::uint32_t gen = 0; pop.generation < demography.model_end_time() - 1
+    for (std::uint32_t gen = 0; pop.forward_model_time < demography.model_end_time() - 1
                                 && gen < simlen && !stopping_criteron_met;
          ++gen)
         {
@@ -455,6 +455,7 @@ evolve_with_tree_sequences(
                     throw std::runtime_error("forward graph is in an error state");
                 }
             ++pop.generation;
+            ++pop.forward_model_time;
             evolve_generation_ts(rng, pop, genetics, demography, fitness_lookup,
                                  fitness_bookmark, // miglookup,
                                  pop.generation, *new_edge_buffer, offspring,


### PR DESCRIPTION
This PR will enable the following work flows:

* Evolve part of a model with fwdpy11
* Export to tskit
* Restore a population from the tskit tree sequence
* Continue evolving the rest of the model.

Related: #1114
