### PR TITLE
Use toplevel metadata to adjust times when importing a tree sequence.

### DIFF
--- a/cpp/fwdpy11_types/DiploidPopulation.cc
+++ b/cpp/fwdpy11_types/DiploidPopulation.cc
@@ -43,7 +43,8 @@ PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidMetadata>);
 PYBIND11_MAKE_OPAQUE(fwdpy11::DiploidPopulation::genome_container);
 PYBIND11_MAKE_OPAQUE(fwdpy11::DiploidPopulation::mutation_container);
 
-fwdpy11::DiploidPopulation create_DiploidPopulation_from_tree_sequence(py::object ts);
+fwdpy11::DiploidPopulation
+create_DiploidPopulation_from_tree_sequence(py::object ts, std::uint32_t generation);
 
 namespace
 {
@@ -309,7 +310,7 @@ init_DiploidPopulation(py::module& m)
                     = load(f).cast<decltype(rv.ancient_sample_genetic_value_matrix)>();
                 return rv;
             })
-        .def_static("_create_from_tskit", [](py::object ts) {
-            return create_DiploidPopulation_from_tree_sequence(ts);
+        .def_static("_create_from_tskit", [](py::object ts, std::uint32_t generation) {
+            return create_DiploidPopulation_from_tree_sequence(ts, generation);
         });
 }

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -109,7 +109,11 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
               of fwdpy11.
 
         """
-        ll = ll_DiploidPopulation._create_from_tskit(ts)
+        generation = 0
+        if len(ts.metadata) > 0:
+            if "generation" in ts.metadata:
+                generation = ts.metadata["generation"]
+        ll = ll_DiploidPopulation._create_from_tskit(ts, generation)
         if import_mutations is True:
             import fwdpy11.tskit_tools
             for mutation in ts.mutations():
@@ -145,7 +149,7 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
                 if i is not None:
                     mvec.append(i)
             ll._set_mutations(mvec, mutation_nodes,
-                              [int(i.time) for i in ts.mutations()])
+                              [int(i.time) - ll._generation for i in ts.mutations()])
         return cls(0, 0.0, ll_pop=ll)
 
     @ classmethod


### PR DESCRIPTION
* The "generation" field is used to convert backwards times to
  forward time.
* This adjustment is applied to node times and to mutation
  origin times.
* Add test of complex evolve/export/import/evolve work flows

Closes #1114
Closes #1111
