### PR TITLE
Restore individual metadata

### DIFF
--- a/cpp/fwdpy11_types/DiploidVector.cc
+++ b/cpp/fwdpy11_types/DiploidVector.cc
@@ -27,7 +27,8 @@ namespace py = pybind11;
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidGenotype>);
 PYBIND11_MAKE_OPAQUE(std::vector<fwdpy11::DiploidMetadata>);
 
-void init_DiploidVector(py::module & m)
+void
+init_DiploidVector(py::module& m)
 {
     PYBIND11_NUMPY_DTYPE(fwdpy11::DiploidGenotype, first, second);
 
@@ -54,12 +55,11 @@ void init_DiploidVector(py::module & m)
                 return rv;
             }));
 
-    PYBIND11_NUMPY_DTYPE(fwdpy11::DiploidMetadata, g, e, w, geography, label,
-                         parents, deme, sex, nodes);
+    PYBIND11_NUMPY_DTYPE(fwdpy11::DiploidMetadata, g, e, w, geography, label, parents,
+                         deme, sex, nodes);
 
     py::bind_vector<std::vector<fwdpy11::DiploidMetadata>>(
-        m, "DiploidMetadataVector", py::module_local(false),
-        py::buffer_protocol(),
+        m, "DiploidMetadataVector", py::module_local(false), py::buffer_protocol(),
         R"delim(
         Container of diploid metadata.
         )delim")
@@ -80,5 +80,7 @@ void init_DiploidVector(py::module & m)
                         rv.push_back(i.cast<fwdpy11::DiploidMetadata>());
                     }
                 return rv;
-            }));
+            }))
+        .def("_resize", [](std::vector<fwdpy11::DiploidMetadata>& self,
+                           std::size_t newsize) { self.resize(newsize); });
 }

--- a/doc/misc/changelog.md
+++ b/doc/misc/changelog.md
@@ -3,6 +3,17 @@
 Major changes are listed below.  Each release likely contains fiddling with back-end code,
 updates to latest `fwdpp` version, etc.
 
+## Next release
+
+# New features
+
+* {func}`fwdpy11.DiploidPopulation.create_from_tskit` is now able to restore
+  individual metadata, populating {attr}`fwdpy11.DiploidPopulation.diploid_metadata` 
+  and {attr}`fwdpy11.DiploidPopulation.ancient_sample_metadata`. 
+  PR {pr}`1157`.
+  Issue {issue}`1130`.
+
+
 ## 0.20.1
 
 Bug fixes


### PR DESCRIPTION
When importing from a tskit "trees" file, restore individual
metadata.
