### PR TITLE
Streamline when CI checks are run.

### DIFF
--- a/.github/workflows/docker_deployment.yml
+++ b/.github/workflows/docker_deployment.yml
@@ -7,6 +7,8 @@ on:
   release:
     types: [created]
   pull_request:
+    branches:
+      - 'main'
 
 jobs:
   docker:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   builddocs:
-    name: Build
+    name: Build manual
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/macos_x86.yml
+++ b/.github/workflows/macos_x86.yml
@@ -6,12 +6,10 @@ name: macOS_x86
 
 on:
   pull_request:
-  push:
-    branches: [main, dev]
 
 jobs:
-  test:
-    name: Python
+  test_macos_x86:
+    name: macOS_x86
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,11 +2,9 @@ name: UbuntuStressTest
 
 on:
   pull_request:
-  push:
-    branches: [main, dev]
 
 jobs:
-  test:
+  test_ubuntu:
     name: Ubuntu
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,8 +6,9 @@ on:
   release:
     types: [created]
   push:
-    branches: [main, dev]
-#  pull_request:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   macOS_wheel:


### PR DESCRIPTION
- Rename job for building manual
- rename macOS x86 test jobs
- Only run wheels actions on pulls/merges into main.
- Don't run test upon push to branch
