### PR TITLE
fix docker image builds

### DIFF
--- a/.github/workflows/docker_deployment.yml
+++ b/.github/workflows/docker_deployment.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'dev'
 
 jobs:
   docker:

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY . /app
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install cmake \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
   gcc \
   git \
   g++ \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "wheel",
     "setuptools_scm",
     "pybind11[global]==2.11.1",
+    "cmake>=3.27.2"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
- Add cmake to pyproject.toml
- Rely on cmake via pyproject.toml for building Docker image.
