### PR TITLE
pin setuptools_scm to < version 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools>=30.3.0",
     "wheel",
-    "setuptools_scm",
+    "setuptools_scm<8",
     "pybind11[global]==2.11.1",
     "cmake>=3.27.2"
 ]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,12 +8,15 @@ scipy
 attrs
 black
 demes~=0.2.2
+# NOTE: this jsonschema pin is a hack until tskit issue 2840
+# is resolved
+jsonschema<=4.18.6
 
 #below are for building package
 #and running tests
 msprime~=1.0
 tskit~=0.5.0
-setuptools_scm
+setuptools_scm<8
 pytest
 pytest-xdist
 hypothesis==6.56.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ install_requires =
     scipy
     tskit ~= 0.5.0
     demes ~= 0.2.2
+# NOTE: this jsonschema pin is a hack until tskit issue 2840
+# is resolved
+    jsonschema < 4.18.7
 setup_requires =
     setuptools
     setuptools_scm


### PR DESCRIPTION
Replaces #1183.

Provides temporary workaround for tskit-dev/tskit#2840
