### PR TITLE
Deprecate StrictAdditiveMultivariateEffects.

### DIFF
--- a/fwdpy11/__init__.py
+++ b/fwdpy11/__init__.py
@@ -59,6 +59,7 @@ from .genetic_values import (  # NOQA
     Multiplicative,
     GBR,
     StrictAdditiveMultivariateEffects,
+    AdditivePleiotropy,
     PyDiploidGeneticValue
 )
 

--- a/fwdpy11/genetic_values.py
+++ b/fwdpy11/genetic_values.py
@@ -24,6 +24,8 @@ import warnings
 import attr
 import numpy as np
 
+from deprecated import deprecated
+
 from ._fwdpy11 import (GeneticValueIsTrait, GeneticValueNoise, _ll_Additive,
                        _ll_GaussianNoise, _ll_GBR,
                        _ll_GaussianStabilizingSelection,
@@ -589,7 +591,7 @@ class GBR(_ll_GBR):
 @attr_class_pickle_with_super
 @attr_class_to_from_dict_no_recurse
 @attr.s(auto_attribs=True, frozen=True, repr_ns="fwdpy11")
-class StrictAdditiveMultivariateEffects(_ll_StrictAdditiveMultivariateEffects):
+class AdditivePleiotropy(_ll_StrictAdditiveMultivariateEffects):
     """
     Multivariate trait values under strictly additive effects.
 
@@ -626,12 +628,17 @@ class StrictAdditiveMultivariateEffects(_ll_StrictAdditiveMultivariateEffects):
     noise: object = None
 
     def __attrs_post_init__(self):
-        super(StrictAdditiveMultivariateEffects, self).__init__(
+        super(AdditivePleiotropy, self).__init__(
             self.ndimensions,
             self.focal_trait,
             self.gvalue_to_fitness,
             self.noise
         )
+
+
+@deprecated(reason="Use AdditivePleiotropy instead.")
+class StrictAdditiveMultivariateEffects(AdditivePleiotropy):
+    pass
 
 
 class PyDiploidGeneticValue(_PyDiploidGeneticValue):

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,6 +8,7 @@ scipy
 attrs
 black
 demes~=0.2.2
+Deprecated
 
 #below are for building package
 #and running tests

--- a/requirements/wheel_building_workflow.txt
+++ b/requirements/wheel_building_workflow.txt
@@ -8,3 +8,4 @@ attrs >= 20.3.0
 demes == 0.2.2
 tskit >= 0.5.6
 scipy
+Deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     scipy
     tskit >= 0.5.6
     demes ~= 0.2.2
+    Deprecated
 setup_requires =
     setuptools
     setuptools_scm

--- a/tests/test_dgvalue_pointer_vector.py
+++ b/tests/test_dgvalue_pointer_vector.py
@@ -33,7 +33,7 @@ class TestBadInput(unittest.TestCase):
         a = fwdpy11.Additive(2.0)
         mvgss = fwdpy11.GaussianStabilizingSelection.pleiotropy(
             [fwdpy11.PleiotropicOptima(np.zeros(2), 10.0, when=0)])
-        mv = fwdpy11.StrictAdditiveMultivariateEffects(2, 0, mvgss)
+        mv = fwdpy11.AdditivePleiotropy(2, 0, mvgss)
         from fwdpy11._fwdpy11 import _dgvalue_pointer_vector
 
         with self.assertRaises(ValueError):

--- a/tests/test_multivariate_effects.py
+++ b/tests/test_multivariate_effects.py
@@ -20,7 +20,7 @@ def set_up_quant_trait_model():
     GSSmo = fwdpy11.GaussianStabilizingSelection.pleiotropy(po)
     cmat = np.identity(ntraits)
     np.fill_diagonal(cmat, 0.1)
-    a = fwdpy11.StrictAdditiveMultivariateEffects(ntraits, 0, GSSmo)
+    a = fwdpy11.AdditivePleiotropy(ntraits, 0, GSSmo)
     demography = fwdpy11.ForwardDemesGraph.tubes([N], burnin=100,
                                                  burnin_is_exact=True)
     p = {

--- a/tests/test_record_genetic_value_matrix.py
+++ b/tests/test_record_genetic_value_matrix.py
@@ -73,7 +73,7 @@ def set_up_two_trait_quant_trait_model():
         ),
     ]
     GSSmo = fwdpy11.GaussianStabilizingSelection.pleiotropy(optima)
-    a = fwdpy11.StrictAdditiveMultivariateEffects(2, 0, GSSmo)
+    a = fwdpy11.AdditivePleiotropy(2, 0, GSSmo)
     vcov = np.identity(2)
     np.fill_diagonal(vcov, 0.25)
     DES = fwdpy11.MultivariateGaussianEffects(0, 1, 1, vcov)


### PR DESCRIPTION
* Rename the class AdditivePleiotropy and the deprecated class
  inherits from this.
* Adds Deprecated as dependency
