### PR TITLE
Remove use of oldest-supported-numpy when building wheels.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,9 +35,6 @@ jobs:
           # Upgrade pip to get bdist_wheel
           pip install --upgrade pip
           pip install setuptools wheel build
-          # Instead of letting setup.py install a newer numpy we install it here
-          # using the oldest supported version for ABI compatibility
-          pip install oldest-supported-numpy
       - name: Build Wheel
         run: |
           python -m build --wheel

--- a/deployment/linux_wheels/wheel_workflow.sh
+++ b/deployment/linux_wheels/wheel_workflow.sh
@@ -29,7 +29,7 @@ git config --global --add safe.directory /project
 
 $(which $PYTHON) -m venv venv
 source venv/bin/activate
-python -m pip install --upgrade pip setuptools build oldest-supported-numpy
+python -m pip install --upgrade pip setuptools build
 python -m build .
 deactivate
 rm -rf build venv


### PR DESCRIPTION
* the package is deprecated in light of upcoming numpy 2.0
