### PR TITLE
clamp lethal mutations

### DIFF
--- a/cpp/genetic_values/Additive.cc
+++ b/cpp/genetic_values/Additive.cc
@@ -21,97 +21,25 @@
 #include <stdexcept>
 
 #include <fwdpy11/types/Mutation.hpp>
-#include <fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp>
+#include <fwdpy11/genetic_values/DiploidAdditive.hpp>
 #include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
 #include <pybind11/pybind11.h>
-
-namespace
-{
-    struct single_deme_additive_het
-    {
-        inline void
-        operator()(double& d, const fwdpy11::Mutation& m) const
-        {
-            d += m.s * m.h;
-        }
-    };
-
-    struct multi_deme_additive_het
-    {
-        inline void
-        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
-        {
-            d += m.esizes[deme] * m.heffects[deme];
-        }
-    };
-
-    struct single_deme_additive_hom
-    {
-        double scaling;
-        single_deme_additive_hom(double s) : scaling(s)
-        {
-        }
-
-        inline void
-        operator()(double& d, const fwdpy11::Mutation& m) const
-        {
-            d += scaling * m.s;
-        }
-    };
-
-    struct multi_deme_additive_hom
-    {
-        double scaling;
-        multi_deme_additive_hom(double s) : scaling(s)
-        {
-        }
-
-        inline void
-        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
-        {
-            d += scaling * m.esizes[deme];
-        }
-    };
-
-    struct final_additive_trait
-    {
-        inline double
-        operator()(double d) const
-        {
-            return d;
-        }
-    };
-
-    struct final_additive_fitness
-    {
-        inline double
-        operator()(double d) const
-        {
-            return std::max(0.0, 1. + d);
-        }
-    };
-
-    using DiploidAdditive = fwdpy11::stateless_site_dependent_genetic_value_wrapper<
-        single_deme_additive_het, single_deme_additive_hom, multi_deme_additive_het,
-        multi_deme_additive_hom, 0>;
-}
 
 namespace py = pybind11;
 
 void
 init_Additive(py::module& m)
 {
-    py::class_<DiploidAdditive, fwdpy11::DiploidGeneticValue>(m, "_ll_Additive")
+    py::class_<fwdpy11::DiploidAdditive, fwdpy11::DiploidGeneticValue>(m, "_ll_Additive")
         .def(py::init([](double scaling,
                          const fwdpy11::GeneticValueIsTrait* gvalue_to_fitness,
                          const fwdpy11::GeneticValueNoise* noise, std::size_t ndemes) {
                  if (gvalue_to_fitness != nullptr)
                      {
-                         return DiploidAdditive(ndemes, scaling, final_additive_trait(),
-                                                gvalue_to_fitness, noise);
+                         return fwdpy11::additive_trait_model(ndemes, scaling,
+                                                              gvalue_to_fitness, noise);
                      }
-                 return DiploidAdditive(ndemes, scaling, final_additive_fitness(),
-                                        gvalue_to_fitness, noise);
+                 return fwdpy11::additive_fitness_model(ndemes, scaling, noise);
              }),
              py::arg("scaling"), py::arg("gvalue_to_fitness"), py::arg("noise"),
              py::arg("ndemes"));

--- a/cpp/genetic_values/Multiplicative.cc
+++ b/cpp/genetic_values/Multiplicative.cc
@@ -17,104 +17,28 @@
 // along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include <functional>
-#include <stdexcept>
 
 #include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
-#include <fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp>
+#include <fwdpy11/genetic_values/DiploidMultiplicative.hpp>
 #include <fwdpy11/types/Mutation.hpp>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
-namespace
-{
-    struct single_deme_multiplicative_het
-    {
-        inline void
-        operator()(double& d, const fwdpy11::Mutation& m) const
-        {
-            d *= (1. + m.s * m.h);
-        }
-    };
-
-    struct multi_deme_multiplicative_het
-    {
-        inline void
-        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
-        {
-            d *= (1. + m.esizes[deme] * m.heffects[deme]);
-        }
-    };
-
-    struct single_deme_multiplicative_hom
-    {
-        double scaling;
-        single_deme_multiplicative_hom(double s) : scaling(s)
-        {
-        }
-
-        inline void
-        operator()(double& d, const fwdpy11::Mutation& m) const
-        {
-            d *= (1. + scaling * m.s);
-        }
-    };
-
-    struct multi_deme_multiplicative_hom
-    {
-        double scaling;
-        multi_deme_multiplicative_hom(double s) : scaling(s)
-        {
-        }
-
-        inline void
-        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
-        {
-            d *= (1. + scaling * m.esizes[deme]);
-        }
-    };
-
-    struct final_multiplicative_trait
-    {
-        inline double
-        operator()(double d) const
-        {
-            return d - 1.0;
-        }
-    };
-
-    struct final_multiplicative_fitness
-    {
-        inline double
-        operator()(double d) const
-        {
-            return std::max(0.0, d);
-        }
-    };
-
-    using DiploidMultiplicative
-        = fwdpy11::stateless_site_dependent_genetic_value_wrapper<
-            single_deme_multiplicative_het, single_deme_multiplicative_hom,
-            multi_deme_multiplicative_het, multi_deme_multiplicative_hom, 1>;
-}
-
 void
 init_Multiplicative(py::module& m)
 {
-    py::class_<DiploidMultiplicative, fwdpy11::DiploidGeneticValue>(m,
-                                                                    "_ll_Multiplicative")
+    py::class_<fwdpy11::DiploidMultiplicative, fwdpy11::DiploidGeneticValue>(
+        m, "_ll_Multiplicative")
         .def(py::init([](double scaling,
                          const fwdpy11::GeneticValueIsTrait* gvalue_to_fitness,
                          const fwdpy11::GeneticValueNoise* noise, std::size_t ndemes) {
                  if (gvalue_to_fitness != nullptr)
                      {
-                         return DiploidMultiplicative(ndemes, scaling,
-                                                      final_multiplicative_trait(),
-                                                      gvalue_to_fitness, noise);
+                         return fwdpy11::multiplicative_trait_model(
+                             ndemes, scaling, gvalue_to_fitness, noise);
                      }
-                 return DiploidMultiplicative(ndemes, scaling,
-                                              final_multiplicative_fitness(),
-                                              gvalue_to_fitness, noise);
+                 return fwdpy11::multiplicative_fitness_model(ndemes, scaling, noise);
              }),
              py::arg("scaling"), py::arg("gvalue_to_fitness"), py::arg("noise"),
              py::arg("ndemes"));

--- a/cpptests/CMakeLists.txt
+++ b/cpptests/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(CPPTEST_SOURCES
     forward_demes_graph_fixtures.cc
     test_evolvets.cc
     test_core_genetic_map_regions.cc
+    test_site_dependent_genetic_value.cc
 )
 
 add_executable(fwdpy11_cpp_tests ${CPPTEST_SOURCES})

--- a/cpptests/test_site_dependent_genetic_value.cc
+++ b/cpptests/test_site_dependent_genetic_value.cc
@@ -1,0 +1,211 @@
+#include "fwdpp/fundamental_types/haploid_genome.hpp"
+#include "fwdpp/fundamental_types/mutation_base.hpp"
+#include "fwdpy11/genetic_value_data/genetic_value_data.hpp"
+#include "fwdpy11/genetic_values/site_dependent_genetic_value.hpp"
+#include "fwdpy11/types/Diploid.hpp"
+#include "fwdpy11/types/DiploidPopulation.hpp"
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <fwdpy11/genetic_values/DiploidMultiplicative.hpp>
+#include <fwdpy11/genetic_values/DiploidAdditive.hpp>
+
+struct Mutation : public fwdpp::mutation_base
+{
+    double s;
+    double h;
+    Mutation(double pos, double s, double h)
+        : fwdpp::mutation_base(pos, 0, false), s(s), h(h)
+    {
+    }
+};
+
+struct Pop
+{
+    std::vector<Mutation> mutations;
+    std::vector<fwdpp::haploid_genome> genomes;
+    std::vector<fwdpy11::DiploidMetadata> metadata;
+
+    Pop() : mutations{}, genomes{}, metadata{}
+    {
+    }
+};
+
+struct Fwdpy11Pop
+{
+    fwdpy11::DiploidPopulation pop;
+    std::vector<fwdpy11::DiploidMetadata> offspring_metadata;
+
+    Fwdpy11Pop() : pop{1, 100.}, offspring_metadata()
+    {
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(test_low_level_gvalue_calculation)
+
+BOOST_FIXTURE_TEST_CASE(test_multiplicative_fitness_0, Pop)
+{
+    mutations.emplace_back(1.0, -0.55, 1.0);
+    genomes.emplace_back(1);
+    genomes.emplace_back(1);
+    genomes[0].smutations.emplace_back(0);
+    BOOST_REQUIRE_EQUAL(genomes.size(), 2);
+    fwdpy11::site_dependent_genetic_value sdgv{[](const double) { return false; }};
+    auto gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w *= (1. + 2.0 * m.s); },
+        [](double &w, const auto &m) { w *= (1. + m.s * m.h); },
+        [](const double w) { return std::max(w, 0.0); }, 1.0);
+    BOOST_REQUIRE_EQUAL(gv, 1.0 - 0.55);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_multiplicative_fitness_1, Pop)
+{
+    mutations.emplace_back(1.0, -1.1, 1.0);
+    genomes.emplace_back(1);
+    genomes.emplace_back(1);
+    genomes[0].smutations.emplace_back(0);
+    BOOST_REQUIRE_EQUAL(genomes.size(), 2);
+    fwdpy11::site_dependent_genetic_value sdgv{[](const double) { return false; }};
+    auto gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w *= (1. + 2.0 * m.s); },
+        [](double &w, const auto &m) { w *= (1. + m.s * m.h); },
+        [](const double w) { return std::max(w, 0.0); }, 1.0);
+    BOOST_REQUIRE_EQUAL(gv, 0.0);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_multiplicative_fitness_2, Pop)
+{
+    mutations.emplace_back(1.0, -1.1, 1.0);
+    mutations.emplace_back(1.0, -1.1, 1.0);
+    genomes.emplace_back(1);
+    genomes.emplace_back(1);
+    genomes[0].smutations.emplace_back(0);
+    genomes[0].smutations.emplace_back(1);
+    BOOST_REQUIRE_EQUAL(genomes.size(), 2);
+    // Gives the previous behavior where two "more than lethal"
+    // variants give w > 0.0 when multiplied together
+    fwdpy11::site_dependent_genetic_value sdgv{[](const double) { return false; }};
+    auto gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w *= (1. + 2.0 * m.s); },
+        [](double &w, const auto &m) { w *= (1. + m.s * m.h); },
+        fwdpy11::final_multiplicative_fitness{}, 1.0);
+    BOOST_REQUIRE(gv > 0.0);
+
+    // Redo with a new closure that will return a fitness of 0.0
+    // when we first see w <= 0.0
+    sdgv
+        = fwdpy11::site_dependent_genetic_value{[](const double w) { return w <= 0.0; }};
+    gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w *= (1. + 2.0 * m.s); },
+        [](double &w, const auto &m) { w *= (1. + m.s * m.h); },
+        fwdpy11::final_multiplicative_fitness{}, 1.0);
+    BOOST_REQUIRE_EQUAL(gv, 0.0);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_additive_fitness, Pop)
+{
+    mutations.emplace_back(1.0, -1.1, 1.0);
+    mutations.emplace_back(1.0, -1.1, 1.0);
+    genomes.emplace_back(1);
+    genomes.emplace_back(1);
+    genomes[0].smutations.emplace_back(0);
+    genomes[0].smutations.emplace_back(1);
+    BOOST_REQUIRE_EQUAL(genomes.size(), 2);
+    // Gives the previous behavior where two "more than lethal"
+    // variants give w > 0.0 when multiplied together
+    fwdpy11::site_dependent_genetic_value sdgv{[](const double) { return false; }};
+    auto gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w += (2.0 * m.s); },
+        [](double &w, const auto &m) { w += (m.s * m.h); },
+        fwdpy11::final_additive_fitness(), 0.0);
+    BOOST_REQUIRE_EQUAL(gv, 0.0);
+
+    // Additive models DIFFER!!
+    // If we use the same callback as for the multiplicative case,
+    // we incorrectly get a final fitness > 0.
+    sdgv
+        = fwdpy11::site_dependent_genetic_value{[](const double w) { return w <= 0.0; }};
+    gv = sdgv(
+        genomes[0].smutations.begin(), genomes[0].smutations.end(),
+        genomes[1].smutations.begin(), genomes[1].smutations.end(), mutations,
+        [](double &w, const auto &m) { w += (m.s); },
+        [](double &w, const auto &m) { w += (m.s * m.h); },
+        fwdpy11::final_additive_fitness(), 0.0);
+    BOOST_REQUIRE(gv > 0.0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// NOTE: the tests below rely on knowledge of how
+// code that is not really part of the public API
+// works and are thus fragile.
+
+BOOST_AUTO_TEST_SUITE(test_diploid_multiplicative)
+
+BOOST_FIXTURE_TEST_CASE(test_multiplicative_fitness_0, Fwdpy11Pop)
+{
+    pop.mutations.emplace_back(false, 0.1, -0.55, 1.0, 0);
+    pop.haploid_genomes[0].smutations.emplace_back(0);
+    pop.haploid_genomes.emplace_back(1);
+    BOOST_REQUIRE_EQUAL(pop.haploid_genomes.size(), 2);
+    auto m = fwdpy11::multiplicative_fitness_model(1, 2, nullptr);
+    offspring_metadata.emplace_back(
+        fwdpy11::DiploidMetadata{0., 0., 1., {0., 0., 0.}, 0, {0, 0}, 0, 0, {0, 0}});
+    fwdpy11::GSLrng_t rng(42);
+    pop.diploids[0] = {0, 1};
+    fwdpy11::DiploidGeneticValueData data{rng,
+                                          pop,
+                                          pop.diploid_metadata[0],
+                                          pop.diploid_metadata[0],
+                                          0,
+                                          offspring_metadata[0]};
+    m(data);
+    BOOST_REQUIRE_CLOSE(offspring_metadata[0].g, 1.0 - 0.55, 1e-3);
+    BOOST_REQUIRE_CLOSE(offspring_metadata[0].w, 1.0 - 0.55, 1e-3);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_multiplicative_fitness_1, Fwdpy11Pop)
+{
+    pop.mutations.emplace_back(false, 0.1, -1.55, 1.0, 0);
+    pop.mutations.emplace_back(false, 0.2, -1.55, 1.0, 0);
+    pop.haploid_genomes[0].smutations.emplace_back(0);
+    pop.haploid_genomes[0].smutations.emplace_back(1);
+    pop.haploid_genomes.emplace_back(1);
+    BOOST_REQUIRE_EQUAL(pop.haploid_genomes.size(), 2);
+    // This lambda will NOT exit when w first is <= 0.0
+    fwdpy11::DiploidMultiplicative m(
+        1, 2., fwdpy11::final_multiplicative_fitness(),
+        [](const double) { return false; }, nullptr, nullptr);
+    offspring_metadata.emplace_back(
+        fwdpy11::DiploidMetadata{0., 0., 1., {0., 0., 0.}, 0, {0, 0}, 0, 0, {0, 0}});
+    fwdpy11::GSLrng_t rng(42);
+    pop.diploids[0] = {0, 1};
+    BOOST_CHECK_EQUAL(pop.haploid_genomes[0].smutations.size(), 2);
+    fwdpy11::DiploidGeneticValueData data{rng,
+                                          pop,
+                                          pop.diploid_metadata[0],
+                                          pop.diploid_metadata[0],
+                                          0,
+                                          offspring_metadata[0]};
+    m(data);
+    BOOST_REQUIRE(offspring_metadata[0].g > 0.0);
+    BOOST_REQUIRE(offspring_metadata[0].w > 0.0);
+
+    // we now pass in this correct lambda expression
+    m = fwdpy11::multiplicative_fitness_model(1, 2., nullptr);
+    m(data);
+    BOOST_REQUIRE_EQUAL(offspring_metadata[0].g, 0.);
+    BOOST_REQUIRE_EQUAL(offspring_metadata[0].w, 0.);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidAdditive.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidAdditive.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
+#include "fwdpp_wrappers/fwdpp_genetic_value.hpp"
+
+namespace fwdpy11
+{
+    struct single_deme_additive_het
+    {
+        inline void
+        operator()(double& d, const fwdpy11::Mutation& m) const
+        {
+            d += m.s * m.h;
+        }
+    };
+
+    struct multi_deme_additive_het
+    {
+        inline void
+        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
+        {
+            d += m.esizes[deme] * m.heffects[deme];
+        }
+    };
+
+    struct single_deme_additive_hom
+    {
+        double scaling;
+        single_deme_additive_hom(double s) : scaling(s)
+        {
+        }
+
+        inline void
+        operator()(double& d, const fwdpy11::Mutation& m) const
+        {
+            d += scaling * m.s;
+        }
+    };
+
+    struct multi_deme_additive_hom
+    {
+        double scaling;
+        multi_deme_additive_hom(double s) : scaling(s)
+        {
+        }
+
+        inline void
+        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
+        {
+            d += scaling * m.esizes[deme];
+        }
+    };
+
+    struct final_additive_trait
+    {
+        inline double
+        operator()(double d) const
+        {
+            return d;
+        }
+    };
+
+    struct final_additive_fitness
+    {
+        inline double
+        operator()(double d) const
+        {
+            return std::max(0.0, 1. + d);
+        }
+    };
+
+    using DiploidAdditive = fwdpy11::stateless_site_dependent_genetic_value_wrapper<
+        single_deme_additive_het, single_deme_additive_hom, multi_deme_additive_het,
+        multi_deme_additive_hom, 0>;
+
+    inline DiploidAdditive
+    additive_fitness_model(std::size_t ndemes, double scaling,
+                           const GeneticValueNoise* noise)
+    {
+        return DiploidAdditive(
+            ndemes, scaling, final_additive_fitness(),
+            [](const double) { return false; }, nullptr, noise);
+    }
+
+    inline DiploidAdditive
+    additive_trait_model(std::size_t ndemes, double scaling,
+                         const GeneticValueIsTrait* gvalue_to_fitness,
+                         const GeneticValueNoise* noise)
+    {
+        return DiploidAdditive(
+            ndemes, scaling, final_additive_trait(), [](const double) { return false; },
+            gvalue_to_fitness, noise);
+    }
+
+}

--- a/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultiplicative.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/DiploidMultiplicative.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <fwdpy11/types/Mutation.hpp>
+#include <fwdpy11/genetic_value_to_fitness/GeneticValueIsTrait.hpp>
+#include "fwdpp_wrappers/fwdpp_genetic_value.hpp"
+
+namespace fwdpy11
+{
+    struct single_deme_multiplicative_het
+    {
+        inline void
+        operator()(double& d, const fwdpy11::Mutation& m) const
+        {
+            d *= (1. + m.s * m.h);
+        }
+    };
+
+    struct multi_deme_multiplicative_het
+    {
+        inline void
+        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
+        {
+            d *= (1. + m.esizes[deme] * m.heffects[deme]);
+        }
+    };
+
+    struct single_deme_multiplicative_hom
+    {
+        double scaling;
+        single_deme_multiplicative_hom(double s) : scaling(s)
+        {
+        }
+
+        inline void
+        operator()(double& d, const fwdpy11::Mutation& m) const
+        {
+            d *= (1. + scaling * m.s);
+        }
+    };
+
+    struct multi_deme_multiplicative_hom
+    {
+        double scaling;
+        multi_deme_multiplicative_hom(double s) : scaling(s)
+        {
+        }
+
+        inline void
+        operator()(const std::size_t deme, double& d, const fwdpy11::Mutation& m) const
+        {
+            d *= (1. + scaling * m.esizes[deme]);
+        }
+    };
+
+    struct final_multiplicative_trait
+    {
+        inline double
+        operator()(double d) const
+        {
+            return d - 1.0;
+        }
+    };
+
+    struct final_multiplicative_fitness
+    {
+        inline double
+        operator()(double d) const
+        {
+            return std::max(0.0, d);
+        }
+    };
+
+    using DiploidMultiplicative
+        = fwdpy11::stateless_site_dependent_genetic_value_wrapper<
+            single_deme_multiplicative_het, single_deme_multiplicative_hom,
+            multi_deme_multiplicative_het, multi_deme_multiplicative_hom, 1>;
+
+    inline DiploidMultiplicative
+    multiplicative_fitness_model(std::size_t ndemes, double scaling,
+                                 const GeneticValueNoise* noise)
+    {
+        return DiploidMultiplicative(
+            ndemes, scaling, final_multiplicative_fitness(),
+            [](const double w) { return w <= 0.0; }, nullptr, noise);
+    }
+
+    inline DiploidMultiplicative
+    multiplicative_trait_model(std::size_t ndemes, double scaling,
+                               const GeneticValueIsTrait* gvalue_to_fitness,
+                               const GeneticValueNoise* noise)
+    {
+        return DiploidMultiplicative(
+            ndemes, scaling, final_multiplicative_trait(),
+            [](const double) { return false; }, gvalue_to_fitness, noise);
+    }
+}

--- a/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/fwdpp_wrappers/fwdpp_genetic_value.hpp
@@ -1,10 +1,11 @@
 #ifndef FWDPY11_GENETIC_VALUES_WRAPPERS_FWDPP__GVALUE_HPP__
 #define FWDPY11_GENETIC_VALUES_WRAPPERS_FWDPP__GVALUE_HPP__
 
+#include <limits>
 #include <type_traits>
 #include <functional>
 #include "../DiploidGeneticValue.hpp"
-#include <fwdpp/fitness_models.hpp>
+#include <fwdpy11/genetic_values/site_dependent_genetic_value.hpp>
 #include <fwdpy11/genetic_value_noise/GeneticValueNoise.hpp>
 
 namespace fwdpy11
@@ -26,7 +27,7 @@ namespace fwdpy11
             }
 
             inline double
-            operator()(const fwdpp::site_dependent_genetic_value& gv,
+            operator()(const fwdpy11::site_dependent_genetic_value& gv,
                        const std::size_t diploid_index,
                        const DiploidMetadata& /*metadata*/,
                        const DiploidPopulation& pop) const
@@ -47,7 +48,7 @@ namespace fwdpy11
             }
 
             inline double
-            operator()(const fwdpp::site_dependent_genetic_value& gv,
+            operator()(const fwdpy11::site_dependent_genetic_value& gv,
                        const std::size_t diploid_index, const DiploidMetadata& metadata,
                        const DiploidPopulation& pop) const
             {
@@ -75,7 +76,7 @@ namespace fwdpy11
         };
 
         using callback_type = std::function<double(
-            const fwdpp::site_dependent_genetic_value&, const std::size_t,
+            const fwdpy11::site_dependent_genetic_value&, const std::size_t,
             const DiploidMetadata&, const DiploidPopulation&)>;
 
         using make_return_value_t = std::function<double(double)>;
@@ -90,7 +91,7 @@ namespace fwdpy11
             return multi_deme_callback(aa_scaling);
         }
 
-        fwdpp::site_dependent_genetic_value gv;
+        fwdpy11::site_dependent_genetic_value gv;
         double aa_scaling;
         make_return_value_t make_return_value;
         callback_type callback;
@@ -99,8 +100,9 @@ namespace fwdpy11
       public:
         stateless_site_dependent_genetic_value_wrapper(
             std::size_t ndim, double scaling, make_return_value_t mrv,
-            const GeneticValueToFitnessMap* gv2w_, const GeneticValueNoise* noise_)
-            : DiploidGeneticValue{ndim, gv2w_, noise_}, gv{}, aa_scaling(scaling),
+            std::function<bool(double)> clamp, const GeneticValueToFitnessMap* gv2w_,
+            const GeneticValueNoise* noise_)
+            : DiploidGeneticValue{ndim, gv2w_, noise_}, gv{clamp}, aa_scaling(scaling),
               make_return_value(std::move(mrv)),
               callback(init_callback(ndim, aa_scaling)), isfitness(gv2w->isfitness)
         {

--- a/fwdpy11/headers/fwdpy11/genetic_values/site_dependent_genetic_value.hpp
+++ b/fwdpy11/headers/fwdpy11/genetic_values/site_dependent_genetic_value.hpp
@@ -1,0 +1,249 @@
+#pragma once
+
+#include <fwdpp/type_traits.hpp>
+#include <limits>
+
+namespace fwdpy11
+{
+    struct site_dependent_genetic_value
+    {
+        std::function<bool(const double)> clamp;
+        //! The return value type
+        using result_type = double;
+
+        template <typename iterator_t, typename MutationContainerType,
+                  typename updating_policy_hom, typename updating_policy_het,
+                  typename make_return_value>
+        inline result_type
+        operator()(iterator_t first1, iterator_t last1, iterator_t first2,
+                   iterator_t last2, const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const make_return_value &rv_function,
+                   const double starting_value) const noexcept
+        /*!
+          Range-based call operator.  Calculates genetic values over ranges of
+          mutation keys first1/last1
+          and first2/last2, which are iterators derived from the 'smutations'
+          of two haploid_genomes in a diploid.
+
+          \param first1 Iterator to first mutation derived from haploid_genome 1
+          \param last1 Iterator to one past the last mutation derived from
+          haploid_genome 1
+          \param first2 Iterator to first mutation derived from haploid_genome 2
+          \param last2 Iterator to one past the last mutation derived from
+          haploid_genome 2
+          \param mutations The container of mutations for the simulation
+          \param fpol_hom Policy that updates genetic value for a homozygous
+          mutation.
+          \param fpol_het Policy that updates genetic value for a heterozygous
+          mutation.
+          \param make_return_value Policy generated the final return value.
+                 Must be equivalent to std::function<double(double)>
+          \param starting_value The initial genetic value.
+
+          \returns Fitness (double)
+        */
+        {
+            static_assert(fwdpp::traits::is_mutation<
+                              typename MutationContainerType::value_type>::value,
+                          "MutationContainerType::value_type must be a mutation type");
+            static_assert(
+                std::is_convertible<
+                    updating_policy_hom,
+                    std::function<void(double &, const typename MutationContainerType::
+                                                     value_type &)>>::value,
+                "decltype(fpol_hom) must be convertible to "
+                "std::function<void(double &,const typename "
+                "MutationContainerType::value_type");
+            static_assert(
+                std::is_convertible<
+                    updating_policy_het,
+                    std::function<void(double &, const typename MutationContainerType::
+                                                     value_type &)>>::value,
+                "decltype(fpol_het) must be convertible to "
+                "std::function<void(double &,const typename "
+                "MutationContainerType::value_type");
+            result_type w = starting_value;
+            if (first1 == last1 && first2 == last2)
+                return rv_function(w);
+            else if (first1 == last1)
+                {
+                    for (; first2 != last2; ++first2)
+                        {
+                            fpol_het(w, mutations[*first2]);
+                            if (clamp(w))
+                                {
+                                    return rv_function(0.0);
+                                }
+                        }
+                    return rv_function(w);
+                }
+            else if (first2 == last2)
+                {
+                    for (; first1 != last1; ++first1)
+                        {
+                            fpol_het(w, mutations[*first1]);
+                            if (clamp(w))
+                                {
+                                    return rv_function(0.0);
+                                }
+                        }
+
+                    return rv_function(w);
+                }
+            for (; first1 != last1; ++first1)
+                {
+                    for (; first2 != last2 && *first1 != *first2
+                           && mutations[*first2].pos < mutations[*first1].pos;
+                         ++first2)
+                        // All mutations in this range are Aa
+                        {
+                            fpol_het(w, mutations[*first2]);
+                            if (clamp(w))
+                                {
+                                    return rv_function(0.0);
+                                }
+                        }
+                    if (first2 < last2
+                        && (*first1 == *first2
+                            || mutations[*first1].pos == mutations[*first2].pos))
+                        // mutation with index first1 is homozygous
+                        {
+                            fpol_hom(w, mutations[*first1]);
+                            if (clamp(w))
+                                {
+                                    return rv_function(0.0);
+                                }
+                            ++first2; // increment so that we don't re-process
+                            // this site as a het next time 'round
+                        }
+                    else // mutation first1 is heterozygous
+                        {
+                            fpol_het(w, mutations[*first1]);
+                            if (clamp(w))
+                                {
+                                    return rv_function(0.0);
+                                }
+                        }
+                }
+            for (; first2 != last2; ++first2)
+                {
+                    fpol_het(w, mutations[*first2]);
+                    if (clamp(w))
+                        {
+                            return rv_function(0.0);
+                        }
+                }
+            return rv_function(w);
+        }
+
+        template <typename iterator_t, typename MutationContainerType,
+                  typename updating_policy_hom, typename updating_policy_het>
+        inline result_type
+        operator()(iterator_t first1, iterator_t last1, iterator_t first2,
+                   iterator_t last2, const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const double starting_value) const noexcept
+        {
+            return this->operator()(
+                first1, last1, first2, last2, mutations, fpol_hom, fpol_het,
+                [](double d) { return d; }, starting_value);
+        }
+
+        template <typename HaploidGenomeType, typename MutationContainerType,
+                  typename updating_policy_hom, typename updating_policy_het,
+                  typename make_return_value>
+        inline result_type
+        operator()(const HaploidGenomeType &g1, const HaploidGenomeType &g2,
+                   const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const make_return_value &rv_function,
+                   const double starting_value) const noexcept
+        /*!
+          Calculates genetic value for a diploid whose genotype
+          across sites is given by haploid_genomes g1 and  g2.
+
+          \param g1 A haploid_genome
+          \param g2 A haploid_genome
+          \param mutations The container of mutations for the simulation
+          \param fpol_hom Policy that updates genetic value for a homozygous
+          mutation.
+          \param fpol_het Policy that updates genetic value for a heterozygous
+          mutation.
+          \param starting_value The initial genetic value.
+
+          \returns Fitness (double)
+        */
+        {
+            static_assert(fwdpp::traits::is_haploid_genome<HaploidGenomeType>::value,
+                          "HaploidGenomeType::value_type must be a haploid_genome "
+                          "type");
+            return this->operator()(g1.smutations.cbegin(), g1.smutations.cend(),
+                                    g2.smutations.cbegin(), g2.smutations.cend(),
+                                    mutations, fpol_hom, fpol_het, rv_function,
+                                    starting_value);
+        }
+
+        template <typename HaploidGenomeType, typename MutationContainerType,
+                  typename updating_policy_hom, typename updating_policy_het>
+        inline result_type
+        operator()(const HaploidGenomeType &g1, const HaploidGenomeType &g2,
+                   const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const double starting_value) const noexcept
+        {
+            return this->operator()(
+                g1, g2, mutations, fpol_hom, fpol_het, [](double d) { return d; },
+                starting_value);
+        }
+
+        template <typename DiploidType, typename GenomeContainerType,
+                  typename MutationContainerType, typename updating_policy_hom,
+                  typename updating_policy_het, typename make_return_value>
+        inline result_type
+        operator()(const DiploidType &dip, const GenomeContainerType &haploid_genomes,
+                   const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const make_return_value &rv_function,
+                   const double starting_value) const noexcept
+        /*!
+          Calculates genetic value for a diploid type.
+
+          \param dip A diploid
+          \param haploid_genomes The container of haploid_genomes for the simulation.
+          \param mutations The container of mutations for the simulation
+          \param fpol_hom Policy that updates genetic value for a homozygous
+          mutation.
+          \param fpol_het Policy that updates genetic value for a heterozygous
+          mutation.
+          \param starting_value The initial genetic value.
+
+          \returns Fitness (double)
+        */
+        {
+            return this->operator()(haploid_genomes[dip.first],
+                                    haploid_genomes[dip.second], mutations, fpol_hom,
+                                    fpol_het, rv_function, starting_value);
+        }
+
+        template <typename DiploidType, typename GenomeContainerType,
+                  typename MutationContainerType, typename updating_policy_hom,
+                  typename updating_policy_het>
+        inline result_type
+        operator()(const DiploidType &dip, const GenomeContainerType &haploid_genomes,
+                   const MutationContainerType &mutations,
+                   const updating_policy_hom &fpol_hom,
+                   const updating_policy_het &fpol_het,
+                   const double starting_value) const noexcept
+        {
+            return this->operator()(
+                dip, haploid_genomes, mutations, fpol_hom, fpol_het,
+                [](double d) { return d; }, starting_value);
+        }
+    };
+}


### PR DESCRIPTION
refactor C++ back end a bit:

- copy fwdpp's genetic value type into fwdpy11
- add field to copied type that allows us to "clamp" genetic values to 0 for models of fitness as soon as fitness <= 0
