### PR TITLE
Properly weight candidate nodes in DiploidPopulation.add_mutation

### DIFF
--- a/cpp/functions/add_mutation.cc
+++ b/cpp/functions/add_mutation.cc
@@ -17,6 +17,7 @@
 // along with fwdpy11.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <vector>
 #include <stdexcept>
@@ -47,9 +48,9 @@ new_mutation_data::new_mutation_data(double e, double h, std::vector<double> esi
         {
             throw std::invalid_argument("new mutation must have non-zero effect size");
         }
-    if (!std::isfinite(e) || std::any_of(begin(esizes), end(esizes), [](double d) {
-            return !std::isfinite(d);
-        }))
+    if (!std::isfinite(e)
+        || std::any_of(begin(esizes), end(esizes),
+                       [](double d) { return !std::isfinite(d); }))
         {
             throw std::invalid_argument("all effect size values must be finite");
         }
@@ -180,11 +181,11 @@ namespace
                                         if (deme < 0
                                             || std::all_of(
                                                 begin(descendants), end(descendants),
-                                                [&pop,
-                                                 deme](fwdpp::ts::table_index_t i) {
-                                                    return pop.tables->nodes[i].deme
-                                                           == deme;
-                                                }))
+                                                [&pop, deme](fwdpp::ts::table_index_t i)
+                                                    {
+                                                        return pop.tables->nodes[i].deme
+                                                               == deme;
+                                                    }))
                                             {
                                                 if (node_has_valid_time(
                                                         pop.tables->nodes, n,
@@ -259,7 +260,8 @@ namespace
 // Returns size_t max value if no candidates are found.
 std::size_t
 add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right,
-             const fwdpp::ts::table_index_t ndescendants,
+             const fwdpp::ts::table_index_t ndescendants_min,
+             const fwdpp::ts::table_index_t ndescendants_max,
              const fwdpp::ts::table_index_t deme, const new_mutation_data& data,
              fwdpy11::DiploidPopulation& pop)
 {
@@ -290,13 +292,21 @@ add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right
             throw std::invalid_argument(
                 "a population must have ancestry in order to add mutations");
         }
-    if (ndescendants < 1)
+    if (ndescendants_min < 1)
         {
             throw std::invalid_argument("number of descendants must be >= 1");
         }
-    if (static_cast<decltype(pop.N)>(ndescendants) >= 2 * pop.N)
+    if (ndescendants_max <= ndescendants_min)
         {
-            throw std::invalid_argument("ndescendants must be < 2*pop.N");
+            throw std::invalid_argument("ndescendants_max must be > ndescendants_min");
+        }
+    if (static_cast<decltype(pop.N)>(ndescendants_min) >= 2 * pop.N)
+        {
+            throw std::invalid_argument("ndescendants_min must be < 2*pop.N");
+        }
+    if (static_cast<decltype(pop.N)>(ndescendants_max) >= 2 * pop.N)
+        {
+            throw std::invalid_argument("ndescendants_max must be < 2*pop.N");
         }
     if (deme >= 0)
         {
@@ -323,14 +333,33 @@ add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right
                     throw std::invalid_argument(
                         "no alive individuals have the desired deme id");
                 }
-            if (static_cast<unsigned>(ndescendants) >= 2 * deme_sizes[deme])
+            if (static_cast<unsigned>(ndescendants_min) >= 2 * deme_sizes[deme])
                 {
-                    throw std::invalid_argument("ndescendants must be < 2*(deme size)");
+                    throw std::invalid_argument(
+                        "ndescendants_min must be < 2*(deme size)");
+                }
+            if (static_cast<unsigned>(ndescendants_max) >= 2 * deme_sizes[deme])
+                {
+                    throw std::invalid_argument(
+                        "ndescendants_max must be < 2*(deme size)");
                 }
         }
 
     std::size_t new_mutation_key = std::numeric_limits<std::size_t>::max();
-    auto candidates = generate_canidate_list(left, right, ndescendants, deme, pop);
+    std::vector<candidate_node_map> candidates;
+    std::vector<int> counts;
+
+    for (auto ndescendants_i = ndescendants_min; ndescendants_i < ndescendants_max; ++ndescendants_i)
+        {
+            auto candidates_i
+                = generate_canidate_list(left, right, ndescendants_i, deme, pop);
+            for(std::size_t j = 0 ; j < candidates_i.size() ; ++j) {
+                counts.push_back(ndescendants_i);
+            }
+            candidates.insert(std::end(candidates),
+                              std::make_move_iterator(std::begin(candidates_i)),
+                              std::make_move_iterator(std::end(candidates_i)));
+        }
 
     if (candidates.empty())
         {
@@ -388,15 +417,16 @@ add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right
     new_mutation_key = fwdpy11::infsites_Mutation(
         empty, pop.mutations, pop.mut_lookup, false, mutation_node_time,
         // The lambdas will simply transfer input parameters to the new object.
-        [&rng, &candidate_data]() {
-            return fwdpy11_core::internal::gsl_ran_flat(rng, candidate_data.left,
-                                                        candidate_data.right);
-        },
+        [&rng, &candidate_data]()
+            {
+                return fwdpy11_core::internal::gsl_ran_flat(rng, candidate_data.left,
+                                                            candidate_data.right);
+            },
         [&data]() { return data.effect_size; },
         [&data](double) { return data.dominance; }, [&data]() { return data.esizes; },
         [&data]() { return data.heffects; }, data.label);
 
-    pop.mcounts.push_back(ndescendants);
+    pop.mcounts.push_back(counts[candidate]);
     if (pop.mutations.size() != pop.mcounts.size())
         {
             throw std::runtime_error("mutations.size() != mcounts.size()");
@@ -451,9 +481,8 @@ add_mutation(const fwdpy11::GSLrng_t& rng, const double left, const double right
             auto itr = std::upper_bound(
                 begin(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
                 end(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
-                new_mutation_key, [&pop](const auto new_key, const auto key) {
-                    return pop.mutations[new_key].pos < pop.mutations[key].pos;
-                });
+                new_mutation_key, [&pop](const auto new_key, const auto key)
+                    { return pop.mutations[new_key].pos < pop.mutations[key].pos; });
             std::copy(begin(pop.haploid_genomes[nodes_to_haploid_genome[n]].smutations),
                       itr, std::back_inserter(new_genome.smutations));
             new_genome.smutations.push_back(new_mutation_key);

--- a/cpp/functions/add_mutation.hpp
+++ b/cpp/functions/add_mutation.hpp
@@ -34,6 +34,8 @@ struct new_mutation_data
 };
 
 std::size_t add_mutation(const fwdpy11::GSLrng_t& rng, const double left,
-                         const double right, const fwdpp::ts::table_index_t ndescendants,
+                         const double right,
+                         const fwdpp::ts::table_index_t ndescendants_min,
+                         const fwdpp::ts::table_index_t ndescendants_max,
                          const fwdpp::ts::table_index_t deme,
                          const new_mutation_data& data, fwdpy11::DiploidPopulation& pop);

--- a/fwdpy11/_types/diploid_population.py
+++ b/fwdpy11/_types/diploid_population.py
@@ -451,7 +451,7 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
         rng: fwdpy11.GSLrng,
         *,
         window: Tuple[float, float] = None,
-        ndescendants: int = 1,
+        ndescendants: Union[int, Tuple[int]] = 1,
         deme: Optional[int] = None,
         data: NewMutationData = None,
     ) -> Optional[int]:
@@ -469,10 +469,13 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
                        the mutation. The default is `None`, meaning
                        the window is the entire genome.
         :type window: tuple[float, float]
-        :param ndescendants: The number of alive nodes carrying the new
-                             mutation. Default is `1`, implying that a
+        :param ndescendants: Tuple representing the range of alive nodes
+                             carrying the new mutation.
+                             Default is `1`, implying that a
                              singleton mutation will be generated.
-        :type ndescendants: int
+                             When a tuple is input, it represents
+                             [min, max) values for the allele count of the
+                             added mutation.
         :param deme: The deme in which to place the new mutation
                      The default is `None`, meaning that alive node demes are
                      not considered.
@@ -525,8 +528,21 @@ class DiploidPopulation(ll_DiploidPopulation, PopulationMixin):
 
         from fwdpy11._fwdpy11 import _add_mutation
 
+        try:
+            ndescendants_min, ndescendants_max = ndescendants[0], ndescendants[1]
+            assert len(ndescendants) == 2
+        except TypeError:
+            ndescendants_min, ndescendants_max = ndescendants, ndescendants + 1
+
         key = _add_mutation(
-            rng, _window[0], _window[1], ndescendants, _deme, data, self
+            rng,
+            _window[0],
+            _window[1],
+            ndescendants_min,
+            ndescendants_max,
+            _deme,
+            data,
+            self,
         )
         if key == np.iinfo(np.uint64).max:
             return None

--- a/fwdpy11/conditional_models/_track_added_mutation.py
+++ b/fwdpy11/conditional_models/_track_added_mutation.py
@@ -169,7 +169,7 @@ def _integer_count_details(
                     f"count {c} "
                     f"is not compatible with total population size of {pop.N}"
                 )
-    return range(minimum, maximum + 1)
+    return (minimum, maximum + 1)
 
 
 def _get_allele_count_range(
@@ -235,22 +235,21 @@ def _copy_pop_and_add_mutation(
     if when is None or when == 0:
         count_range = _get_allele_count_range(pop, mutation_parameters)
 
-        for c in count_range:
-            pcopy = copy.deepcopy(pop)
-            _mutation_params = {
-                "window": (
-                    mutation_parameters.position.left,
-                    mutation_parameters.position.right,
-                ),
-                "ndescendants": c,
-                "data": mutation_parameters.data,
-                "deme": mutation_parameters.deme,
-            }
-            idx = pcopy.add_mutation(rng, **_mutation_params)
-            if idx is not None:
-                final_count = c
-                break
-        if idx is None:
+        pcopy = copy.deepcopy(pop)
+        _mutation_params = {
+            "window": (
+                mutation_parameters.position.left,
+                mutation_parameters.position.right,
+            ),
+            "ndescendants": count_range,
+            "data": mutation_parameters.data,
+            "deme": mutation_parameters.deme,
+        }
+        idx = pcopy.add_mutation(rng, **_mutation_params)
+        if idx is not None:
+            print(count_range, idx, pcopy.mcounts[idx])
+            final_count = pcopy.mcounts[idx]
+        else:
             raise AddMutationFailure("failed to add mutation")
         out_params = copy.deepcopy(params)
     else:
@@ -264,22 +263,19 @@ def _copy_pop_and_add_mutation(
         fwdpy11.evolvets(rng, pcopy, pre_sweep_params, **evolvets_options.asdict())
 
         count_range = _get_allele_count_range(pcopy, mutation_parameters)
-        for c in count_range:
-            _mutation_params = {
-                "window": (
-                    mutation_parameters.position.left,
-                    mutation_parameters.position.right,
-                ),
-                "ndescendants": c,
-                "data": mutation_parameters.data,
-                "deme": mutation_parameters.deme,
-            }
-            idx = pcopy.add_mutation(rng, **_mutation_params)
-            if idx is not None:
-                final_count = c
-                break
-
-        if idx is None:
+        _mutation_params = {
+            "window": (
+                mutation_parameters.position.left,
+                mutation_parameters.position.right,
+            ),
+            "ndescendants": count_range,
+            "data": mutation_parameters.data,
+            "deme": mutation_parameters.deme,
+        }
+        idx = pcopy.add_mutation(rng, **_mutation_params)
+        if idx is not None:
+            final_count = pcopy.mcounts[idx]
+        else:
             raise AddMutationFailure("failed to add mutation")
         sweep_pdict = {k: v for k, v in pre_sweep_params.asdict().items()}
         sweep_pdict["simlen"] = params.simlen - pcopy.generation


### PR DESCRIPTION
See #1449

The new implementation goes over all input allele counts, gets candidates and their weights from the tree sequence, and samples from that pool over all the input allele counts.